### PR TITLE
Fix: Ignore non em services

### DIFF
--- a/server/modules/service-discovery/consul/consulCatalog.js
+++ b/server/modules/service-discovery/consul/consulCatalog.js
@@ -42,7 +42,7 @@ function getNode(environment, nodeName) {
   return executeConsul(environment, clientInstance => clientInstance.catalog.node.services(nodeName))
     .then((nodes) => {
       if (!nodes || !nodes.Services) {
-        return null;
+        return nodes;
       } else {
         // Filter out services that were not installed via environment manager
         nodes.Services = _.filter(nodes.Services,

--- a/server/modules/service-discovery/consul/consulCatalog.js
+++ b/server/modules/service-discovery/consul/consulCatalog.js
@@ -39,7 +39,17 @@ function getAllNodes(environment) {
 
 function getNode(environment, nodeName) {
   assert(nodeName, 'nodeName is required');
-  return executeConsul(environment, clientInstance => clientInstance.catalog.node.services(nodeName));
+  return executeConsul(environment, clientInstance => clientInstance.catalog.node.services(nodeName))
+    .then((nodes) => {
+      if (!nodes || !nodes.Services) {
+        return null;
+      } else {
+        // Filter out services that were not installed via environment manager
+        nodes.Services = _.filter(nodes.Services,
+          service => service.Tags && service.Tags.find(tag => tag.startsWith('deployment_id')));
+        return nodes;
+      }
+    });
 }
 
 function getNodeHealth(environment, nodeName) {

--- a/server/test/modules/service-reporter/consul/consulCatalogTest.js
+++ b/server/test/modules/service-reporter/consul/consulCatalogTest.js
@@ -11,10 +11,39 @@ describe('consulCatalog', function() {
   let sut;
   let consulClient;
   let consul;
-  
+
+  const NODES = {
+    Node: {
+      Node: 'valid-and-invalid-services-node'
+    },
+    Services: {
+      'valid-service': {
+        Service:'a-valid-service',
+        Tags: [
+          'name:service-name',
+          'deployment_id:abc123'
+        ]
+      },
+      'invalid-service-no-deployment-id': {
+        Service:'invalid-service-1',
+        Tags: [
+          'name:service-name'
+        ]
+      },
+      'invalid-service-no-tags': {
+        Service:'invalid-service-2'
+      }
+    }
+  };
+
   beforeEach(() => {
     consul = {
-      catalog: { service: { list: sinon.stub().returns(require('./catalog-data.json')) }}
+      catalog: {
+        service: { list: sinon.stub().returns(require('./catalog-data.json')) },
+        node: {
+          services: sinon.stub().returns(NODES)
+        }
+      }
     };
     
     consulClient = {
@@ -36,4 +65,13 @@ describe('consulCatalog', function() {
       });
     });
   });
+
+  describe('getNode', function() {
+    it('filters out services with no tags or no deployment ID', () => {
+      return sut.getNode('environment', 'nodeName').then(nodes => {
+        assert.equal(nodes.Services.length, 1);
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
Service discovery results from Consul can include infrastructure services that were not installed via Environment Manager - we should not include these in any service lists. See the last service in the image below for an example:

![selection_028](https://cloud.githubusercontent.com/assets/1502359/21993774/764f3f86-dc14-11e6-9835-785a82f4b1cc.png)


This fix filters service discovery results to only include services that have a `Tags` object containing a `deployment_id` field.