### PR TITLE
Fix: property of argument to SetLaunchConfiguration should be 'data', not 'value'

### DIFF
--- a/server/api/controllers/asgs/asgController.js
+++ b/server/api/controllers/asgs/asgController.js
@@ -190,12 +190,12 @@ function putAsgSize(req, res, next) {
  */
 function putAsgLaunchConfig(req, res, next) {
   const environmentName = req.swagger.params.environment.value;
-  const value = req.swagger.params.body.value;
+  const data = req.swagger.params.body.value;
   const autoScalingGroupName = req.swagger.params.name.value;
 
   return co(function* () {
     let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
-    SetLaunchConfiguration({ accountName, autoScalingGroupName, value }).then(data => res.json(data)).catch(next);
+    SetLaunchConfiguration({ accountName, autoScalingGroupName, data }).then(res.json.bind(res)).catch(next);
   });
 }
 


### PR DESCRIPTION
Fix for bug introduced [here](https://github.com/trainline/environment-manager/compare/7075d438b9b658884f812ef358fd11e78809e6e4...5839c6a347d7c09f574e5daa284f6d57238ccfe2#diff-2a443044f4c246ce221a85ac00e15570L198) by renaming `data` to `value` in order to avoid shadowing the name `data`.

This bug results in requests to the `/asgs/{asg name}/launch-config?environment={environment name}` API receiving the following response:
```
{"error": "Expected \"command.data\" not to be undefined"}
```