### PR TITLE
Scheduler fixes

### DIFF
--- a/lambda/Scheduler/index.js
+++ b/lambda/Scheduler/index.js
@@ -13,7 +13,7 @@ exports.handler = (event, context, callback) => {
 
     scheduler.doScheduling()
     .then(result => {
-      if (result.success) callback(null, result);
+      if (result.success) callback(null, logSuccess(result));
       else callback(logError('Scheduling Failure', result));
     })
     .catch(err => {
@@ -25,6 +25,11 @@ exports.handler = (event, context, callback) => {
   }
 
 };
+
+function logSuccess(result) {
+  console.log(JSON.stringify(result, null, 2));
+  return `SUCCESS! See logs for more details.`;
+}
 
 function logError(err, details) {
   console.error(JSON.stringify({ err, details }, null, 2));

--- a/lambda/Scheduler/package.json
+++ b/lambda/Scheduler/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "mocha": "^3.1.2",
-    "mocha-teamcity-reporter": "^1.1.1"
+    "mocha-teamcity-reporter": "^1.1.1",
+    "sinon": "^1.17.6"
   }
 }

--- a/lambda/Scheduler/services/aws.js
+++ b/lambda/Scheduler/services/aws.js
@@ -1,33 +1,47 @@
 'use strict'
 
 const AWS = require('aws-sdk');
+const RateLimiter = require('./rateLimiter');
 
 function createAWSService(config) {
 
   let ec2 = new AWS.EC2(config);
   let autoscaling = new AWS.AutoScaling(config);
 
+  let autoscalingRateLimiter = new RateLimiter(10);
+
   function switchInstancesOn(instances) {
-    return ec2.startInstances({ InstanceIds: instances.map(i => i.id) }).promise();
+    return promiseAllWithSlowFail(instances.map(instance => {
+      return ec2.startInstances({
+        InstanceIds: [instance.id]
+      }).promise();
+    }));
   }
 
   function switchInstancesOff(instances) {
-    return ec2.stopInstances({ InstanceIds: instances.map(i => i.id) }).promise();
+    return promiseAllWithSlowFail(instances.map(instance => {
+      return ec2.stopInstances({
+        InstanceIds: [instance.id]
+      }).promise();
+    }));
   }
 
   function putAsgInstancesInService(instances) {
-    return promiseAllWithSlowFail(instances.map(instance => {
+    let tasks = instances.map(instance => {
       return () => {
         return autoscaling.exitStandby({
           AutoScalingGroupName: instance.asg,
           InstanceIds: [instance.id]
         }).promise();
       };
-    }));
+    });
+
+    let promises = tasks.map(autoscalingRateLimiter.queueTask);
+    return promiseAllWithSlowFail(tasks);
   }
 
   function putAsgInstancesInStandby(instances) {
-    return promiseAllWithSlowFail(instances.map(instance => {
+    let tasks = instances.map(instance => {
       return () => {
         return autoscaling.enterStandby({
           AutoScalingGroupName: instance.asg,
@@ -35,19 +49,26 @@ function createAWSService(config) {
           ShouldDecrementDesiredCapacity: true
         }).promise();
       };
-    }));
-  }
-
-  function promiseAllWithSlowFail(tasks) {
-    let errors = [];
-
-    let promises = tasks.map(task => {
-      return task().catch(err => { errors.push(err); });
     });
 
-    return Promise.all(promises).then(() => {
+    let promises = tasks.map(autoscalingRateLimiter.queueTask);
+    return promiseAllWithSlowFail(promises);
+  }
+
+  function promiseAllWithSlowFail(promises) {
+    let errors = [];
+
+    let safePromises = promises.map(promise => {
+      return promise.catch(err => {
+        errors.push(err);
+      });
+    });
+
+    return Promise.all(safePromises).then(results => {
       if (errors.length > 0)
         throw { message: `${errors.length} operations failed.`, errors: errors };
+
+      return results;
     });
   }
 

--- a/lambda/Scheduler/services/rateLimiter.js
+++ b/lambda/Scheduler/services/rateLimiter.js
@@ -1,0 +1,44 @@
+'use strict'
+
+function RateLimiter(taskLimitPerSecond) {
+
+  let tasksStartedWithinTheSecond = 0;
+  let jobQueue = [];
+
+  this.queueTask = function(task) {
+    if (rateLimitNotReached()) {
+      return startTask(task);
+    }
+    
+    return new Promise((resolve, reject) => {
+      jobQueue.push({ task, resolve, reject });
+    });
+  }
+
+  function rateLimitNotReached() {
+    return tasksStartedWithinTheSecond < taskLimitPerSecond;
+  }
+
+  function startTask(task) {
+    tasksStartedWithinTheSecond++;
+    delay(1000).then(timeoutCompleted);
+    return task();
+  }
+
+  function timeoutCompleted() {
+    tasksStartedWithinTheSecond--;
+    if (jobQueue.length > 0) {
+      let job = jobQueue.shift();
+      startTask(job.task).then(job.resolve).catch(job.reject);
+    }
+  }
+
+  function delay(milliseconds) {
+    return new Promise(resolve => {
+      setTimeout(resolve, milliseconds);
+    });
+  }
+
+};
+
+module.exports = RateLimiter;

--- a/lambda/Scheduler/services/rateLimiter.js
+++ b/lambda/Scheduler/services/rateLimiter.js
@@ -1,3 +1,4 @@
+/* Copyright (c) Trainline Limited, 2016. All rights reserved. See LICENSE.txt in the project root for license information. */
 'use strict'
 
 function RateLimiter(taskLimitPerSecond) {
@@ -21,7 +22,7 @@ function RateLimiter(taskLimitPerSecond) {
 
   function startTask(task) {
     tasksStartedWithinTheSecond++;
-    delay(1000).then(timeoutCompleted);
+    setTimeout(timeoutCompleted, 1000);
     return task();
   }
 
@@ -31,12 +32,6 @@ function RateLimiter(taskLimitPerSecond) {
       let job = jobQueue.shift();
       startTask(job.task).then(job.resolve).catch(job.reject);
     }
-  }
-
-  function delay(milliseconds) {
-    return new Promise(resolve => {
-      setTimeout(resolve, milliseconds);
-    });
   }
 
 };

--- a/lambda/Scheduler/services/rateLimiter.spec.js
+++ b/lambda/Scheduler/services/rateLimiter.spec.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const expect = require('chai').expect;
+const sinon = require('sinon');
+
+const RateLimiter = require('./rateLimiter');
+
+let createTaskSpy = () => {
+  return sinon.spy(() => { return Promise.resolve(); });
+}
+
+describe('rate limiter', () => {
+
+  let clock;
+
+  before(function () { clock = sinon.useFakeTimers(); });
+  after(function () { clock.restore(); });
+
+  it('should call tasks immediately when under the limit', () => {
+
+    let taskSpy = createTaskSpy();
+
+    let rl = new RateLimiter(1);
+    rl.queueTask(taskSpy);
+
+    expect(taskSpy.calledOnce).to.be.true;
+
+  });
+
+  it('should delay execution when over the limit', () => {
+
+    let task1Spy = createTaskSpy(),
+        task2Spy = createTaskSpy();
+
+    let rl = new RateLimiter(1);
+
+    rl.queueTask(task1Spy);
+    rl.queueTask(task2Spy);
+
+    expect(task1Spy.called).to.be.true;
+    expect(task2Spy.notCalled).to.be.true;
+
+    clock.tick(1000);
+    expect(task2Spy.called).to.be.true;
+
+  });
+
+});


### PR DESCRIPTION
This rate limits the number of ASG API requests that are made by the scheduler since it will often eat all the available requests when it runs, especially if large numbers of ASGs are scheduled at the same time. This is causing problems for other apps like EM, and means scheduling runs need longer due to retries.

This also breaks EC2 API calls down into individual calls so that failure to switch on/off a particular instance will not stop the scheduler from acting on other instances.