### PR TITLE
Report exact build version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,5 @@ build/
 # Build artifacts
 client/index-build-temp.html
 publish_id.txt
+version.txt
 environment-manager-*.zip

--- a/client/app/common/MainController.js
+++ b/client/app/common/MainController.js
@@ -4,6 +4,7 @@
 angular.module('EnvironmentManager.common').controller('MainController',
   function ($rootScope, $scope, $route, $routeParams, $location, modal, cachedResources) {
 
+    $scope.appVersion = window.version;
     $scope.$route = $route; // Used by index page to determine active section
     $scope.LoggedInUser = window.user.getName(); // For display in header
     $scope.ParentEnvironmentsList = []; // For Environments selection

--- a/client/index.html
+++ b/client/index.html
@@ -163,7 +163,7 @@
 <body ng-controller="MainController">
     <header>
         <a href="#/"><img id="logo" src="assets/images/logo.jpg" height="30"/></a>
-        <h1 title="EnvironmentManager"><a href="#/">Environment Manager</a></h1>
+        <h1 title="Environment Manager {{appVersion}}"><a href="#/">Environment Manager</a></h1>
         <nav>
             <ul>
                 <li><a href="#/environments" ng-class="{active: GetSection()=='environments'}">Environments</a></li>

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -2,10 +2,11 @@
 'use strict';
 
 let nconf = require('nconf');
+let fs = require('fs');
+
 const REQUIRED_VALUES = ['EM_AWS_REGION'];
 const LOGGED_VALUES = ['EM_AWS_REGION', 'EM_AWS_RESOURCE_PREFIX', 'EM_AWS_S3_BUCKET'];
-let fs = require('fs');
-let appVersion = require('package.json').version;
+const APP_VERSION = require('./version').getVersion();
 
 /**
  * ENV is default but allow argument overrides
@@ -42,7 +43,7 @@ const useDevSources = nconf.get('DEV_SOURCES') === 'true';
 const publicDir = isProduction || useDevSources ? './dist' : '../client';
 
 nconf.set('IS_PRODUCTION', isProduction);
-nconf.set('APP_VERSION', appVersion);
+nconf.set('APP_VERSION', APP_VERSION);
 nconf.set('PUBLIC_DIR', publicDir);
 
 /**

--- a/server/config/version.js
+++ b/server/config/version.js
@@ -1,0 +1,19 @@
+/* Copyright (c) Trainline Limited, 2016. All rights reserved. See LICENSE.txt in the project root for license information. */
+'use strict';
+
+const VERSION_INFO = 'version.txt';
+
+let fs = require('fs');
+let packageInfo = require('package.json');
+
+function getVersion() {
+  if (fs.existsSync(VERSION_INFO)) {
+    return fs.readFileSync(VERSION_INFO, 'utf-8')
+  } else {
+    return `${packageInfo.version}-DEV`;
+  }
+}
+
+module.exports = {
+  getVersion: getVersion
+};


### PR DESCRIPTION
Instead of simply using the value of `version` in `package.json`, this change reads the version info from a `version.txt` file. This file can be created at build time and provide more specific build info.

This also fixes the regression that prevented version info being shown when hovering over the main title.