### PR TITLE
Maintenance mode instance tag and scheduler changes

### DIFF
--- a/server/api/controllers/instances/instancesController.js
+++ b/server/api/controllers/instances/instancesController.js
@@ -34,9 +34,7 @@ function getInstances(req, res, next) {
       filter['tag:Environment'] = environment;
     }
     if (maintenance === true) {
-      let entry = yield asgIpsDynamo.getByKey('MAINTENANCE_MODE', { accountName });
-      let ips = JSON.parse(entry.IPs);
-      filter['private-ip-address'] = ips;
+      filter['tag:Maintenance'] = 'true';
     }
     if (ipAddress !== undefined) {
       filter['private-ip-address'] = ipAddress;
@@ -106,6 +104,8 @@ function putInstanceMaintenance(req, res, next) {
         throw err;
       }
     }
+
+    yield instance.persistTag({ key: 'Maintenance', value: enable.toString() });
 
     /**
      * Now switch Maintenance mode (previously done in separate end point)

--- a/server/models/Instance.js
+++ b/server/models/Instance.js
@@ -4,6 +4,7 @@
 let _ = require('lodash');
 let taggable = require('./taggable');
 let ScanCrossAccountInstances = require('queryHandlers/ScanCrossAccountInstances');
+let ec2InstanceClientFactory = require('modules/clientFactories/ec2InstanceClientFactory');
 
 class Instance {
 
@@ -13,6 +14,18 @@ class Instance {
 
   getAutoScalingGroupName() {
     return this.getTag('aws:autoscaling:groupName');
+  }
+
+  persistTag(tag) {
+    return ec2InstanceClientFactory.create({ accountName: this.AccountName }).then(client => {
+      let parameters = {
+        instanceIds: [this.InstanceId],
+        tagKey: tag.key,
+        tagValue: tag.value,
+      };
+
+      return client.setTag(parameters);
+    });
   }
 
   static getById(instanceId) {

--- a/server/modules/clientFactories/ec2InstanceClientFactory.js
+++ b/server/modules/clientFactories/ec2InstanceClientFactory.js
@@ -1,10 +1,9 @@
 /* Copyright (c) Trainline Limited, 2016. All rights reserved. See LICENSE.txt in the project root for license information. */
 'use strict';
 
-let resourceProvider = require('modules/resourceProvider');
-
 module.exports = {
   create: function (parameters) {
+    let resourceProvider = require('modules/resourceProvider');
     return resourceProvider.getInstanceByName('instances', parameters);
   },
 };

--- a/server/modules/scheduling/index.js
+++ b/server/modules/scheduling/index.js
@@ -26,6 +26,7 @@ const skipReasons = {
   transitioning: 'This instance is currently transitioning between states',
   asgTransitioning: 'This instance is currently transitioning between ASG lifecycle states',
   asgLifecycleMismatches: 'The ASG has instances in different lifecycle states',
+  maintenanceMode: 'This instance is currently in Maintenance Mode',
   stateIsCorrect: 'The instance is already in the correct state'
 };
 
@@ -47,6 +48,9 @@ function actionForInstance(instance, dateTime) {
 
   if (asgHasMismatchedInstanceLifecycles(instance.AutoScalingGroup))
     return skip(skipReasons.asgLifecycleMismatches);
+
+  if (isInMaintenanceMode(instance))
+    return skip(skipReasons.maintenanceMode);
 
   let foundSchedule = getScheduleForInstance(instance);
 
@@ -123,6 +127,11 @@ function switchOff(instance, source) {
 
   return skip(skipReasons.stateIsCorrect, source);
   
+}
+
+function isInMaintenanceMode(instance) {
+  let maintenanceModeTagValue = getTagValue(instance, 'maintenance');
+  return maintenanceModeTagValue && maintenanceModeTagValue.toLowerCase() === 'true';
 }
 
 function getAsgInstanceLifeCycleState(instance) {

--- a/server/modules/scheduling/index.js
+++ b/server/modules/scheduling/index.js
@@ -46,9 +46,6 @@ function actionForInstance(instance, dateTime) {
   if (!instance.Environment)
     return skip(skipReasons.noEnvironment);
 
-  if (asgHasMismatchedInstanceLifecycles(instance.AutoScalingGroup))
-    return skip(skipReasons.asgLifecycleMismatches);
-
   if (isInMaintenanceMode(instance))
     return skip(skipReasons.maintenanceMode);
 
@@ -157,13 +154,6 @@ function getScheduleForInstance(instance) {
   
   return { parseResult: parseEnvironmentSchedule(instance.Environment), source: sources.environment };
 
-}
-
-function asgHasMismatchedInstanceLifecycles(asg) {
-  if (!asg)
-    return false;
-    
-  return _.uniq(asg.Instances.map(i => i.LifecycleState)).length > 1;
 }
 
 function parseEnvironmentSchedule(environmentSchedule) {

--- a/server/test/modules/scheduling.spec.js
+++ b/server/test/modules/scheduling.spec.js
@@ -4,7 +4,7 @@ const expect = require('chai').expect;
 const _ = require('lodash');
 const scheduling = require('modules/scheduling');
 
-describe('scheduling', () => {
+describe.only('scheduling', () => {
 
   let instance, scheduleTag;
 
@@ -97,18 +97,6 @@ describe('scheduling', () => {
         AutoScalingGroupName: 'x',
         Instances: [ asgInstance ]
       };
-    });
-
-    it('should be skipped when the ASG has instances in different lifecycle states', function() {
-      instance.AutoScalingGroup.Instances = [
-        { InstanceId: 'instanceId', LifecycleState: 'Standby' },
-        { InstanceId: 'instanceId2', LifecycleState: 'InService' }
-      ];
-
-      let action = scheduling.actionForInstance(instance);
-
-      expect(action.action).to.equal(scheduling.actions.skip);
-      expect(action.reason).to.equal(scheduling.skipReasons.asgLifecycleMismatches);
     });
 
     it('should be skipped when transitioning between lifecycle states', function() {

--- a/server/test/modules/scheduling.spec.js
+++ b/server/test/modules/scheduling.spec.js
@@ -47,6 +47,15 @@ describe('scheduling', () => {
     expect(action.reason).to.equal(scheduling.skipReasons.explicitNoSchedule);
   });
 
+  it('should skip instances in maintenance mode', function() {
+    instance.Tags.push({ Key: 'MAINTENANCE', Value: 'TRUE' });
+
+    let action = scheduling.actionForInstance(instance);
+
+    expect(action.action).to.equal(scheduling.actions.skip);
+    expect(action.reason).to.equal(scheduling.skipReasons.maintenanceMode);
+  });
+
   let invalidCrons = ['rubbish', 'rubbish:* * * * *', ':', 'start:;', 'start:*;gah:']
 
   invalidCrons.forEach(cron => {

--- a/server/test/modules/scheduling.spec.js
+++ b/server/test/modules/scheduling.spec.js
@@ -4,7 +4,7 @@ const expect = require('chai').expect;
 const _ = require('lodash');
 const scheduling = require('modules/scheduling');
 
-describe.only('scheduling', () => {
+describe('scheduling', () => {
 
   let instance, scheduleTag;
 


### PR DESCRIPTION
This is to allow the scheduler to process instances contained in an ASG with instances in different lifecycle states. Previously instances in ASGs like these needed to be skipped because we could accidentally bring maintenance mode instances back in service. With this change we're now skipping those instances. This allows other instances in the ASG to be scheduled as normal.