### PR TITLE
Old deployment history URL redirects to API v1 URL

### DIFF
--- a/server/api/controllers/deployments/deploymentsController.js
+++ b/server/api/controllers/deployments/deploymentsController.js
@@ -102,7 +102,7 @@ function* postDeployment(req, res, next) {
 
   sender.sendCommand({ command, user: req.user }).then((deployment) => {
     res.status(201);
-    res.location(`/api/${deployment.accountName}/deployments/history/${deployment.id}`);
+    res.location(`/api/v1/deployments/${deployment.id}`);
     res.json(deployment);
   }).catch(next);
 }

--- a/server/modules/MainServer.js
+++ b/server/modules/MainServer.js
@@ -89,6 +89,11 @@ module.exports = function MainServer() {
         res.send(APP_VERSION);
       });
 
+      // Redirect deployment history requests to v1 API.
+      app.get('/api/:account/deployments/history/:deploymentId', (req, res) => {
+        res.redirect(301, `/api/v1/deployments/${req.params.deploymentId}`);
+      });
+
       if (config.get('IS_PRODUCTION') === true) {
         app.use(expressWinston.errorLogger({ winstonInstance: logger }));
       }

--- a/server/resources/deployments/DeploymentsHistoryDynamoResource.js
+++ b/server/resources/deployments/DeploymentsHistoryDynamoResource.js
@@ -1,4 +1,5 @@
 /* Copyright (c) Trainline Limited, 2016. All rights reserved. See LICENSE.txt in the project root for license information. */
+
 'use strict';
 
 module.exports = {
@@ -10,9 +11,10 @@ module.exports = {
   queryable: true,
   dateField: {
     name: 'Value.StartTimestamp',
-    format: 'ISO'
+    format: 'ISO',
   },
   docs: {
-    disableDocs: true
-  }
+    disableDocs: true,
+  },
+  disableAutoRoute: true,
 };


### PR DESCRIPTION
Implementation of `/api/<account>/deployments/history/<deploymentId>` contains a bug so redirect to v1 URL: `/api/v1/deployments/<deploymentId>`