### PR TITLE
Fix filter by owning cluster on the compare services page

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
     "vars-on-top": 'off',
     "no-plusplus": 'off',
     "no-param-reassign": ['error', { props: false }],
-    "no-use-before-define": 'off'
+    "no-use-before-define": 'off',
+    "no-warning-comments": 1
   },
 };

--- a/client/app/app.module.js
+++ b/client/app/app.module.js
@@ -39,9 +39,6 @@ app.config(function ($httpProvider, $locationProvider, $qProvider) {
   // Set default put request content type to JSON
   $httpProvider.defaults.headers.put['Content-Type'] = 'application/json;charset=utf-8';
 
-  // Suppress 'possibly unhandled rejection' errors
-  $qProvider.errorOnUnhandledRejections(false);
-
   // Set up error pop up on HTTP errors
   $httpProvider.interceptors.push(function ($q, $rootScope) {
     return {

--- a/client/app/app.module.js
+++ b/client/app/app.module.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -61,3 +63,4 @@ app.run(function ($rootScope, $timeout) {
     $rootScope.$broadcast('cookie-expired');
   }, (window.user.getExpiration() - new Date().getTime()));
 });
+

--- a/client/app/common/MainController.js
+++ b/client/app/common/MainController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -159,3 +161,4 @@ angular.module('EnvironmentManager.common').controller('MainController',
 
     init();
   });
+

--- a/client/app/common/directives/cronEditor.js
+++ b/client/app/common/directives/cronEditor.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -116,3 +118,4 @@ angular.module('EnvironmentManager.common')
       }
     };
   });
+

--- a/client/app/common/directives/jsonDiffPatchDirective.js
+++ b/client/app/common/directives/jsonDiffPatchDirective.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -49,3 +51,4 @@ angular
     }
 
   );
+

--- a/client/app/common/directives/loadingOverlay.js
+++ b/client/app/common/directives/loadingOverlay.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -15,6 +17,7 @@ angular.module('EnvironmentManager.common')
       loading.registerLoadingOverlay(vm);
     }
   });
+
 
 
 

--- a/client/app/common/directives/multipleEmails.js
+++ b/client/app/common/directives/multipleEmails.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 'use strict';
 

--- a/client/app/common/directives/scalingCronEditor.js
+++ b/client/app/common/directives/scalingCronEditor.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -121,3 +123,4 @@ angular.module('EnvironmentManager.common')
       }
     };
   });
+

--- a/client/app/common/directives/scheduleViewer.js
+++ b/client/app/common/directives/scheduleViewer.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -44,3 +46,4 @@ angular.module('EnvironmentManager.common')
       update();
     }
   });
+

--- a/client/app/common/directives/spinner.js
+++ b/client/app/common/directives/spinner.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -41,3 +43,4 @@ angular.module('EnvironmentManager.common').directive('spinner', function () {
     }
   };
 });
+

--- a/client/app/common/directives/uniqueAmongDirective.js
+++ b/client/app/common/directives/uniqueAmongDirective.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -35,3 +37,4 @@ angular.module('EnvironmentManager.common').directive('uniqueAmong', function ($
     }
   };
 });
+

--- a/client/app/common/directives/validJsonDirective.js
+++ b/client/app/common/directives/validJsonDirective.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -45,3 +47,4 @@ angular.module('EnvironmentManager.common').directive('validJson', function () {
     }
   };
 });
+

--- a/client/app/common/models/AutoScalingGroup.js
+++ b/client/app/common/models/AutoScalingGroup.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -145,3 +147,4 @@ angular.module('EnvironmentManager.common').factory('AutoScalingGroup',
 
     return AutoScalingGroup;
   });
+

--- a/client/app/common/models/Deployment.js
+++ b/client/app/common/models/Deployment.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -118,3 +120,4 @@ angular.module('EnvironmentManager.common').factory('Deployment',
 
     return Deployment;
   });
+

--- a/client/app/common/models/DeploymentMap.js
+++ b/client/app/common/models/DeploymentMap.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -69,3 +71,4 @@ angular.module('EnvironmentManager.common').factory('DeploymentMap',
 
     return DeploymentMap;
   });
+

--- a/client/app/common/models/Image.js
+++ b/client/app/common/models/Image.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -28,3 +30,4 @@ angular.module('EnvironmentManager.common').factory('Image',
 
     return Image;
   });
+

