### PR TITLE
Fix/set status class from deployment info

### DIFF
--- a/client/app/operations/deployments/DeploymentDetailsModalController.js
+++ b/client/app/operations/deployments/DeploymentDetailsModalController.js
@@ -96,16 +96,6 @@ function deploymentView(deploymentRecord, clusters) {
     return newLogLines.join('\n');
   }
 
-  function getOverallStatus(deployment) {
-    var errorNodes = _.some(deployment.Nodes, function (node) {
-      return node.Status.toLowerCase() == 'failed';
-    });
-
-    if (errorNodes) return 'Failed';
-
-    return deployment.Status;
-  }
-
   var deployment = deploymentRecord.Value;
 
   var service = deployment.ServiceName + ' (' + deployment.ServiceVersion + ')';
@@ -116,7 +106,7 @@ function deploymentView(deploymentRecord, clusters) {
   var duration = getDuration();
   var error = getError();
 
-  var statusClass = getStatusClass(getOverallStatus(deployment));
+  var statusClass = getStatusClass(deployment.Status);
   var nodes = getViewableNodes(deploymentRecord);
 
   var cluster = _.find(clusters, { ClusterName: deployment.OwningCluster });


### PR DESCRIPTION
Status class should be derived from over deployment status, not particular nodes, otherwise this might happen (failed status in "In Progress" deployment):

![image](https://cloud.githubusercontent.com/assets/875141/20751437/a3fb77ec-b6f3-11e6-9bbb-8decbb85db5e.png)

If we want to mark Deployment as "Failed" as a consequence of one of the nodes failing, this needs to be run in Deployment monitor.