### PR TITLE
New Update ASG endpoint

### DIFF
--- a/server/api/controllers/asgs/asgController.js
+++ b/server/api/controllers/asgs/asgController.js
@@ -93,11 +93,9 @@ function putAsg(req, res, next) {
   const environmentName = req.swagger.params.environment.value;
   const autoScalingGroupName = req.swagger.params.name.value;
 
-  const body = req.swagger.params.body.value;
-  const size = body.size;
-  const az = body.az;
+  const parameters = req.swagger.params.body.value;
 
-  UpdateAutoScalingGroup({ environmentName, autoScalingGroupName, size, az })
+  UpdateAutoScalingGroup({ environmentName, autoScalingGroupName, parameters })
     .then(data => res.json(data)).catch(next);
 }
 

--- a/server/api/controllers/asgs/asgController.js
+++ b/server/api/controllers/asgs/asgController.js
@@ -10,6 +10,7 @@ let GetLaunchConfiguration = require('queryHandlers/GetLaunchConfiguration');
 let SetLaunchConfiguration = require('commands/launch-config/SetLaunchConfiguration');
 let SetAutoScalingGroupSize = require('commands/asg/SetAutoScalingGroupSize');
 let SetAutoScalingGroupSchedule = require('commands/asg/SetAutoScalingGroupSchedule');
+let UpdateAutoScalingGroup = require('commands/asg/UpdateAutoScalingGroup');
 let GetAutoScalingGroupScheduledActions = require('queryHandlers/GetAutoScalingGroupScheduledActions');
 let Environment = require('models/Environment');
 
@@ -86,6 +87,21 @@ function getScalingSchedule(req, res, next) {
 }
 
 /**
+ * PUT /asgs/{name}
+ */
+function putAsg(req, res, next) {
+  const environmentName = req.swagger.params.environment.value;
+  const autoScalingGroupName = req.swagger.params.name.value;
+
+  const body = req.swagger.params.body.value;
+  const size = body.size;
+  const az = body.az;
+
+  UpdateAutoScalingGroup({ environmentName, autoScalingGroupName, size, az })
+    .then(data => res.json(data)).catch(next);
+}
+
+/**
  * PUT /asgs/{name}/scaling-schedule
  */
 function putScalingSchedule(req, res, next) {
@@ -146,6 +162,7 @@ module.exports = {
   getAsgLaunchConfig,
   putScalingSchedule,
   getScalingSchedule,
+  putAsg,
   putAsgSize,
   putAsgLaunchConfig
 };

--- a/server/api/swagger.yaml
+++ b/server/api/swagger.yaml
@@ -56,6 +56,29 @@ paths:
           description: The matching ASG
           schema:
             type: object
+    put:
+      operationId: putAsg
+      summary: Update properties of an ASG.
+      tags:
+        - ASG
+      x-authorizer: asgs
+      parameters:
+        - name: environment
+          in: query
+          type: string
+          required: true
+        - name: name
+          in: path
+          type: string
+          required: true
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+      responses:
+        200:
+          description: Ok
   /asgs/{name}/ips:
     x-swagger-router-controller: asgs/asgController
     get:

--- a/server/commands/asg/UpdateAutoScalingGroup.js
+++ b/server/commands/asg/UpdateAutoScalingGroup.js
@@ -108,7 +108,7 @@ function unMapSubnetType(subnetTypeName, subnetType) {
     availabilityZones: azs,
     secure: !!subnetType.Secure,
     hasSubnet: subnet => {
-      return !!_.some(azs, az => az.subnet === subnet);
+      return _.some(azs, az => az.subnet === subnet);
     }
   };
 }

--- a/server/commands/asg/UpdateAutoScalingGroup.js
+++ b/server/commands/asg/UpdateAutoScalingGroup.js
@@ -1,0 +1,84 @@
+/* Copyright (c) Trainline Limited, 2016. All rights reserved. See LICENSE.txt in the project root for license information. */
+'use strict'
+
+let co = require('co');
+let _ = require('lodash');
+let OperationResult = require('../utils/operationResult');
+let resourceProvider = require('modules/resourceProvider');
+let InvalidOperationError = require('modules/errors/InvalidOperationError.class');
+let subnetsProvider = require('modules/provisioning/autoScaling/subnetsProvider');
+let sender = new require('modules/sender');
+let Environment = require('models/Environment');
+let EnvironmentType = require('models/EnvironmentType');
+
+function* handler(command) {
+  const result = new OperationResult();
+
+  // Validation
+  let size = command.size;
+
+  if (!_.isNil(size.min)) {
+    if (!_.isNil(size.max) && size.min > size.max) {
+      throw new InvalidOperationError(
+        `Provided Max size '${size.max}' must be greater than or equal to the Min size '${size.min}'.`
+      );
+    }
+
+    if (!_.isNil(size.desired) && size.desired < size.min) {
+      throw new InvalidOperationError(
+        `Provided Desired size '${size.desired}' must be greater than or equal to the Min size '${size.min}'.`
+      );
+    }
+  }
+
+  if (!_.isNil(size.max)) {
+    if (!_.isNil(size.min) && size.min > size.max) {
+      throw new InvalidOperationError(
+        `Provided Min size '${size.min}' must be less than or equal to the Max size '${size.max}'.`
+      );
+    }
+
+    if (!_.isNil(size.desired) && size.desired > size.max) {
+      throw new InvalidOperationError(
+        `Provided Desired size '${size.desired}' must be less than or equal to the Max size '${size.max}'.`
+      );
+    }
+  }
+
+  let az = command.az;
+
+  let subnets;
+  if (!_.isNil(az)) {
+    let environment = yield Environment.getByName(command.environmentName);
+    let environmentType = yield EnvironmentType.getByName(environment.EnvironmentType);
+
+    let configuration = {
+      serverRole: {
+        SubnetTypeName: az.subnetTypeName,
+        SecurityZone: az.securityZone,
+        AvailabilityZoneName: az.availabilityZoneName
+      },
+      environmentType: environmentType,
+      environmentTypeName: environment.EnvironmentType
+    };
+
+    subnets = yield subnetsProvider.get(configuration);
+  }
+
+  // Get a resource instance to work with AutoScalingGroup in the proper
+  // AWS account.
+  let accountName = yield Environment.getAccountNameForEnvironment(command.environmentName);
+  let resource = yield resourceProvider.getInstanceByName('asgs', { accountName });
+
+  let parameters = {
+    name: command.autoScalingGroupName,
+    minSize: size.min,
+    desiredSize: size.desired,
+    maxSize: size.max,
+    subnets: subnets
+  };
+
+  return resource.put(parameters);
+}
+
+module.exports = co.wrap(handler);