--- a/client/app/common/services/accountMappingService.js
+++ b/client/app/common/services/accountMappingService.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -39,3 +41,4 @@
       }
     };
   });
+

--- a/client/app/common/services/awsService.js
+++ b/client/app/common/services/awsService.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -223,3 +225,4 @@ function groupBy(fn, array) {
     else return 0;
   }
 }
+

--- a/client/app/common/services/cachedResourcesService.js
+++ b/client/app/common/services/cachedResourcesService.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -68,3 +70,4 @@ angular.module('EnvironmentManager.common').factory('cachedResources',
 
     return cachedResources;
   });
+

--- a/client/app/common/services/cronService.js
+++ b/client/app/common/services/cronService.js
@@ -1,5 +1,8 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
 
 angular.module('EnvironmentManager.common').factory('cron', [buildCronService]);
+

--- a/client/app/common/services/environmentDeployService.js
+++ b/client/app/common/services/environmentDeployService.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -25,3 +27,4 @@ angular.module('EnvironmentManager.common').factory('environmentDeploy',
     }
   }
 );
+

--- a/client/app/common/services/loading.js
+++ b/client/app/common/services/loading.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -16,3 +18,4 @@ angular.module('EnvironmentManager.common').factory('loading',
     }
     
   });
+

--- a/client/app/common/services/modalService.js
+++ b/client/app/common/services/modalService.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -42,3 +44,4 @@ angular.module('EnvironmentManager.common').factory('modal',
       }
     };
   });
+

--- a/client/app/common/services/remoteResourceFactoryService.js
+++ b/client/app/common/services/remoteResourceFactoryService.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -127,3 +129,4 @@ angular.module('EnvironmentManager.common').factory('remoteResourceFactory',
       }
     };
   });
+

--- a/client/app/common/services/resourcesService.js
+++ b/client/app/common/services/resourcesService.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -129,3 +131,4 @@ angular.module('EnvironmentManager.common').factory('resources',
 
     return resources;
   });
+

--- a/client/app/common/services/schemaValidatorService.js
+++ b/client/app/common/services/schemaValidatorService.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -65,3 +67,4 @@ angular.module('EnvironmentManager.common')
       ].join(' ');
     }
   });
+

--- a/client/app/common/utilities.js
+++ b/client/app/common/utilities.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -13,3 +15,4 @@ Array.prototype.merge = function (targets, comparer, builder) {
     return builder(source, target);
   });
 };
+

--- a/client/app/common/utils/QuerySync.js
+++ b/client/app/common/utils/QuerySync.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -38,3 +40,4 @@ angular.module('EnvironmentManager.common').factory('QuerySync',
 
     return QuerySync;
   });
+

--- a/client/app/common/utils/QuerySync.spec.js
+++ b/client/app/common/utils/QuerySync.spec.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -60,3 +62,4 @@ describe('QuerySync', function () {
     });
   });
 });
+

--- a/client/app/compare/CompareController.js
+++ b/client/app/compare/CompareController.js
@@ -3,7 +3,8 @@
 'use strict';
 
 angular.module('EnvironmentManager.compare').controller('CompareController',
-  function ($scope, $routeParams, serviceComparison, $location, $q, $uibModal, resources, cachedResources, comparableResources, ResourceComparison, accountMappingService) {
+  function ($scope, $routeParams, serviceComparison, $location, $q, $uibModal,
+  resources, cachedResources, comparableResources, ResourceComparison, $log) {
     var vm = this;
     var SHOW_ALL_OPTION = 'Any';
     var services;

--- a/client/app/compare/CompareController.js
+++ b/client/app/compare/CompareController.js
@@ -122,3 +122,4 @@ angular.module('EnvironmentManager.compare').controller('CompareController',
 
     init();
   });
+

--- a/client/app/compare/directives/serviceCell.js
+++ b/client/app/compare/directives/serviceCell.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -38,3 +40,4 @@ angular.module('EnvironmentManager.compare').component('serviceCell', {
     this.popoverHtml = $sce.trustAsHtml(html);
   }
 });
+

--- a/client/app/compare/services/ResourceComparison.js
+++ b/client/app/compare/services/ResourceComparison.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -128,3 +130,4 @@ angular.module('EnvironmentManager.compare').factory('ResourceComparison',
     };
   }
 );
+

--- a/client/app/compare/services/ResourceComparison.spec.js
+++ b/client/app/compare/services/ResourceComparison.spec.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -84,3 +86,4 @@ describe('comparing resources', function () {
     expect(difference.class).toBe('different showable');
   });
 });
