### PR TITLE
Fix Incorrect Reports of AMI age

### DIFF
--- a/client/app/common/services/awsService.js
+++ b/client/app/common/services/awsService.js
@@ -84,7 +84,7 @@ angular.module('EnvironmentManager.common').factory('awsService',
             if (latestStableVersion) {
               instance.LatestAmi = angular.copy(latestStableVersion);
               instance.UsingLatestAmi = (instance.Ami.AmiVersion == latestStableVersion.AmiVersion);
-              instance.DaysOutOfDate = new Date().getDaysBetweenDates(instance.Ami.CreationDate);
+              instance.DaysBehindLatest = instance.Ami.DaysBehindLatest;
             }
           }
 

--- a/client/app/environments/dialogs/asg/asgInstances.html
+++ b/client/app/environments/dialogs/asg/asgInstances.html
@@ -45,7 +45,7 @@
           <td>
             <span ng-if="instance.LatestAmi">
               <span ng-if="instance.UsingLatestAmi"><span class="glyphicon glyphicon-ok-sign ok"></span> Up to date</span>
-            <span ng-if="!instance.UsingLatestAmi"><span class="glyphicon glyphicon-exclamation-sign warning"></span> {{ instance.DaysOutOfDate }} Days</span>
+            <span ng-if="!instance.UsingLatestAmi"><span class="glyphicon glyphicon-exclamation-sign warning"></span> {{ instance.DaysBehindLatest }} Days</span>
             </span>
             <span ng-if="!instance.LatestAmi">-</span>
           </td>

--- a/client/app/operations/amis/OpsAMIsController.js
+++ b/client/app/operations/amis/OpsAMIsController.js
@@ -107,10 +107,9 @@ angular.module('EnvironmentManager.operations').controller('OpsAMIsController',
       if (server.UsingLatestAmi === true) {
         return false;
       }
-      // console.log(server.DaysOutOfDate);
-      if (server.DaysOutOfDate === undefined) {
+      if (server.DaysBehindLatest === undefined) {
         return false;
-      } else if (server.DaysOutOfDate < days) {
+      } else if (server.DaysBehindLatest < days) {
         return false;
       }
       return true;

--- a/client/app/operations/amis/ops-amis.html
+++ b/client/app/operations/amis/ops-amis.html
@@ -74,7 +74,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr ng-repeat="server in vm.data | orderBy : ['DaysOutOfDate', 'Role', 'Status']">
+        <tr ng-repeat="server in vm.data | orderBy : ['DaysBehindLatest', 'Role', 'Status']">
           <td ng-if="vm.selectedOwningCluster == 'Any'">{{server.OwningCluster || '-'}}</td>
           <td>
             {{server.Name || '-'}}<br/>
@@ -106,7 +106,7 @@
             </div>
 
             <div ng-if="server.LatestAmi && !server.UsingLatestAmi">
-              <span class="glyphicon glyphicon-exclamation-sign warning"></span> {{server.DaysOutOfDate}} Days
+              <span class="glyphicon glyphicon-exclamation-sign warning"></span> {{server.DaysBehindLatest}} Days
             </div>
 
             <div ng-if="!server.LatestAmi">

--- a/server/api/swagger.yaml
+++ b/server/api/swagger.yaml
@@ -2616,6 +2616,9 @@ definitions:
         type: boolean
       AccountName:
         type: string
+      DaysBehindLatest:
+        type: integer
+        minimum: 0
   Instance:
     type: object
     properties:

--- a/server/queryHandlers/ScanServersStatus.js
+++ b/server/queryHandlers/ScanServersStatus.js
@@ -139,7 +139,7 @@ function getAmi(instances) {
 
   return {
     Name: ami.name,
-    Age: moment.utc().diff(moment(ami.created), 'days'),
+    Age: ami.DaysBehindLatest,
     IsLatestStable: ami.isLatestStable
   };
 }
@@ -191,6 +191,7 @@ function getImage(images, imageId) {
   return {
     name: image.Name,
     created: image.CreationDate,
+    DaysBehindLatest: image.DaysBehindLatest,
     isLatestStable: image.IsLatest && image.IsStable
   };
 }

--- a/server/test/modules/machineImage/imageSummaryTest.js
+++ b/server/test/modules/machineImage/imageSummaryTest.js
@@ -138,9 +138,60 @@ describe('imageSummary', function () {
         delete y.Rank;
         return y;
       });
+
       context(`${JSON.stringify(input)}`, function () {
         it(`should return ${JSON.stringify(testCase)}`, function () {
-          sut.rank(input).should.be.eql(testCase);
+          sut.rank(input).should.match(testCase);
+        });
+      });
+    }
+
+    let daysBehindLatestTestCases = [
+      [
+        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: false, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 0 },
+      ],
+      [
+        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 0 },
+      ],
+      [
+        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 0 },
+        { AmiType: 'A', AmiVersion: '0.0.2', IsStable: false, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 0 },
+      ],
+      [
+        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 1 },
+        { AmiType: 'A', AmiVersion: '0.0.2', IsStable: true, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 0 },
+      ],
+      [
+        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 1 },
+        { AmiType: 'A', AmiVersion: '0.0.2', IsStable: true, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 0 },
+        { AmiType: 'A', AmiVersion: '0.0.3', IsStable: false, CreationDate: '2000-01-03T00:00:00.000Z', DaysBehindLatest: 0 },
+      ],
+      [
+        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 2 },
+        { AmiType: 'A', AmiVersion: '0.0.2', IsStable: false, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 1 },
+        { AmiType: 'A', AmiVersion: '0.0.3', IsStable: true, CreationDate: '2000-01-03T00:00:00.000Z', DaysBehindLatest: 0 },
+      ],
+      [
+        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 1 },
+        { AmiType: 'A', AmiVersion: '0.0.2', IsStable: true, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 0 },
+        { AmiType: 'A', AmiVersion: '0.0.3', IsStable: false, CreationDate: '2000-01-03T00:00:00.000Z', DaysBehindLatest: 0 },
+        { AmiType: 'B', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 2 },
+        { AmiType: 'B', AmiVersion: '0.0.2', IsStable: true, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 1 },
+        { AmiType: 'B', AmiVersion: '0.0.3', IsStable: true, CreationDate: '2000-01-03T00:00:00.000Z', DaysBehindLatest: 0 },
+      ],
+    ];
+
+    for (let testCase of daysBehindLatestTestCases) {
+      testCase.sort(sut.compare);
+      let input = testCase.map(x => {
+        let y = Object.assign({}, x);
+        delete y.DaysBehindLatest;
+        return y;
+      });
+
+      context(`${JSON.stringify(input)}`, function () {
+        it(`should return ${JSON.stringify(testCase)}`, function () {
+          sut.rank(input).should.match(testCase);
         });
       });
     }


### PR DESCRIPTION
The age of an AMI should be displayed as the number of days between the creation of that AMI and the creation of the latest _stable_ AMI of the same type.

This age is currently displayed as the number of days between the creation of the AMI and the current date.

This information is visible in three places in the UI:
- The servers page for each environment.
- The server role page linked from the servers page.
- The AMI versions page.

This information is returned from two API endpoints:
- /environments/{environment}/servers
- /images

This fix includes the following changes:
- The /images API now includes a new field: `DaysBehindLatest`
- The /environments/{environment}/servers API now returns `Age = DaysBehindLatest`.
- The client uses the new `DaysBehindLatest` field to display the age of an AMI.