### PR TITLE
Use temp file to avoid changes to source files during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,7 @@ build/
 
 *.swp
 
-# Temp file used for build
-client/index.html.tmp
+# Build artifacts
+client/index-build-temp.html
+publish_id.txt
+environment-manager-*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ build/
 /Lambda/**/*.zip
 
 *.swp
+
+# Temp file used for build
+client/index.html.tmp

--- a/client/gulp/build.js
+++ b/client/gulp/build.js
@@ -4,6 +4,7 @@
 var path = require('path');
 var gulp = require('gulp');
 var conf = require('./conf');
+var rename = require('gulp-rename');
 
 var $ = require('gulp-load-plugins')({
   pattern: ['gulp-*', 'main-bower-files', 'uglify-save-license', 'del']
@@ -37,11 +38,13 @@ gulp.task('html', ['inject', 'partials'], function () {
 
   var jsFilter = $.filter('**/*.js', { restore: true });
   var cssFilter = $.filter('**/*.css', { restore: true });
-  var output = conf.getOutputTarget();
+  var tmpHtmlFilter = $.filter('**/*.html.tmp', { restore: true });
+  var output = conf.getTargetDirectory();
+  var srcHtml = conf.getInjectedHTMLfilePath();
 
   // TODO(filip): fix this path
   // return gulp.src(path.join(conf.paths.tmp, '/serve/*.html'))
-  return gulp.src('./index.html')
+  return gulp.src(srcHtml)
     .pipe($.inject(partialsInjectFile, partialsInjectOptions))
     .pipe($.useref())
     .pipe(jsFilter)
@@ -57,6 +60,12 @@ gulp.task('html', ['inject', 'partials'], function () {
     .pipe($.rev())
     .pipe(cssFilter.restore)
     .pipe($.revReplace())
+    .pipe(tmpHtmlFilter)
+    .pipe(rename(function(path) {
+      path.extname = ''; // file.html.tmp -> file.html
+      return path;
+    }))
+    .pipe(tmpHtmlFilter.restore)
     .pipe(gulp.dest(output))
     .pipe($.size({ title: path.join(conf.paths.dist, '/'), showFiles: true }));
 });
@@ -65,7 +74,7 @@ gulp.task('other', function () {
   var fileFilter = $.filter(function (file) {
     return file.stat.isFile();
   });
-  var output = conf.getOutputTarget();
+  var output = conf.getTargetDirectory();
 
   return gulp.src([
     './assets/images/**/*',

--- a/client/gulp/build.js
+++ b/client/gulp/build.js
@@ -4,7 +4,6 @@
 var path = require('path');
 var gulp = require('gulp');
 var conf = require('./conf');
-var argv = require('yargs').argv;
 
 var $ = require('gulp-load-plugins')({
   pattern: ['gulp-*', 'main-bower-files', 'uglify-save-license', 'del']
@@ -38,7 +37,7 @@ gulp.task('html', ['inject', 'partials'], function () {
 
   var jsFilter = $.filter('**/*.js', { restore: true });
   var cssFilter = $.filter('**/*.css', { restore: true });
-  var output = getOutputTarget();
+  var output = conf.getOutputTarget();
 
   // TODO(filip): fix this path
   // return gulp.src(path.join(conf.paths.tmp, '/serve/*.html'))
@@ -53,21 +52,11 @@ gulp.task('html', ['inject', 'partials'], function () {
     .pipe($.sourcemaps.write('maps'))
     .pipe(jsFilter.restore)
     .pipe(cssFilter)
-    // .pipe($.sourcemaps.init())
     .pipe($.replace('../../bower_components/bootstrap-sass/assets/fonts/bootstrap/', '../fonts/'))
     .pipe($.cssnano())
     .pipe($.rev())
-    // .pipe($.sourcemaps.write('maps'))
     .pipe(cssFilter.restore)
     .pipe($.revReplace())
-    // .pipe(htmlFilter)
-    // .pipe($.htmlmin({
-    //   removeEmptyAttributes: true,
-    //   removeAttributeQuotes: true,
-    //   collapseBooleanAttributes: true,
-    //   collapseWhitespace: true
-    // }))
-    // .pipe(htmlFilter.restore)
     .pipe(gulp.dest(output))
     .pipe($.size({ title: path.join(conf.paths.dist, '/'), showFiles: true }));
 });
@@ -76,7 +65,7 @@ gulp.task('other', function () {
   var fileFilter = $.filter(function (file) {
     return file.stat.isFile();
   });
-  var output = getOutputTarget();
+  var output = conf.getOutputTarget();
 
   return gulp.src([
     './assets/images/**/*',
@@ -90,10 +79,6 @@ gulp.task('other', function () {
   .pipe(fileFilter)
   .pipe(gulp.dest(output));
 });
-
-function getOutputTarget() {
-  return argv.o || path.join(conf.paths.dist, '/');
-}
 
 gulp.task('clean', function () {
   return $.del([path.join(conf.paths.dist, '/'), path.join(conf.paths.tmp, '/')]);

--- a/client/gulp/build.js
+++ b/client/gulp/build.js
@@ -36,11 +36,13 @@ gulp.task('html', ['inject', 'partials'], function () {
     addRootSlash: false
   };
 
+  var injectedHtmlFileName = conf.getInjectedHTMLfileName();
+
   var jsFilter = $.filter('**/*.js', { restore: true });
   var cssFilter = $.filter('**/*.css', { restore: true });
-  var tmpHtmlFilter = $.filter('**/*.html.tmp', { restore: true });
+  var tmpHtmlFilter = $.filter('**/' + injectedHtmlFileName, { restore: true });
   var output = conf.getTargetDirectory();
-  var srcHtml = conf.getInjectedHTMLfilePath();
+  var srcHtml = path.join('./', injectedHtmlFileName);
 
   // TODO(filip): fix this path
   // return gulp.src(path.join(conf.paths.tmp, '/serve/*.html'))
@@ -61,10 +63,7 @@ gulp.task('html', ['inject', 'partials'], function () {
     .pipe(cssFilter.restore)
     .pipe($.revReplace())
     .pipe(tmpHtmlFilter)
-    .pipe(rename(function(path) {
-      path.extname = ''; // file.html.tmp -> file.html
-      return path;
-    }))
+    .pipe(rename('./index.html'))
     .pipe(tmpHtmlFilter.restore)
     .pipe(gulp.dest(output))
     .pipe($.size({ title: path.join(conf.paths.dist, '/'), showFiles: true }));

--- a/client/gulp/conf.js
+++ b/client/gulp/conf.js
@@ -45,7 +45,7 @@ module.exports = {
     return argv.o || 'dist/';
   },
 
-  getInjectedHTMLfilePath: function() {
-    return argv.p ? './index.html.tmp' : './index.html';
+  getInjectedHTMLfileName: function() {
+    return argv.p ? 'index-build-temp.html' : 'index.html';
   }
 };

--- a/client/gulp/conf.js
+++ b/client/gulp/conf.js
@@ -7,6 +7,7 @@
  */
 
 var argv = require('yargs').argv;
+var path = require('path');
 
 /**
  *  The main paths of your project handle these with care
@@ -40,11 +41,11 @@ module.exports = {
     };
   },
 
-  getOutputTarget() {
-    return argv.o || path.join('dist', '/');
+  getTargetDirectory: function() {
+    return argv.o || 'dist/';
   },
 
-  getInjectTarget() {
-    return argv.o || '.';
+  getInjectedHTMLfilePath: function() {
+    return argv.p ? './index.html.tmp' : './index.html';
   }
 };

--- a/client/gulp/conf.js
+++ b/client/gulp/conf.js
@@ -6,6 +6,8 @@
  *  of the tasks
  */
 
+var argv = require('yargs').argv;
+
 /**
  *  The main paths of your project handle these with care
  */
@@ -36,5 +38,13 @@ module.exports = {
       console.error('[' + title + ']',  err.toString());
       this.emit('end');
     };
+  },
+
+  getOutputTarget() {
+    return argv.o || path.join('dist', '/');
+  },
+
+  getInjectTarget() {
+    return argv.o || '.';
   }
 };

--- a/client/gulp/inject.js
+++ b/client/gulp/inject.js
@@ -5,6 +5,7 @@ var gulp = require('gulp');
 var conf = require('./conf');
 var browserSync = require('browser-sync');
 var $ = require('gulp-load-plugins')();
+var rename = require('gulp-rename');
 
 var appStream = gulp.src(conf.paths.appScripts);
 
@@ -24,5 +25,6 @@ gulp.task('inject', [], function () {
 
   return gulp.src(conf.paths.indexHtml)
     .pipe($.inject(injectScripts, injectOptions))
-    .pipe(gulp.dest(conf.getInjectTarget()));
+    .pipe(rename(conf.getInjectedHTMLfilePath()))
+    .pipe(gulp.dest('.'));
 });

--- a/client/gulp/inject.js
+++ b/client/gulp/inject.js
@@ -24,5 +24,5 @@ gulp.task('inject', [], function () {
 
   return gulp.src(conf.paths.indexHtml)
     .pipe($.inject(injectScripts, injectOptions))
-    .pipe(gulp.dest('.'));
+    .pipe(gulp.dest(conf.getInjectTarget()));
 });

--- a/client/gulp/inject.js
+++ b/client/gulp/inject.js
@@ -25,6 +25,6 @@ gulp.task('inject', [], function () {
 
   return gulp.src(conf.paths.indexHtml)
     .pipe($.inject(injectScripts, injectOptions))
-    .pipe(rename(conf.getInjectedHTMLfilePath()))
+    .pipe(rename(conf.getInjectedHTMLfileName()))
     .pipe(gulp.dest('.'));
 });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.6.3",
   "description": "Build wrapper for Environment Manager server and client components",
   "scripts": {
-    "build": "gulp build --gulpfile server/gulpfile.js -o ../build && gulp build --gulpfile client/gulpfile.js -o ../build/dist"
+    "build": "gulp build --gulpfile server/gulpfile.js -p -o ../build && gulp build --gulpfile client/gulpfile.js -p -o ../build/dist"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When we run `npm run build`, the `gulp inject` task is run which can modify the checked in `index.html` file.

This change makes our build side-effect free by creating a temporary `.html` file during the build, which is ignored by git.  