+

--- a/client/app/compare/services/comparableResources.js
+++ b/client/app/compare/services/comparableResources.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -172,3 +174,4 @@ angular.module('EnvironmentManager.compare').factory('comparableResources',
       }
     },];
   });
+

--- a/client/app/compare/services/serviceComparison.js
+++ b/client/app/compare/services/serviceComparison.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -58,3 +60,4 @@ angular.module('EnvironmentManager.compare').factory('serviceComparison',
     };
   }
 );
+

--- a/client/app/configuration/accounts/AccountsController.js
+++ b/client/app/configuration/accounts/AccountsController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -70,3 +72,4 @@ angular.module('EnvironmentManager.configuration').controller('AccountsControlle
 
     vm.loadData();
   });
+

--- a/client/app/configuration/audit/AuditCompareModalController.js
+++ b/client/app/configuration/audit/AuditCompareModalController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -11,3 +13,4 @@ var app = angular.module('EnvironmentManager.configuration').controller('AuditCo
       $uibModalInstance.dismiss('cancel');
     };
   });
+

--- a/client/app/configuration/audit/AuditController.js
+++ b/client/app/configuration/audit/AuditController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -220,3 +222,4 @@ angular.module('EnvironmentManager.configuration').controller('AuditController',
 
     init();
   });
+

--- a/client/app/configuration/clusters/ClusterController.js
+++ b/client/app/configuration/clusters/ClusterController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -96,3 +98,4 @@ angular.module('EnvironmentManager.configuration').controller('ClusterController
 
     init();
   });
+

--- a/client/app/configuration/clusters/ClustersController.js
+++ b/client/app/configuration/clusters/ClustersController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -57,3 +59,4 @@ angular.module('EnvironmentManager.configuration').controller('ClustersControlle
 
     init();
   });
+

--- a/client/app/configuration/deployment-maps/DeploymentMapController.js
+++ b/client/app/configuration/deployment-maps/DeploymentMapController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -222,3 +224,4 @@ angular.module('EnvironmentManager.configuration').controller('DeploymentMapCont
 
     init();
   });
+

--- a/client/app/configuration/deployment-maps/DeploymentMapCreateController.js
+++ b/client/app/configuration/deployment-maps/DeploymentMapCreateController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -43,3 +45,4 @@ angular.module('EnvironmentManager.configuration').controller('DeploymentMapCrea
 
     init();
   });
+

--- a/client/app/configuration/deployment-maps/DeploymentMapTargetController.js
+++ b/client/app/configuration/deployment-maps/DeploymentMapTargetController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -305,3 +307,4 @@ angular.module('EnvironmentManager.configuration').controller('DeploymentMapTarg
 
     init();
   });
+

--- a/client/app/configuration/deployment-maps/DeploymentMapsController.js
+++ b/client/app/configuration/deployment-maps/DeploymentMapsController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -100,3 +102,4 @@ angular.module('EnvironmentManager.configuration').controller('DeploymentMapsCon
 
     init();
   });
+

--- a/client/app/configuration/deployment-maps/copyServerRole.js
+++ b/client/app/configuration/deployment-maps/copyServerRole.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -76,3 +78,4 @@ angular.module('EnvironmentManager.configuration').component('copyServerRole', {
     }
   }
 });
+

--- a/client/app/configuration/em-services/ServiceController.js
+++ b/client/app/configuration/em-services/ServiceController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -113,3 +115,4 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
 
     init();
   });
+

--- a/client/app/configuration/em-services/ServicesController.js
+++ b/client/app/configuration/em-services/ServicesController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -112,3 +114,4 @@ angular.module('EnvironmentManager.configuration').controller('ServicesControlle
 
     init();
   });
+

--- a/client/app/configuration/environment-types/EnvironmentTypeController.js
+++ b/client/app/configuration/environment-types/EnvironmentTypeController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -146,3 +148,4 @@ angular.module('EnvironmentManager.configuration').controller('EnvironmentTypeCo
 
     init();
   });
+

--- a/client/app/configuration/environment-types/EnvironmentTypesController.js
+++ b/client/app/configuration/environment-types/EnvironmentTypesController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -61,4 +63,5 @@ angular.module('EnvironmentManager.configuration').controller('EnvironmentTypesC
 
     init();
   });
+
 