--- a/server/commands/asg/UpdateAutoScalingGroup.js
+++ b/server/commands/asg/UpdateAutoScalingGroup.js
@@ -15,7 +15,7 @@ function* handler(command) {
   const result = new OperationResult();
 
   // Validation
-  let size = command.size;
+  let size = command.parameters.size;
 
   if (!_.isNil(size.min)) {
     if (!_.isNil(size.max) && size.min > size.max) {
@@ -45,30 +45,34 @@ function* handler(command) {
     }
   }
 
-  let az = command.az;
-
-  let subnets;
-  if (!_.isNil(az)) {
-    let environment = yield Environment.getByName(command.environmentName);
-    let environmentType = yield EnvironmentType.getByName(environment.EnvironmentType);
-
-    let configuration = {
-      serverRole: {
-        SubnetTypeName: az.subnetTypeName,
-        SecurityZone: az.securityZone,
-        AvailabilityZoneName: az.availabilityZoneName
-      },
-      environmentType: environmentType,
-      environmentTypeName: environment.EnvironmentType
-    };
-
-    subnets = yield subnetsProvider.get(configuration);
-  }
-
   // Get a resource instance to work with AutoScalingGroup in the proper
   // AWS account.
   let accountName = yield Environment.getAccountNameForEnvironment(command.environmentName);
   let resource = yield resourceProvider.getInstanceByName('asgs', { accountName });
+
+  let subnets;
+  
+  let network = command.parameters.network;
+  if (!_.isNil(network)) {
+
+    let environment = yield Environment.getByName(command.environmentName);
+    let environmentType = yield EnvironmentType.getByName(environment.EnvironmentType);
+    let asg = yield resource.get({ name: command.autoScalingGroupName });
+
+    let currentSubnet = asg.VPCZoneIdentifier.split(',')[0];
+    let currentSubnetType = getSubnetTypeBySubnet(environmentType.Subnets, currentSubnet);
+
+    subnets = yield subnetsProvider.get({
+      serverRole: {
+        SecurityZone: asg.getTag('SecurityZone'),
+        SubnetTypeName: currentSubnetType.name,
+        AvailabilityZoneName: network.availabilityZoneName
+      },
+      environmentType: environmentType,
+      environmentTypeName: environment.EnvironmentType
+    });
+
+  }
 
   let parameters = {
     name: command.autoScalingGroupName,
@@ -79,6 +83,34 @@ function* handler(command) {
   };
 
   return resource.put(parameters);
+}
+
+function getSubnetTypeBySubnet(subnetTypes, subnet) {
+  let subnetTypeArray = _.keys(subnetTypes).map(key => {
+    let subnetType = unMapSubnetType(key, subnetTypes[key]);
+    return subnetType;
+  });
+  return _.find(subnetTypeArray, subnetType => subnetType.hasSubnet(subnet));
+}
+
+function unMapSubnetType(subnetTypeName, subnetType) {
+  let azs = _.keys(subnetType)
+    .filter(key => key.startsWith('AvailabilityZone'))
+    .map(key => {
+      return {
+        name: key,
+        subnet: subnetType[key]
+      }
+    });
+
+  return {
+    name: subnetTypeName,
+    availabilityZones: azs,
+    secure: !!subnetType.Secure,
+    hasSubnet: subnet => {
+      return !!_.some(azs, az => az.subnet === subnet);
+    }
+  };
 }
 
 module.exports = co.wrap(handler);

--- a/server/modules/resourceFactories/AsgResource.js
+++ b/server/modules/resourceFactories/AsgResource.js
@@ -104,6 +104,10 @@ function AsgResource(client, accountName) {
       request.LaunchConfigurationName = parameters.launchConfigurationName;
     }
 
+    if (!_.isNil(parameters.subnets)) {
+      request.VPCZoneIdentifier = parameters.subnets.join(',');
+    }
+
     let asgCache = cacheManager.get('Auto Scaling Groups');
     asgCache.del(accountName);
 


### PR DESCRIPTION
A new endpoint for use by the UI to update an ASG. The first use of this would be to update the subnets on demand. Example PUT:

http://localhost:8080/api/v1/asgs/enter-asg-name?environment=enter-env-name

```
{
	"size": {
		"min": 1,
		"desired": 1,
		"max": 1
	},
	"network": {
		"availabilityZoneName": "A"
	}
}
```

both size and network parameters are optional.