### PR TITLE
Fix deployment instances tab

### DIFF
--- a/client/app/operations/deployments/OpsDeploymentsController.js
+++ b/client/app/operations/deployments/OpsDeploymentsController.js
@@ -150,6 +150,9 @@ angular.module('EnvironmentManager.operations').controller('OpsDeploymentsContro
       if (vm.selectedStatus !== 'Any' && instance.DeploymentStatus !== vm.selectedStatus) {
         return false;
       }
+      if (instance.Services.length === 0) {
+        return true;
+      }
       return _.some(_.map(instance.Services, function (s) { return s.Name.toLowerCase(); }), function (name) { return name.indexOf(vm.serviceName.toLowerCase()) >= 0; });
     };
 

--- a/client/app/operations/deployments/opsDeploymentsInstances.html
+++ b/client/app/operations/deployments/opsDeploymentsInstances.html
@@ -26,8 +26,8 @@
       <tbody>
         <tr ng-repeat="instance in vm.instances | filter: vm.instancesFilter() | orderBy: '-timestamp'">
           <td>
-            <span am-time-ago="instance.LaunchTime"></span><br />
-            <small>{{instance.LaunchTime | amDateFormat:'DD/MM/YYYY HH:mm:ss'}}</small>
+            <span am-time-ago="instance.CreationTime"></span><br />
+            <small>{{instance.CreationTime | amDateFormat:'DD/MM/YYYY HH:mm:ss'}}</small>
           </td>
           <td>
             <health-status status='instance.OverallHealth' title='{{ instance.hoverTitle }}'></health-status> {{ instance.Name || '-'}} <small>({{ instance.InstanceId || '-'}})</small>

--- a/server/api/controllers/instances/instancesController.js
+++ b/server/api/controllers/instances/instancesController.js
@@ -51,10 +51,6 @@ function getInstances(req, res, next) {
     if (instanceId !== undefined) {
       filter['instance-id'] = instanceId;
     }
-    // TODO(Filip): consider adding filter on launch-time for improved performance
-    // if (since !== undefined) {
-    //   filter['launch-time'] = Instance.createLaunchTimeArraySince(since);
-    // }
 
     if (_.isEmpty(filter)) {
       filter = null;
@@ -66,7 +62,12 @@ function getInstances(req, res, next) {
     // Note: be wary of performance - this filters instances AFTER fetching all from AWS
     if (since !== undefined) {
       let sinceDate = new Date(since);
-      list = _.filter(list, instance => sinceDate.getTime() < new Date(instance.LaunchTime).getTime());
+      list = _.filter(list, (instance) => {
+        if (instance.CreationTime === undefined) {
+          return true;
+        }
+        return sinceDate.getTime() < new Date(instance.CreationTime).getTime();
+      });
     }
 
     if (includeDeploymentsStatus === true) {

--- a/server/models/Instance.js
+++ b/server/models/Instance.js
@@ -16,6 +16,7 @@ class Instance {
 
   constructor(data) {
     _.assign(this, data);
+    this.CreationTime = this.getCreationTime();
   }
 
   getAutoScalingGroupName() {
@@ -32,6 +33,10 @@ class Instance {
 
       return client.setTag(parameters);
     });
+  }
+
+  getCreationTime() {
+    return _.get(this, 'BlockDeviceMappings[0].Ebs.AttachTime');
   }
 
   static getById(instanceId) {


### PR DESCRIPTION
.LaunchTime doesn't indicate instance creation time, so we're using block device AttachTime instead to find out when the instance was created.