### PR TITLE
Avoid logging authorization tokens

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,9 @@
     "name": "Platform Development",
     "email": "platform.development@thetrainline.com"
   },
+  "config": {
+    "git-tag-version": false
+  },
   "scripts": {
     "test": "gulp test",
     "test-ci": "gulp test -c",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,12 @@
   "name": "environment-manager",
   "version": "3.25.0",
   "description": "Build wrapper for Environment Manager server and client components",
+  "config": {
+    "git-tag-version": true
+  },
   "scripts": {
-    "build": "gulp build --gulpfile server/gulpfile.js -p -o ../build && gulp build --gulpfile client/gulpfile.js -p -o ../build/dist"
+    "build": "gulp build --gulpfile server/gulpfile.js -p -o ../build && gulp build --gulpfile client/gulpfile.js -p -o ../build/dist",
+    "version": "node version.js"
   },
   "repository": {
     "type": "git",

--- a/server/modules/MainServer.js
+++ b/server/modules/MainServer.js
@@ -7,6 +7,7 @@ let bodyParser = require('body-parser');
 let cookieParser = require('cookie-parser');
 let logger = require('modules/logger');
 let winston = require('winston');
+let fp = require('lodash/fp');
 let fs = require('fs');
 let config = require('config/');
 let compression = require('compression');
@@ -20,6 +21,19 @@ let deploymentMonitorScheduler = require('modules/monitoring/DeploymentMonitorSc
 let apiV1 = require('api/v1');
 
 const APP_VERSION = require('config').get('APP_VERSION');
+
+function requestFilter(req, propName) {
+  // Avoid writing the authorization token to the log.
+  if (propName === 'headers') {
+    return fp.omit(['authorization'])(req[propName]);
+  }
+  return req[propName];
+}
+
+let expressWinstonOptions = {
+  requestFilter,
+  winstonInstance: logger
+};
 
 module.exports = function MainServer() {
   let httpServerFactory = require('modules/http-server-factory');
@@ -58,7 +72,7 @@ module.exports = function MainServer() {
       /* notice how the router goes after the logger.
        * https://www.npmjs.com/package/express-winston#request-logging */
       if (config.get('IS_PRODUCTION') === true) {
-        app.use(expressWinston.logger({ winstonInstance: logger }));
+        app.use(expressWinston.logger(expressWinstonOptions));
       }
 
       const PUBLIC_DIR = config.get('PUBLIC_DIR');
@@ -85,7 +99,7 @@ module.exports = function MainServer() {
       app.use('/api', routeInstaller());
 
       if (config.get('IS_PRODUCTION') === true) {
-        app.use(expressWinston.errorLogger({ winstonInstance: logger }));
+        app.use(expressWinston.errorLogger(expressWinstonOptions));
       }
 
       apiV1.setup(app);

--- a/server/package.json
+++ b/server/package.json
@@ -7,6 +7,9 @@
     "url": "https://github.com/trainline/environment-manager/issues",
     "email": "platform.development@thetrainline.com"
   },
+  "config": {
+    "git-tag-version": false
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/trainline/environment-manager.git"

--- a/version.js
+++ b/version.js
@@ -1,0 +1,18 @@
+'use strict'
+
+let childProcess = require('child_process');
+let path = require('path');
+let process = require('process');
+
+let version = process.env['npm_package_version'];
+
+function versionPackage(rootDirectory) {
+    return childProcess.execSync(`npm version "${version}" && git add -A`, {
+        cwd: rootDirectory,
+        env: process.env
+    })
+}
+
+['client', 'server']
+    .map(relDir => path.resolve(process.cwd(), relDir))
+    .forEach(versionPackage);


### PR DESCRIPTION
A user with access to the application log can view the bearer tokens used to authenticate requests with Environment Manager. This allows them to authenticate themselves with environment manager using the token and assume the identity of the owner of the token.

This fix excludes the `authorization` HTTP header from the request headers written to the application log.