### PR TITLE
Fix/write deployment log before complete

### DIFF
--- a/server/commands/utils/metadata.js
+++ b/server/commands/utils/metadata.js
@@ -1,30 +1,8 @@
 /* Copyright (c) Trainline Limited, 2016. All rights reserved. See LICENSE.txt in the project root for license information. */
+
 'use strict';
 
 let guid = require('node-uuid');
-
-function createFromParameters(parameters) {
-  let command = Object.assign({}, parameters.command);
-
-  if (parameters.parent) {
-    command.commandId = parameters.parent.commandId;
-    command.username  = parameters.parent.username;
-  } else {
-    command.commandId = createCommandId();
-    command.username  = getUsername(parameters.user);
-  }
-
-  command.timestamp = createTimestamp();
-  return command;
-}
-
-function addMetadata(command) {
-  command.commandId = createCommandId();
-  command.username = getUsername(command.user);
-  command.timestamp = createTimestamp();
-  delete command.user;
-  return command;
-}
 
 function createCommandId() {
   return guid.v1();
@@ -38,7 +16,36 @@ function getUsername(user) {
   return user.getName();
 }
 
+function createFromParameters(parameters) {
+  let command = Object.assign({}, parameters.command);
+
+  // Why must we override these if they are already set?
+  if (parameters.parent) {
+    command.commandId = parameters.parent.commandId;
+    command.username = parameters.parent.username;
+  } else {
+    command.commandId = createCommandId();
+    command.username = getUsername(parameters.user);
+  }
+
+  command.timestamp = createTimestamp();
+  return command;
+}
+
+function addMetadata(command) {
+  // Why must we override these if they are already set?
+  let overrides = {
+    commandId: createCommandId(),
+    username: getUsername(command.user),
+    timestamp: createTimestamp(),
+  };
+
+  let result = Object.assign({}, command, overrides);
+  delete result.user;
+  return result;
+}
+
 module.exports = {
   createFromParameters,
-  addMetadata
+  addMetadata,
 };

--- a/server/modules/DeploymentLogsStreamer.js
+++ b/server/modules/DeploymentLogsStreamer.js
@@ -1,63 +1,59 @@
 /* Copyright (c) Trainline Limited, 2016. All rights reserved. See LICENSE.txt in the project root for license information. */
+
 'use strict';
 
-let co = require('co');
 let logger = require('modules/logger');
-let sender = require('modules/sender');
-let assert = require('assert');
 let Deployment = require('models/Deployment');
+let timer = require('timers');
 
 module.exports = function DeploymentLogsStreamer() {
+  let pendingLogEntries = (() => {
+    let state = new Map();
+    return {
+      add: (deploymentId, message) => {
+        if (!state.has(deploymentId)) {
+          state.set(deploymentId, []);
+        }
+        state.get(deploymentId).push(message);
+      },
+      deploymentIds: () => Array.from(state.keys()),
+      getByDeploymentId: deploymentId => state.get(deploymentId) || [],
+      removeByDeploymentId: deploymentId => state.delete(deploymentId),
+    };
+  })();
 
-  let deploymentLogStreams = {};
-  let isRunning = false;
-
-  this.log = function (deploymentId, accountName, message) {
-    let logStreams = getLogStreamsByDeploymentIdAndAccountName(deploymentId);
-    let timestamp = new Date().toISOString();
-
-    logStreams.logs.push(`[${timestamp}] ${message}`);
-  };
-
-  function getLogStreamsByDeploymentIdAndAccountName(deploymentId) {
-    let logStreams = deploymentLogStreams[deploymentId];
-    if (logStreams === undefined) {
-      logStreams = {
-        deploymentId,
-        logs: [],
-      };
-
-      deploymentLogStreams[deploymentId] = logStreams;
+  function logWriteErrors(result) {
+    if (result.error) {
+      logger.error(result.error);
+      logger.error(`Failed to flush pending log entries for deployment ${result.deploymentId}:
+${result.logEntries.join('\n')}`);
     }
-
-    return logStreams;
+    return result;
   }
 
-  function flushLogStream(logStream) {
-    return co(function* () {
-      let deployment = yield Deployment.getById(logStream.deploymentId)
-      return deployment.addExecutionLogEntries(logStream.logs);
-    });
+  function flushPendingLogEntries(deploymentId) {
+    let logEntries = pendingLogEntries.getByDeploymentId(deploymentId);
+    pendingLogEntries.removeByDeploymentId(deploymentId);
+    return Deployment.getById(deploymentId)
+      .then(deployment => deployment.addExecutionLogEntries(logEntries))
+      .then(() => ({ deploymentId }))
+      .catch(error => ({ deploymentId, logEntries, error }))
+      .then(logWriteErrors);
   }
 
-  setInterval(() => {
-    isRunning = true;
-    let promises = [];
-    for (let deploymentId in deploymentLogStreams) {
-      let logStream = deploymentLogStreams[deploymentId];
-      promises.push(flushLogStream(logStream));
-    }
-
-    deploymentLogStreams = {};
-
-    Promise.all(promises).then(
-      () => { isRunning = false; },
+  timer.setInterval(() => {
+    let promises = pendingLogEntries.deploymentIds().map(flushPendingLogEntries);
+    Promise.all(promises).catch(
       (error) => {
-        isRunning = false;
         logger.error(`An error has occurred streaming logs to DynamoDB: ${error.message}`);
       }
     );
-
   }, 1000);
 
+  this.log = (deploymentId, accountName, message) => {
+    let timestamp = new Date().toISOString();
+    pendingLogEntries.add(deploymentId, `[${timestamp}] ${message}`);
+  };
+
+  this.flush = flushPendingLogEntries;
 };

--- a/server/test/modules/DeploymentLogsStreamerTest.js
+++ b/server/test/modules/DeploymentLogsStreamerTest.js
@@ -1,0 +1,83 @@
+'use strict';
+
+let memoize = require('modules/memoize');
+let proxyquire = require('proxyquire').noCallThru();
+let should = require('should');
+let sinon = require('sinon');
+
+describe('DeploymentLogsStreamer', function () {
+    let deploymentLogsStreamer;
+    let fakeTimer;
+    let loggedMessages;
+    let deploymentLogs;
+    beforeEach(function () {
+
+        deploymentLogs = [];
+        let fakeDeployment = {
+            getById: deploymentId => Promise.resolve({
+                addExecutionLogEntries: entries => {
+                    entries.forEach(entry => deploymentLogs.push({ deploymentId, entry }));
+                }
+            }),
+        };
+
+        loggedMessages = [];
+        let fakeLogger = (() => {
+            let logger = {};
+            ['error', 'warn', 'info', 'debug'].forEach(level => {
+                logger[level] = message => {
+                    loggedMessages.push({ level, message });
+                }
+            });
+            return logger;
+        })();
+
+        fakeTimer = (() => {
+            let callbacks = []
+            return {
+                elapse: () => Promise.all(callbacks.map(fn => Promise.resolve(fn()))),
+                setInterval: (fn, _) => callbacks.push(fn),
+            }
+        })();
+
+        let DeploymentLogsStreamer = proxyquire('modules/DeploymentLogsStreamer', {
+            'models/Deployment': fakeDeployment,
+            'modules/logger': fakeLogger,
+            'timers': fakeTimer,
+        });
+        deploymentLogsStreamer = new DeploymentLogsStreamer();
+    });
+    describe('log', function () {
+        context('once the flush period has elapsed', function () {
+            it('adds the messages to the correct deployment', function () {
+                let deploymentId = 'my-deployment-id';
+                let accountName = 'my-account-name';
+                ['one', 'two'].forEach(message => deploymentLogsStreamer.log('deployment-1', accountName, message));
+                ['three'].forEach(message => deploymentLogsStreamer.log('deployment-2', accountName, message));
+                return fakeTimer.elapse().then(() => deploymentLogs).should.finally.match([
+                    { deploymentId: 'deployment-1', entry: /one/ },
+                    { deploymentId: 'deployment-1', entry: /two/ },
+                    { deploymentId: 'deployment-2', entry: /three/ },
+                ]);
+            });
+        });
+    });
+    describe('flush', function () {
+        it('flushes all the log entries for the specified deployment', function () {
+            let deploymentId = 'my-deployment-id';
+            let accountName = 'my-account-name';
+            ['one', 'two'].forEach(message => deploymentLogsStreamer.log(deploymentId, accountName, message));
+            return deploymentLogsStreamer.flush(deploymentId).then(() => deploymentLogs).should.finally.match([
+                { deploymentId, entry: /one/ },
+                { deploymentId, entry: /two/ },
+            ]);
+        });
+        it('does not double up entries if called twice', function () {
+            let deploymentId = 'my-deployment-id';
+            let accountName = 'my-account-name';
+            deploymentLogsStreamer.log(deploymentId, accountName, 'hello');
+            let flush = () => deploymentLogsStreamer.flush(deploymentId);
+            return Promise.all([flush(), flush()]).then(() => deploymentLogs).should.finally.have.length(1);
+        });
+    });
+});


### PR DESCRIPTION
Deployment records are moved from _ConfigDeploymentExecutionStatus_ to _ConfigCompletedDeployments_ by a Lambda function when the deployment status changes from _In Progress_ to one of the completed statuses.

The application may attempt to append log entries to the record in _ConfigDeploymentExecutionStatus_ after it has been moved resulting in an error.

This fix ensures that all log entries for a deployment are flushed to the DynamoDB record before the status is updated.

See [Trello](https://trello.com/c/PfulubkA/647-error-writing-deployment-log-entries-to-a-completed-deployment) for details.