### PR TITLE
Post environment type to /config/environment-types

### DIFF
--- a/client/app/configuration/environment-types/EnvironmentTypeController.js
+++ b/client/app/configuration/environment-types/EnvironmentTypeController.js
@@ -88,7 +88,7 @@ angular.module('EnvironmentManager.configuration').controller('EnvironmentTypeCo
       } else {
         promise = $http({
           method: 'post',
-          url: '/api/v1/config/clusters',
+          url: '/api/v1/config/environment-types',
           data: {
             EnvironmentType: environmentTypeName,
             Value: value


### PR DESCRIPTION
This PR fixes a bug introduced [here](https://github.com/trainline/environment-manager/compare/trainline:73acc41...trainline:3c8bdd0#diff-29faf2982f8fb8ee9ba20bb9abd59ddcR90) which caused a new environment type to be posted to `config/clusters` instead of `config/environment-types`.