### PR TITLE
Fix/delete asg fixes

### DIFF
--- a/server/api/controllers/deployments/deploymentsController.js
+++ b/server/api/controllers/deployments/deploymentsController.js
@@ -148,13 +148,13 @@ function patchDeployment(req, res, next) {
 
 function switchDeployment(key, enable, user) {
   return deploymentsHelper.get({ key }).then((deployment) => {
-    // Old deployments don't have 'ServerRoleName' field
-    if (deployment.Value.ServerRoleName === undefined) {
-      throw new Error('This operation is unsupported for Deployments started before 09.2016. If you would like to use this feature, please redeploy your service, or contact Platform Dev team.');
+    // Old deployments don't have 'ServerRoleName' and 'RuntimeServerRoleName' fields.
+    // Unfortunately we are unable to determine these from existing data.
+    if (deployment.Value.ServerRoleName === undefined || deployment.Value.RuntimeServerRoleName === undefined) {
+      throw new Error('This operation is unsupported for Deployments started before 01.2017. If you would like to use this feature,'
+        + 'please redeploy your service before trying again, or contact Platform Dev team.');
     }
-    // Note: falling back to ServerRoleName is a temporary measure - RuntimeServerRoleName should be used,
-    // but it's not available in deployments before Jan 2017
-    let serverRole = deployment.Value.RuntimeServerRoleName || deployment.Value.ServerRoleName;
+    let serverRole = deployment.Value.RuntimeServerRoleName;
     let environment = deployment.Value.EnvironmentName;
     let slice = deployment.Value.ServiceSlice;
     let service = deployment.Value.ServiceName;

--- a/server/modules/environment-state/getServicesState.js
+++ b/server/modules/environment-state/getServicesState.js
@@ -130,9 +130,6 @@ function* getServicesState(environmentName, runtimeServerRoleName, instances) {
       Action: serviceAction
     };
   });
-
-  servicesList = [];
-
   
   // Look for services that weren't deployed to any instances
   // Since this service wasn't found 

--- a/server/modules/environment-state/getServicesState.js
+++ b/server/modules/environment-state/getServicesState.js
@@ -3,9 +3,11 @@
 'use strict';
 
 let _ = require('lodash');
+let co = require('co');
+
 let Enums = require('Enums');
 let DIFF_STATE = Enums.DIFF_STATE;
-let co = require('co');
+let DEPLOYMENT_STATUS = Enums.DEPLOYMENT_STATUS;
 let logger = require('modules/logger');
 let serviceTargets = require('modules/service-targets');
 
@@ -101,6 +103,7 @@ function* getServicesState(environmentName, runtimeServerRoleName, instances) {
         return serviceOnInstance.OverallHealth === 'Healthy';
       }
       return false;
+
     });
 
     let serviceHealthChecks = getServiceChecksInfo(serviceObjects);
@@ -126,6 +129,35 @@ function* getServicesState(environmentName, runtimeServerRoleName, instances) {
       HealthChecks: serviceHealthChecks,
       Action: serviceAction
     };
+  });
+
+  servicesList = [];
+
+  
+  // Look for services that weren't deployed to any instances
+  // Since this service wasn't found 
+  _.each(targetServiceStates, (targetService) => {
+    if (_.find(servicesList, { Name: targetService.Name, Slice: targetService.Slice }) === undefined) {
+      let serviceAction = targetService.Action || SERVICE_INSTALL;
+
+      let missingService = {
+        Name: targetService.Name,
+        Version: targetService.Version,
+        Slice: targetService.Slice,
+        DiffWithTargetState: (targetService.Action === Enums.ServiceAction.INSTALL ? DIFF_STATE.Missing : DIFF_STATE.Ignored),
+        DeploymentId: targetService.DeploymentId,
+        InstancesNames: [],
+        InstancesCount: {
+          Healthy: 0,
+          Present: 0,
+          Total: 0
+        },
+        HealthChecks: [],
+        OverallHealth: Enums.HEALTH_STATUS.Missing,
+        Action: targetService.Action
+      };
+      servicesList.push(missingService);
+    }
   });
 
   return servicesList;


### PR DESCRIPTION
Solves several problems related to deleting ASG (that happens when last service on ASG is marked as ignored):

1. In case there are no instances present on ASG, service from target state wouldn't show up in Services tab. Now they do.

![image](https://cloud.githubusercontent.com/assets/875141/22430675/eaac588a-e706-11e6-9cc5-4a36e23a7ccb.png)

2. It refuses to trigger ignore for old deployments where required data for triggering is missing (RuntimeServerRoleName and ServerRoleName). The original plan was to fill in the data, but there's no way to recover it just from existing deployment data.

https://jira.thetrainline.com/browse/IS-271157