### PR TITLE
Fix validation of load balancer settings and upstreams

### DIFF
--- a/server/api/controllers/config/lb-settings/lbSettingsController.js
+++ b/server/api/controllers/config/lb-settings/lbSettingsController.js
@@ -47,7 +47,6 @@ function postLBSettingsConfig(req, res, next) {
   const user = req.user;
 
   co(function* () {
-    let environmentName = body.EnvironmentName;
     let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
     return dynamoHelper.createWithSortKey(environmentName, vHostName, { Value: body.Value }, user, { accountName });
   }).then(_ => res.status(201).end()).catch(next);

--- a/server/api/controllers/config/upstreams/upstreamsConfigController.js
+++ b/server/api/controllers/config/upstreams/upstreamsConfigController.js
@@ -1,4 +1,5 @@
 /* Copyright (c) Trainline Limited, 2016. All rights reserved. See LICENSE.txt in the project root for license information. */
+
 'use strict';
 
 const RESOURCE = 'config/lbupstream';
@@ -42,14 +43,14 @@ function postUpstreamsConfig(req, res, next) {
  */
 function putUpstreamConfigByName(req, res, next) {
   let body = req.swagger.params.body.value;
-  let key = req.swagger.params.name.value
+  let key = req.swagger.params.name.value;
   let expectedVersion = req.swagger.params['expected-version'].value;
   let user = req.user;
   let environmentName = body.EnvironmentName;
 
   co(function* () {
     let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
-    return dynamoHelper.update(key, { Value: body }, expectedVersion, user, { accountName })
+    return dynamoHelper.update(key, { Value: body }, expectedVersion, user, { accountName });
   }).then(data => res.json(data)).catch(next);
 }
 
@@ -57,7 +58,7 @@ function putUpstreamConfigByName(req, res, next) {
  * DELETE /config/upstreams/{name}
  */
 function deleteUpstreamConfigByName(req, res, next) {
-  let key = req.swagger.params.name.value
+  let key = req.swagger.params.name.value;
   let user = req.user;
   let accountName = req.swagger.params.account.value;
   return dynamoHelper.delete(key, user, { accountName }).then(data => res.json(data)).catch(next);
@@ -68,5 +69,5 @@ module.exports = {
   getUpstreamConfigByName,
   postUpstreamsConfig,
   putUpstreamConfigByName,
-  deleteUpstreamConfigByName
+  deleteUpstreamConfigByName,
 };

--- a/server/api/swagger.yaml
+++ b/server/api/swagger.yaml
@@ -133,7 +133,7 @@ paths:
     x-swagger-router-controller: asgController
     get:
       operationId: getAsgIps
-      summary: Get IPs associated with an ASG under the given account.
+      summary: Get IPs associated with an ASG in the given environment.
       tags:
         - ASG
       parameters:
@@ -199,7 +199,7 @@ paths:
     x-swagger-router-controller: asgController
     put:
       operationId: putAsgSize
-      summary: Resize an ASG under the given account.
+      summary: Resize an ASG in the given environment.
       tags:
         - ASG
       x-authorizer: asgs
@@ -233,7 +233,7 @@ paths:
     x-swagger-router-controller: asgController
     get:
       operationId: getAsgLaunchConfig
-      summary: Get the launch config associated with an ASG under the given account.
+      summary: Get the launch config associated with an ASG in the given environment.
       tags:
         - ASG
       x-authorizer: asgs  
@@ -253,7 +253,7 @@ paths:
             $ref: '#/definitions/AWSLaunchConfig'
     put:
       operationId: putAsgLaunchConfig
-      summary: Update the launch config associated with an ASG under the given account.
+      summary: Update the launch config associated with an ASG in the given environment.
       tags:
         - ASG
       x-authorizer: asgs

--- a/server/api/swagger.yaml
+++ b/server/api/swagger.yaml
@@ -2687,8 +2687,8 @@ definitions:
   UpstreamConfig:
     type: object
     required:
-      - AccountName
       - key
+      - Value
     properties:
       AccountName:
         type: string
@@ -2698,6 +2698,8 @@ definitions:
         $ref: '#/definitions/UpstreamConfigValue'
   UpstreamConfigValue:
     type: object
+    required:
+      - EnvironmentName
     properties:
       EnvironmentName:
         type: string

--- a/server/api/swagger.yaml
+++ b/server/api/swagger.yaml
@@ -2606,7 +2606,6 @@ definitions:
   LBSetting:
     type: object
     required:
-      - AccountName
       - EnvironmentName
       - VHostName
       - Value


### PR DESCRIPTION
Remove validation constraints that prevent creation and modification of load balancer settings and upstreams.

- Make AccountName optional for /config/lb-settings
- Make AccountName optional for /config/upstreams
- Update API documentation for routes that were parameterised by account but are now parameterised by environment