--- a/client/app/configuration/export/ExportController.js
+++ b/client/app/configuration/export/ExportController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -67,3 +69,4 @@ angular.module('EnvironmentManager.configuration').controller('ExportController'
 
     init();
   });
+

--- a/client/app/configuration/import/ImportController.js
+++ b/client/app/configuration/import/ImportController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -87,3 +89,4 @@ angular.module('EnvironmentManager.configuration')
 
     init();
   });
+

--- a/client/app/configuration/load-balancers/LBCloneController.js
+++ b/client/app/configuration/load-balancers/LBCloneController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -36,3 +38,4 @@ var app = angular.module('EnvironmentManager.configuration').controller('LBClone
 
     init();
   });
+

--- a/client/app/configuration/load-balancers/LBController.js
+++ b/client/app/configuration/load-balancers/LBController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -271,3 +273,4 @@ angular.module('EnvironmentManager.configuration').controller('LBController',
     });
     init();
   });
+

--- a/client/app/configuration/load-balancers/LBUpstreamController.js
+++ b/client/app/configuration/load-balancers/LBUpstreamController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -184,3 +186,4 @@ angular.module('EnvironmentManager.configuration').controller('LBUpstreamControl
 
     init();
   });
+

--- a/client/app/configuration/load-balancers/LBUpstreamsController.js
+++ b/client/app/configuration/load-balancers/LBUpstreamsController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -145,3 +147,4 @@ angular.module('EnvironmentManager.configuration').controller('LBUpstreamsContro
 
     init();
   });
+

--- a/client/app/configuration/load-balancers/LBsController.js
+++ b/client/app/configuration/load-balancers/LBsController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -239,4 +241,5 @@ angular.module('EnvironmentManager.configuration').controller('LBsController',
 
     init();
   });
+
 

--- a/client/app/configuration/notification-settings/notificationSettingsEntry.js
+++ b/client/app/configuration/notification-settings/notificationSettingsEntry.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 'use strict';
 

--- a/client/app/configuration/notification-settings/notificationSettingsList.js
+++ b/client/app/configuration/notification-settings/notificationSettingsList.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 'use strict';
 

--- a/client/app/configuration/permissions/PermissionController.js
+++ b/client/app/configuration/permissions/PermissionController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -72,3 +74,4 @@ angular.module('EnvironmentManager.configuration').controller('PermissionControl
 
     init();
   });
+

--- a/client/app/configuration/permissions/PermissionsController.js
+++ b/client/app/configuration/permissions/PermissionsController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -61,4 +63,5 @@ angular.module('EnvironmentManager.configuration').controller('PermissionsContro
 
     init();
   });
+
 

--- a/client/app/configuration/pick-ami/PickAmiController.js
+++ b/client/app/configuration/pick-ami/PickAmiController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 angular.module('EnvironmentManager.configuration').controller('PickAmiController',
   function ($scope, $uibModalInstance, awsService, currentAmi, context) {
     var vm = this;
@@ -114,3 +116,4 @@ angular.module('EnvironmentManager.configuration').controller('PickAmiController
 
     init();
   });
+

--- a/client/app/configuration/services/arrayItemHashDetectorService.js
+++ b/client/app/configuration/services/arrayItemHashDetectorService.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -71,3 +73,4 @@ angular
         }
       };
     });
+

--- a/client/app/configuration/services/deploymentMapConverter.js
+++ b/client/app/configuration/services/deploymentMapConverter.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -101,3 +103,4 @@ angular.module('EnvironmentManager.configuration').factory('deploymentMapConvert
       }
     };
   });
+

--- a/client/app/configuration/services/lbBulkOperationService.js
+++ b/client/app/configuration/services/lbBulkOperationService.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -39,3 +41,4 @@ angular.module('EnvironmentManager.configuration').factory('lbBulkOperationServi
 
     return new LoadBalancerBulkOperationService();
   });
+

--- a/client/app/configuration/services/permissionsValidationService.js
+++ b/client/app/configuration/services/permissionsValidationService.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -67,3 +69,4 @@ angular.module('EnvironmentManager.configuration').factory('permissionsValidatio
       if (errors.length > 0) return errors;
     };
   });
+

--- a/client/app/configuration/services/permissionsValidationService.spec.js
+++ b/client/app/configuration/services/permissionsValidationService.spec.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -157,3 +159,4 @@ describe('permissions validation', function () {
     expect(errors).toContain('EnvironmentTypes attribute on permission 1 must be a javascript array or "all"');
   });
 });
+

--- a/client/app/environments/dialogs/ASGDetailsModalController.js
+++ b/client/app/environments/dialogs/ASGDetailsModalController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -371,3 +373,4 @@ angular.module('EnvironmentManager.environments').controller('ASGDetailsModalCon
 
     init();
   });
+

--- a/client/app/environments/dialogs/CreateEnvironmentController.js
+++ b/client/app/environments/dialogs/CreateEnvironmentController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -100,3 +102,4 @@ angular.module('EnvironmentManager.environments').controller('CreateEnvironmentC
 
     init();
   });
+

--- a/client/app/environments/dialogs/DeployModalController.js
+++ b/client/app/environments/dialogs/DeployModalController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -165,3 +167,4 @@ angular.module('EnvironmentManager.environments').controller('DeployModalControl
 
     init();
   });
+

--- a/client/app/environments/dialogs/asg/asgDistribution.js
+++ b/client/app/environments/dialogs/asg/asgDistribution.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -38,3 +40,4 @@ angular.module('EnvironmentManager.environments').factory('asgDistributionServic
     calcDistribution: calcDistribution
   };
 });
+

--- a/client/app/environments/dialogs/asg/asgSingleService.js
+++ b/client/app/environments/dialogs/asg/asgSingleService.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -31,3 +33,4 @@ angular.module('EnvironmentManager.environments').component('asgSingleService', 
     };
   }
 });
+

--- a/client/app/environments/directives/currentDesiredTitle.js
+++ b/client/app/environments/directives/currentDesiredTitle.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -21,3 +23,4 @@ angular.module('EnvironmentManager.environments')
       }
     };
   });
+

--- a/client/app/environments/directives/healthChecks.js
+++ b/client/app/environments/directives/healthChecks.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -15,3 +17,4 @@ angular.module('EnvironmentManager.environments')
       }
     };
   });
+

--- a/client/app/environments/schedule/ManageEnvironmentScheduleController.js
+++ b/client/app/environments/schedule/ManageEnvironmentScheduleController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -130,3 +132,4 @@ angular.module('EnvironmentManager.environments').controller('ManageEnvironmentS
 
     init();
   });
+

--- a/client/app/environments/servers/ManageEnvironmentServersController.js
+++ b/client/app/environments/servers/ManageEnvironmentServersController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -149,3 +151,4 @@ angular.module('EnvironmentManager.environments')
 
       init();
     });
+

--- a/client/app/environments/servers/serversView.js
+++ b/client/app/environments/servers/serversView.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -143,3 +145,4 @@ angular.module('EnvironmentManager.environments').factory('serversView',
 
     return serversView;
   });
+

--- a/client/app/environments/settings/ManageEnvironmentSettingsController.js
+++ b/client/app/environments/settings/ManageEnvironmentSettingsController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -212,3 +214,4 @@ angular.module('EnvironmentManager.environments').controller('ManageEnvironmentS
 
     init();
   });
+

--- a/client/app/environments/summary/EnvironmentsSummaryController.js
+++ b/client/app/environments/summary/EnvironmentsSummaryController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -132,3 +134,4 @@ angular.module('EnvironmentManager.environments').controller('EnvironmentsSummar
 
     init();
   });
+

--- a/client/app/operations/amis/OpsAMIsController.js
+++ b/client/app/operations/amis/OpsAMIsController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -144,3 +146,4 @@ angular.module('EnvironmentManager.operations').controller('OpsAMIsController',
 
     init();
   });
+

--- a/client/app/operations/deployments/DeploymentDetailsModalController.js
+++ b/client/app/operations/deployments/DeploymentDetailsModalController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -188,3 +190,4 @@ angular.module('EnvironmentManager.operations')
 
     init();
   });
+

--- a/client/app/operations/deployments/OpsDeploymentsController.js
+++ b/client/app/operations/deployments/OpsDeploymentsController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -160,3 +162,4 @@ angular.module('EnvironmentManager.operations').controller('OpsDeploymentsContro
 
     init();
   });
+

--- a/client/app/operations/deployments/opsDeploymentsList.js
+++ b/client/app/operations/deployments/opsDeploymentsList.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -38,3 +40,4 @@ angular.module('EnvironmentManager.operations').component('opsDeploymentsList', 
     });
   }
 });
+

--- a/client/app/operations/maintenance/MainteinanceAddServerModalController.js
+++ b/client/app/operations/maintenance/MainteinanceAddServerModalController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -74,3 +76,4 @@ angular.module('EnvironmentManager.operations').controller('MaintenanceAddServer
 
     init();
   });
+

--- a/client/app/operations/maintenance/OpsMaintenanceController.js
+++ b/client/app/operations/maintenance/OpsMaintenanceController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -196,3 +198,4 @@ angular.module('EnvironmentManager.operations').controller('OpsMaintenanceContro
 
     init();
   });
+

--- a/client/app/operations/upstream/OpsUpstreamController.js
+++ b/client/app/operations/upstream/OpsUpstreamController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -298,3 +300,4 @@ angular.module('EnvironmentManager.operations').controller('OpsUpstreamControlle
 
     init();
   });
+

--- a/client/app/operations/upstream/UpstreamDetailsModalController.js
+++ b/client/app/operations/upstream/UpstreamDetailsModalController.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -114,3 +116,4 @@ angular.module('EnvironmentManager.operations').controller('UpstreamDetailsModal
 
     init();
   });
+

--- a/client/app/operations/upstream/directives/lbServersStatesCell.js
+++ b/client/app/operations/upstream/directives/lbServersStatesCell.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -56,3 +58,4 @@ angular.module('EnvironmentManager.operations').component('lbServersStatesCell',
     this.popoverHtml = $sce.trustAsHtml(html);
   }
 });
+

--- a/client/gulp/build.js
+++ b/client/gulp/build.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -96,3 +98,4 @@ gulp.task('clean', function () {
 });
 
 gulp.task('build', ['html', 'other']);
+

--- a/client/gulp/conf.js
+++ b/client/gulp/conf.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /**
  *  This file contains the variables used in other gulp files
  *  which defines tasks
@@ -52,3 +54,4 @@ module.exports = {
     return argv.p !== undefined;
   }
 };
+

--- a/client/gulp/scripts.js
+++ b/client/gulp/scripts.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -26,3 +28,4 @@ function buildScripts() {
     .pipe($.eslint.format())
     .pipe($.size());
 }
+

--- a/client/gulp/server.js
+++ b/client/gulp/server.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -63,3 +65,4 @@ gulp.task('serve:e2e', ['inject'], function () {
 gulp.task('serve:e2e-dist', ['build'], function () {
   browserSyncInit(conf.paths.dist, []);
 });
+

--- a/client/gulp/styles.js
+++ b/client/gulp/styles.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -46,3 +48,4 @@ function buildStyles() {
     .pipe(gulp.dest('./styles/'));
     // .pipe(gulp.dest(path.join(conf.paths.tmp, '/serve/app/')));
 }
+

--- a/client/gulp/unit-tests.js
+++ b/client/gulp/unit-tests.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -40,3 +42,4 @@ gulp.task('test', [], function (done) {
 gulp.task('test:auto', ['watch'], function (done) {
   runTests(false, done);
 });
+

--- a/client/gulp/watch.js
+++ b/client/gulp/watch.js
@@ -1,3 +1,5 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
 
 'use strict';
@@ -39,3 +41,4 @@ gulp.task('watch', ['inject'], function () {
     browserSync.reload(event.path);
   });
 });
+

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "gulp test",
     "test-ci": "gulp test -c",
-    "lint": "eslint app/ gulp/ --ext .js",
+    "lint": "eslint app/ gulp/ --ext .js --max-warnings 92",
     "lint-fix": "eslint app/ gulp/ --ext .js --fix"
   },
   "devDependencies": {


### PR DESCRIPTION
The root cause is the presence of a service in one of the environments being compared that is absent from the set of defined services (it has been deployed to an environment and its definition subsequently deleted). This causes $log.warn to be dereferenced at [this line](https://github.com/trainline/environment-manager/blob/5286e92a71e02afb5b99680a272bb5d928c4d425/client/app/compare/CompareController.js#L111). The resulting promise rejection is unhandled but this is not reported because it is explicitly suppressed [here](https://github.com/trainline/environment-manager/blob/5286e92a71e02afb5b99680a272bb5d928c4d425/client/app/app.module.js#L43)

This fix contains the following changes:
- Remove suppression of unhandled promise rejections.
- Enable ESLint rules that identify the undefined `$log` variable.
- Disable ESLint for all other files with errors, raising a warning that notifies ESLint is disabled.
- Pass `$log` into the constructor of `CompareController.js`

[Trello ticket](https://trello.com/c/xTsSOntc/688-filtering-broken-on-compare-service-versions-across-environments-page)