### PR TITLE
Feature/improve services ui

### DIFF
--- a/client/app/configuration/em-services/ServiceController.js
+++ b/client/app/configuration/em-services/ServiceController.js
@@ -23,13 +23,14 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
         upper: 41000
       },
       blue: {
+        existing: null,
         taken: false
       },
       green: {
+        existing: null,
         taken: false
       }
     };
-    vm.allPorts = null;
 
     vm.cancel = navigateToList;
 
@@ -72,7 +73,12 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
           url: '/api/v1/config/services',
           headers: { 'expected-version': vm.version }
         }).then(function (result) {
-          vm.allPorts = extractPortNumbers(result.data);
+          var ports = extractPortNumbers(result.data);
+          vm.ports.blue.existing = ports.blue;
+          vm.ports.green.existing = ports.green;
+        }).then(function () {
+          vm.getBluePort = findNewPort({range: vm.ports.range, ports: vm.ports.blue.existing});
+          vm.getGreenPort = findNewPort({range: vm.ports.range, ports: vm.ports.green.existing});
         });
     }
 
@@ -120,34 +126,29 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
       return service;
     }
 
-    vm.getBluePort = function getBluePort() {
-      for(var i = vm.ports.range.lower; i <= vm.ports.range.upper; i += 1) {
-        if(vm.allPorts.blue.indexOf(i) === -1) {
-          vm.service.Value.BluePort = i;
-          break;
+    function findNewPort(config) {
+      return function () {
+        var newPort = 0;
+        for(var i = config.range.lower; i <= config.range.upper; i += 1) {
+          if(config.ports.indexOf(i) === -1) {
+           newPort = i;
+           break;
+          }
         }
+        return newPort;
       }
     }
 
     vm.checkBluePort = function() {
-      if(vm.allPorts.blue.indexOf(vm.service.Value.BluePort) !== -1) {
+      if(vm.ports.blue.existing.indexOf(vm.service.Value.BluePort) !== -1) {
         vm.ports.blue.taken = true;
       } else {
         vm.ports.blue.taken = false;
       }
     }
 
-    vm.getGreenPort = function getGreenPort() {
-      for(var i = vm.ports.range.lower; i <= vm.ports.range.upper; i += 1) {
-        if(vm.allPorts.green.indexOf(i) === -1) {
-          vm.service.Value.GreenPort = i;
-          break;
-        }
-      }
-    }
-
     vm.checkGreenPort = function() {
-      if(vm.allPorts.green.indexOf(vm.service.Value.GreenPort) !== -1) {
+      if(vm.ports.green.existing.indexOf(vm.service.Value.GreenPort) !== -1) {
         vm.ports.green.taken = true;
       } else {
         vm.ports.green.taken = false;

--- a/client/app/configuration/em-services/ServiceController.js
+++ b/client/app/configuration/em-services/ServiceController.js
@@ -144,6 +144,16 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
       }
     }
 
+    vm.getNextFreeGreenPort = function () {
+      vm.service.Value.GreenPort = vm.getGreenPort();
+      vm.checkGreenPort();
+    };
+
+    vm.getNextFreeBluePort = function () {
+      vm.service.Value.BluePort = vm.getBluePort();
+      vm.checkBluePort();
+    };
+
     vm.checkBluePort = function() {
       if(vm.ports.blue.existing.indexOf(vm.service.Value.BluePort) !== -1 
           && vm.service.Value.BluePort !== vm.ports.blue.current) {

--- a/client/app/configuration/em-services/ServiceController.js
+++ b/client/app/configuration/em-services/ServiceController.js
@@ -24,11 +24,13 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
       },
       blue: {
         existing: null,
-        taken: false
+        taken: false,
+        current: null
       },
       green: {
         existing: null,
-        taken: false
+        taken: false,
+        current: null
       }
     };
 
@@ -100,6 +102,8 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
       resources.config.services.get({ key: name, range: range }).then(function (data) {
         vm.dataFound = true;
         vm.service = readableService(data);
+        vm.ports.green.current = vm.service.Value.GreenPort;
+        vm.ports.blue.current = vm.service.Value.BluePort;
         vm.version = data.Version;
       }, function (err) {
         vm.dataFound = false;
@@ -140,7 +144,8 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
     }
 
     vm.checkBluePort = function() {
-      if(vm.ports.blue.existing.indexOf(vm.service.Value.BluePort) !== -1) {
+      if(vm.ports.blue.existing.indexOf(vm.service.Value.BluePort) !== -1 
+          && vm.service.Value.BluePort !== vm.ports.blue.current) {
         vm.ports.blue.taken = true;
       } else {
         vm.ports.blue.taken = false;
@@ -148,7 +153,8 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
     }
 
     vm.checkGreenPort = function() {
-      if(vm.ports.green.existing.indexOf(vm.service.Value.GreenPort) !== -1) {
+      if(vm.ports.green.existing.indexOf(vm.service.Value.GreenPort) !== -1 
+          && vm.service.Value.GreenPort !== vm.ports.green.current) {
         vm.ports.green.taken = true;
       } else {
         vm.ports.green.taken = false;

--- a/client/app/configuration/em-services/ServiceController.js
+++ b/client/app/configuration/em-services/ServiceController.js
@@ -17,6 +17,7 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
     vm.owningClustersList = [];
     vm.serviceNames = [];
     vm.version = 0;
+    vm.allPorts = null;
 
     vm.cancel = navigateToList;
 
@@ -36,7 +37,9 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
 
         resources.config.services.all().then(function (services) {
           vm.serviceNames = _.map(services, 'ServiceName');
-        })
+        }),
+
+        fetchPortNumbers()
       ]).then(function () {
         if (vm.editMode) {
           readItem(serviceName, owningCluster);
@@ -49,6 +52,30 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
           };
         }
       });
+    }
+
+    function fetchPortNumbers() {
+      $http({
+          method: 'GET',
+          url: '/api/v1/config/services',
+          headers: { 'expected-version': vm.version }
+        }).then(function (result) {
+          vm.allPorts = extractPortNumbers(result.data);
+        });
+    }
+
+    function extractPortNumbers(data) {
+      var ports = {
+        blue: [],
+        green: []
+      };
+      _.map(data, function (item) {
+        if (item.Value) {
+          ports.green.push(item.Value.GreenPort);
+          ports.blue.push(item.Value.BluePort);
+        }
+      });
+      return ports;
     }
 
     function readItem(name, range) {

--- a/client/app/configuration/em-services/ServiceController.js
+++ b/client/app/configuration/em-services/ServiceController.js
@@ -17,6 +17,18 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
     vm.owningClustersList = [];
     vm.serviceNames = [];
     vm.version = 0;
+    vm.ports = {
+      range: {
+        lower: 40000, 
+        upper: 41000
+      },
+      blue: {
+        taken: false
+      },
+      green: {
+        taken: false
+      }
+    };
     vm.allPorts = null;
 
     vm.cancel = navigateToList;
@@ -71,8 +83,8 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
       };
       _.map(data, function (item) {
         if (item.Value) {
-          ports.green.push(item.Value.GreenPort);
-          ports.blue.push(item.Value.BluePort);
+          ports.green.push(item.Value.GreenPort * 1);
+          ports.blue.push(item.Value.BluePort * 1);
         }
       });
       return ports;
@@ -106,6 +118,40 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
         delete service.Value.BluePort;
       }
       return service;
+    }
+
+    vm.getBluePort = function getBluePort() {
+      for(var i = vm.ports.range.lower; i <= vm.ports.range.upper; i += 1) {
+        if(vm.allPorts.blue.indexOf(i) === -1) {
+          vm.service.Value.BluePort = i;
+          break;
+        }
+      }
+    }
+
+    vm.checkBluePort = function() {
+      if(vm.allPorts.blue.indexOf(vm.service.Value.BluePort) !== -1) {
+        vm.ports.blue.taken = true;
+      } else {
+        vm.ports.blue.taken = false;
+      }
+    }
+
+    vm.getGreenPort = function getGreenPort() {
+      for(var i = vm.ports.range.lower; i <= vm.ports.range.upper; i += 1) {
+        if(vm.allPorts.green.indexOf(i) === -1) {
+          vm.service.Value.GreenPort = i;
+          break;
+        }
+      }
+    }
+
+    vm.checkGreenPort = function() {
+      if(vm.allPorts.green.indexOf(vm.service.Value.GreenPort) !== -1) {
+        vm.ports.green.taken = true;
+      } else {
+        vm.ports.green.taken = false;
+      }
     }
 
     vm.canUser = function () {

--- a/client/app/configuration/em-services/ServiceController.js
+++ b/client/app/configuration/em-services/ServiceController.js
@@ -91,6 +91,7 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
       };
       _.map(data, function (item) {
         if (item.Value) {
+          // Some values came back as strings from the end point, so changing them to numbers here
           ports.green.push(item.Value.GreenPort * 1);
           ports.blue.push(item.Value.BluePort * 1);
         }

--- a/client/app/configuration/em-services/ServiceController.js
+++ b/client/app/configuration/em-services/ServiceController.js
@@ -31,7 +31,8 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
         existing: null,
         taken: false,
         current: null
-      }
+      },
+      used: []
     };
 
     vm.cancel = navigateToList;
@@ -96,6 +97,16 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
           ports.blue.push(item.Value.BluePort * 1);
         }
       });
+
+      //Add all the ports to a single array. 
+      //It doesn't matter whether they come from green or blue. 
+      data.forEach(function (item) {
+        if(item.Value) {
+          vm.ports.used.push(item.Value.GreenPort * 1);
+          vm.ports.used.push(item.Value.BluePort * 1);
+        }
+      });
+
       return ports;
     }
 
@@ -144,13 +155,40 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
       }
     }
 
+    function portIsNotUsedAlready(p) {
+      return vm.ports.used.indexOf(p) === -1;
+    }
+
+    function greenPortIsNotSetToThisNumber(p) {
+      return vm.service.Value.GreenPort !== p;
+    }
+
+    function bluePortIsNotSetToThisNumber(p) {
+      return vm.service.Value.BluePort !== p;
+    }
+
+    function portIsAvailable(portNumber) {
+      return portIsNotUsedAlready(portNumber) && greenPortIsNotSetToThisNumber(portNumber) && bluePortIsNotSetToThisNumber(portNumber);
+    }
+
+    vm.getUnusedPort = function () {
+      var port = null;
+      for(var i = vm.ports.range.lower; i < vm.ports.range.upper; i += 1) {
+        if(portIsAvailable(i)) {
+          port = i;
+          break;
+        }
+      }
+      return port;
+    }
+
     vm.getNextFreeGreenPort = function () {
-      vm.service.Value.GreenPort = vm.getGreenPort();
+      vm.service.Value.GreenPort = vm.getUnusedPort();
       vm.checkGreenPort();
     };
 
     vm.getNextFreeBluePort = function () {
-      vm.service.Value.BluePort = vm.getBluePort();
+      vm.service.Value.BluePort = vm.getUnusedPort();
       vm.checkBluePort();
     };
 

--- a/client/app/configuration/em-services/service.html
+++ b/client/app/configuration/em-services/service.html
@@ -75,19 +75,17 @@
                    ng-keyup="vm.checkBluePort()" />
 
                 <span class="input-group-btn">
-                    <button class="btn btn-secondary" type="button" ng-click="vm.getBluePort()">Get Next Available</button>
+                    <button class="btn btn-secondary" type="button" ng-click="vm.service.Value.BluePort = vm.getBluePort()">Get Next Available</button>
                 </span>
             </div>
         </div>
-        
-        <span class="help-block" ng-if="form.BluePort.$dirty && form.BluePort.$invalid">Blue Port must be between 40000 and 41000.</span>
-        <span class="help-block" ng-if="vm.ports.blue.taken">This port number is currently in use.</span>
+        <span class="help-block" ng-if="form.BluePort.$dirty && form.BluePort.$invalid">Blue Port must be between {{vm.ports.range.lower}} and {{vm.ports.range.upper}}.</span>
+        <span class="help-block" ng-if="vm.ports.blue.taken"><i>This port number is currently in use.</i></span>
     </div>
     <div class="form-group" ng-class="{'has-error': form.GreenPort.$invalid}">
         <label class="col-sm-2 control-label text-left nowrap">Green Port:</label>
         <div class="col-sm-4">
             <div class="input-group">
-
                 <input type="number"
                    name="GreenPort"
                    class="form-control"
@@ -99,15 +97,13 @@
                    ng-keyup="vm.checkGreenPort()" />
 
                 <span class="input-group-btn">
-                    <button class="btn btn-secondary" type="button" ng-click="vm.getGreenPort()">Get Next Available</button>
+                    <button class="btn btn-secondary" type="button" ng-click="vm.service.Value.GreenPort = vm.getGreenPort()">Get Next Available</button>
                 </span>
             </div>
         </div>
-        
-        
         <div class="col-sm-6">
-            <span class="help-block" ng-if="form.GreenPort.$dirty && form.GreenPort.$invalid">Green Port must be between 40000 and 41000.</span>
-            <span class="help-block" ng-if="vm.ports.green.taken">This port number is currently in use.</span>
+            <span class="help-block" ng-if="form.GreenPort.$dirty && form.GreenPort.$invalid">Blue Port must be between {{vm.ports.range.lower}} and {{vm.ports.range.upper}}.</span>
+            <span class="help-block" ng-if="vm.ports.green.taken"><i>This port number is currently in use.</i></span>
         </div>
         
     </div>
@@ -120,7 +116,7 @@
                 Cancel
             </button>
             <button type="button"
-                    class="btn btn-default"
+                    class="btn btn-primary"
                     ng-if="vm.canUser('edit')"
                     ng-disabled="!form.$valid"
                     ng-click="vm.save()">Save</button>

--- a/client/app/configuration/em-services/service.html
+++ b/client/app/configuration/em-services/service.html
@@ -7,15 +7,15 @@
 
 <div ng-show="vm.editMode && !vm.dataFound">No data found.</div>
 
-<form name="form" class="form-horizontal" ng-show="vm.dataFound || !vm.editMode">
+<form  name="form" class="form-horizontal" ng-show="vm.dataFound || !vm.editMode">
 
-    <div class="form-group" ng-if="!vm.editMode" ng-class="{'has-error': form.ServiceName.$invalid}">
+    <div class="form-group" ng-if="!vm.editMode" ng-class="{'has-error': form.ServiceName.$invalid && form.ServiceName.$dirty} ">
         <label class="col-sm-2 control-label text-left nowrap">Service Name: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
         <div class="col-sm-4">
             <input type="text"
                    name="ServiceName"
-                   class="form-control"
                    required=""
+                   class="form-control"
                    autofocus
                    maxlength="50"
                    ng-model="vm.service.ServiceName"
@@ -27,7 +27,7 @@
         <span class="help-block" ng-if="form.ServiceName.$dirty && form.ServiceName.$error.duplicated">A Service already exists with the same name.</span>
         <span class="help-block" ng-if="form.ServiceName.$dirty && form.ServiceName.$error.pattern">Service name must contain only alphanumeric characters.</span>
     </div>
-    <div class="form-group" ng-class="{'has-error': form.OwningClusters.$invalid}">
+    <div class="form-group" ng-class="{'has-error': form.OwningClusters.$invalid} && form.OwningClusters.$dirty">
         <label class="col-sm-2 control-label text-left nowrap">Owning Cluster: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
         <div class="col-sm-4">
             <select class="form-control"
@@ -99,10 +99,10 @@
                    min="40000"
                    max="41000"
                    ng-readonly="!vm.canUser('edit')"
-                   ng-keyup="vm.checkBluePort()" />
+                   ng-change="vm.checkBluePort()" />
 
                 <span class="input-group-btn">
-                    <button class="btn btn-default" type="button" ng-click="vm.service.Value.BluePort = vm.getBluePort()">Next Free Port <span class="glyphicon glyphicon-step-forward"></span></button>
+                    <button class="btn btn-default" type="button" ng-click="vm.getNextFreeBluePort()">Next Free Port <span class="glyphicon glyphicon-step-forward"></span></button>
                 </span>
             </div>
         </div>
@@ -123,10 +123,10 @@
                    min="40000"
                    max="41000"
                    ng-readonly="!vm.canUser('edit')"
-                   ng-keyup="vm.checkGreenPort()" />
+                   ng-change="vm.checkGreenPort()" />
 
                 <span class="input-group-btn">
-                    <button class="btn btn-default" type="button" ng-click="vm.service.Value.GreenPort = vm.getGreenPort()">Next Free Port <span class="glyphicon glyphicon-step-forward"></span></button>
+                    <button class="btn btn-default" type="button" ng-click="vm.getNextFreeGreenPort()">Next Free Port <span class="glyphicon glyphicon-step-forward"></span></button>
                 </span>
             </div>
         </div>

--- a/client/app/configuration/em-services/service.html
+++ b/client/app/configuration/em-services/service.html
@@ -136,7 +136,6 @@
         </div>
         
     </div>
-    <!-- TODO: validate blue and green ports not the same number -->
     <div class="form-group">
         <div class="col-sm-offset-2 col-sm-3">
             <button type="button"

--- a/client/app/configuration/em-services/service.html
+++ b/client/app/configuration/em-services/service.html
@@ -47,6 +47,34 @@
                       ng-readonly="!vm.canUser('edit')"></textarea>
         </div>
     </div>
+
+    <div class="form-group" >
+        <label class="col-sm-2 control-label text-left">Documentation URL:</label>
+        <div class="col-sm-4">
+            <input type="text"
+                   name="DocumentationUrl"
+                   class="form-control"
+                   autofocus
+                   maxlength="256"
+                   ng-model="vm.service.Value.DocumentationUrl"
+                   ng-readonly="!vm.canUser('edit')" />
+        </div>
+    </div>
+
+    <div class="form-group">
+        <label class="col-sm-2 control-label text-left nowrap">Primary Contact:</span></label>
+        <div class="col-sm-4">
+            <input type="text"
+                   name="PrimaryContact"
+                   class="form-control"
+                   autofocus
+                   maxlength="50"
+                   ng-model="vm.service.Value.PrimaryContact"
+                   pattern="[a-zA-Z\s]*"
+                   ng-readonly="!vm.canUser('edit')" />
+        </div>
+    </div>
+
     <div class="form-group" ng-class="{'has-error': form.ApplicationId.$invalid}">
         <label class="col-sm-2 control-label text-left nowrap">Application ID:</label>
         <div class="col-sm-2">
@@ -59,32 +87,6 @@
                    ng-readonly="!vm.canUser('edit')" />
         </div>
         <span class="help-block" ng-if="form.ApplicationId.$dirty && form.ApplicationId.$error.pattern">Application ID must be a number.</span>
-    </div>
-
-    <div class="form-group">
-        <label class="col-sm-2 control-label text-left nowrap">Goto-person:</span></label>
-        <div class="col-sm-4">
-            <input type="text"
-                   name="GotoPerson"
-                   class="form-control"
-                   autofocus
-                   maxlength="50"
-                   ng-model="vm.service.Value.GotoPerson"
-                   pattern="[a-zA-Z\s]*"
-                   ng-readonly="!vm.canUser('edit')" />
-        </div>
-    </div>
-    <div class="form-group" >
-        <label class="col-sm-2 control-label text-left">Service + Documentation URL:</label>
-        <div class="col-sm-4">
-            <input type="text"
-                   name="ServiceDocumentationUrl"
-                   class="form-control"
-                   autofocus
-                   maxlength="256"
-                   ng-model="vm.service.Value.ServiceDocumentationUrl"
-                   ng-readonly="!vm.canUser('edit')" />
-        </div>
     </div>
 
     <div class="form-group" ng-class="{'has-error': form.BluePort.$invalid}">
@@ -102,7 +104,7 @@
                    ng-change="vm.checkBluePort()" />
 
                 <span class="input-group-btn">
-                    <button class="btn btn-default" type="button" ng-click="vm.getNextFreeBluePort()">Next Free Port <span class="glyphicon glyphicon-step-forward"></span></button>
+                    <button class="btn btn-default" type="button" ng-click="vm.getNextFreeBluePort()">Get Free Port <span class="glyphicon glyphicon-step-forward"></span></button>
                 </span>
             </div>
         </div>
@@ -126,7 +128,7 @@
                    ng-change="vm.checkGreenPort()" />
 
                 <span class="input-group-btn">
-                    <button class="btn btn-default" type="button" ng-click="vm.getNextFreeGreenPort()">Next Free Port <span class="glyphicon glyphicon-step-forward"></span></button>
+                    <button class="btn btn-default" type="button" ng-click="vm.getNextFreeGreenPort()">Get Free Port <span class="glyphicon glyphicon-step-forward"></span></button>
                 </span>
             </div>
         </div>

--- a/client/app/configuration/em-services/service.html
+++ b/client/app/configuration/em-services/service.html
@@ -11,7 +11,7 @@
 
     <div class="form-group" ng-if="!vm.editMode" ng-class="{'has-error': form.ServiceName.$invalid}">
         <label class="col-sm-2 control-label text-left nowrap">Service Name: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
-        <div class="col-sm-2">
+        <div class="col-sm-4">
             <input type="text"
                    name="ServiceName"
                    class="form-control"
@@ -29,7 +29,7 @@
     </div>
     <div class="form-group" ng-class="{'has-error': form.OwningClusters.$invalid}">
         <label class="col-sm-2 control-label text-left nowrap">Owning Cluster: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
-        <div class="col-sm-2">
+        <div class="col-sm-4">
             <select class="form-control"
                     name="OwningClusters"
                     required=""
@@ -42,14 +42,14 @@
     </div>
     <div class="form-group">
         <label class="col-sm-2 control-label text-left nowrap">Description:</label>
-        <div class="col-sm-2">
+        <div class="col-sm-4">
             <textarea ng-model="vm.service.Value.Description"
                       ng-readonly="!vm.canUser('edit')"></textarea>
         </div>
     </div>
     <div class="form-group" ng-class="{'has-error': form.ApplicationId.$invalid}">
         <label class="col-sm-2 control-label text-left nowrap">Application ID:</label>
-        <div class="col-sm-1">
+        <div class="col-sm-2">
             <input type="text"
                    name="ApplicationId"
                    class="form-control"
@@ -62,7 +62,7 @@
     </div>
     <div class="form-group" ng-class="{'has-error': form.BluePort.$invalid}">
         <label class="col-sm-2 control-label text-left nowrap">Blue Port:</label>
-        <div class="col-sm-1">
+        <div class="col-sm-2">
             <input type="number"
                    name="BluePort"
                    class="form-control"
@@ -76,7 +76,7 @@
     </div>
     <div class="form-group" ng-class="{'has-error': form.GreenPort.$invalid}">
         <label class="col-sm-2 control-label text-left nowrap">Green Port:</label>
-        <div class="col-md-1">
+        <div class="col-md-2">
             <input type="number"
                    name="GreenPort"
                    class="form-control"
@@ -90,7 +90,7 @@
     </div>
     <!-- TODO: validate blue and green ports not the same number -->
     <div class="form-group">
-        <div class="col-md-offset-1 col-sm-3">
+        <div class="col-sm-offset-2 col-sm-3">
             <button type="button"
                     class="btn btn-default"
                     ng-click="vm.cancel()">

--- a/client/app/configuration/em-services/service.html
+++ b/client/app/configuration/em-services/service.html
@@ -106,8 +106,10 @@
                 </span>
             </div>
         </div>
-        <span class="help-block" ng-if="form.BluePort.$dirty && form.BluePort.$invalid">Blue Port must be between {{vm.ports.range.lower}} and {{vm.ports.range.upper}}.</span>
-        <span class="help-block" ng-if="vm.ports.blue.taken"><i>This port number is currently in use.</i></span>
+        <div class="col-sm-6">
+            <span class="help-block" ng-if="form.BluePort.$dirty && form.BluePort.$invalid">Blue Port must be between {{vm.ports.range.lower}} and {{vm.ports.range.upper}}.</span>
+            <span class="help-block" ng-if="vm.ports.blue.taken"><i>This port number is currently in use.</i></span>
+        </div>
     </div>
     <div class="form-group" ng-class="{'has-error': form.GreenPort.$invalid}">
         <label class="col-sm-2 control-label text-left nowrap">Green Port:</label>
@@ -129,7 +131,7 @@
             </div>
         </div>
         <div class="col-sm-6">
-            <span class="help-block" ng-if="form.GreenPort.$dirty && form.GreenPort.$invalid">Blue Port must be between {{vm.ports.range.lower}} and {{vm.ports.range.upper}}.</span>
+            <span class="help-block" ng-if="form.GreenPort.$dirty && form.GreenPort.$invalid">Green Port must be between {{vm.ports.range.lower}} and {{vm.ports.range.upper}}.</span>
             <span class="help-block" ng-if="vm.ports.green.taken"><i>This port number is currently in use.</i></span>
         </div>
         
@@ -145,7 +147,7 @@
             <button type="button"
                     class="btn btn-primary"
                     ng-if="vm.canUser('edit')"
-                    ng-disabled="!form.$valid"
+                    ng-disabled="!form.$valid || vm.service.Value.GreenPort === vm.service.Value.BluePort"
                     ng-click="vm.save()">Save</button>
         </div>
     </div>

--- a/client/app/configuration/em-services/service.html
+++ b/client/app/configuration/em-services/service.html
@@ -62,31 +62,54 @@
     </div>
     <div class="form-group" ng-class="{'has-error': form.BluePort.$invalid}">
         <label class="col-sm-2 control-label text-left nowrap">Blue Port:</label>
-        <div class="col-sm-2">
-            <input type="number"
+        <div class="col-sm-4">
+            <div class="input-group">
+                <input type="number"
                    name="BluePort"
                    class="form-control"
                    maxlength="5"
                    ng-model="vm.service.Value.BluePort"
                    min="40000"
                    max="41000"
-                   ng-readonly="!vm.canUser('edit')" />
+                   ng-readonly="!vm.canUser('edit')"
+                   ng-keyup="vm.checkBluePort()" />
+
+                <span class="input-group-btn">
+                    <button class="btn btn-secondary" type="button" ng-click="vm.getBluePort()">Get Next Available</button>
+                </span>
+            </div>
         </div>
+        
         <span class="help-block" ng-if="form.BluePort.$dirty && form.BluePort.$invalid">Blue Port must be between 40000 and 41000.</span>
+        <span class="help-block" ng-if="vm.ports.blue.taken">This port number is currently in use.</span>
     </div>
     <div class="form-group" ng-class="{'has-error': form.GreenPort.$invalid}">
         <label class="col-sm-2 control-label text-left nowrap">Green Port:</label>
-        <div class="col-md-2">
-            <input type="number"
+        <div class="col-sm-4">
+            <div class="input-group">
+
+                <input type="number"
                    name="GreenPort"
                    class="form-control"
                    maxlength="5"
                    ng-model="vm.service.Value.GreenPort"
                    min="40000"
                    max="41000"
-                   ng-readonly="!vm.canUser('edit')" />
+                   ng-readonly="!vm.canUser('edit')"
+                   ng-keyup="vm.checkGreenPort()" />
+
+                <span class="input-group-btn">
+                    <button class="btn btn-secondary" type="button" ng-click="vm.getGreenPort()">Get Next Available</button>
+                </span>
+            </div>
         </div>
-        <span class="help-block" ng-if="form.GreenPort.$dirty && form.GreenPort.$invalid">Blue Port must be between 40000 and 41000.</span>
+        
+        
+        <div class="col-sm-6">
+            <span class="help-block" ng-if="form.GreenPort.$dirty && form.GreenPort.$invalid">Green Port must be between 40000 and 41000.</span>
+            <span class="help-block" ng-if="vm.ports.green.taken">This port number is currently in use.</span>
+        </div>
+        
     </div>
     <!-- TODO: validate blue and green ports not the same number -->
     <div class="form-group">

--- a/client/app/configuration/em-services/service.html
+++ b/client/app/configuration/em-services/service.html
@@ -60,6 +60,35 @@
         </div>
         <span class="help-block" ng-if="form.ApplicationId.$dirty && form.ApplicationId.$error.pattern">Application ID must be a number.</span>
     </div>
+
+    <div class="form-group">
+        <label class="col-sm-2 control-label text-left nowrap">Goto-person:</span></label>
+        <div class="col-sm-4">
+            <input type="text"
+                   name="GotoPerson"
+                   class="form-control"
+                   required=""
+                   autofocus
+                   maxlength="50"
+                   ng-model="vm.service.Value.GotoPerson"
+                   pattern="[a-zA-Z\s]*"
+                   ng-readonly="!vm.canUser('edit')" />
+        </div>
+    </div>
+    <div class="form-group" >
+        <label class="col-sm-2 control-label text-left">Service + Documentation URL:</label>
+        <div class="col-sm-4">
+            <input type="text"
+                   name="ServiceDocumentationUrl"
+                   class="form-control"
+                   required=""
+                   autofocus
+                   maxlength="256"
+                   ng-model="vm.service.Value.ServiceDocumentationUrl"
+                   ng-readonly="!vm.canUser('edit')" />
+        </div>
+    </div>
+
     <div class="form-group" ng-class="{'has-error': form.BluePort.$invalid}">
         <label class="col-sm-2 control-label text-left nowrap">Blue Port:</label>
         <div class="col-sm-4">
@@ -75,7 +104,7 @@
                    ng-keyup="vm.checkBluePort()" />
 
                 <span class="input-group-btn">
-                    <button class="btn btn-secondary" type="button" ng-click="vm.service.Value.BluePort = vm.getBluePort()">Get Next Available</button>
+                    <button class="btn btn-default" type="button" ng-click="vm.service.Value.BluePort = vm.getBluePort()">Next Free Port</button>
                 </span>
             </div>
         </div>
@@ -97,7 +126,7 @@
                    ng-keyup="vm.checkGreenPort()" />
 
                 <span class="input-group-btn">
-                    <button class="btn btn-secondary" type="button" ng-click="vm.service.Value.GreenPort = vm.getGreenPort()">Get Next Available</button>
+                    <button class="btn btn-default" type="button" ng-click="vm.service.Value.GreenPort = vm.getGreenPort()">Next Free Port</button>
                 </span>
             </div>
         </div>

--- a/client/app/configuration/em-services/service.html
+++ b/client/app/configuration/em-services/service.html
@@ -10,8 +10,8 @@
 <form name="form" class="form-horizontal" ng-show="vm.dataFound || !vm.editMode">
 
     <div class="form-group" ng-if="!vm.editMode" ng-class="{'has-error': form.ServiceName.$invalid}">
-        <label class="col-md-1 control-label text-left nowrap">Service Name: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
-        <div class="col-md-2">
+        <label class="col-sm-2 control-label text-left nowrap">Service Name: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
+        <div class="col-sm-2">
             <input type="text"
                    name="ServiceName"
                    class="form-control"
@@ -28,8 +28,8 @@
         <span class="help-block" ng-if="form.ServiceName.$dirty && form.ServiceName.$error.pattern">Service name must contain only alphanumeric characters.</span>
     </div>
     <div class="form-group" ng-class="{'has-error': form.OwningClusters.$invalid}">
-        <label class="col-md-1 control-label text-left nowrap">Owning Cluster: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
-        <div class="col-md-2">
+        <label class="col-sm-2 control-label text-left nowrap">Owning Cluster: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
+        <div class="col-sm-2">
             <select class="form-control"
                     name="OwningClusters"
                     required=""
@@ -41,15 +41,15 @@
         <span class="help-block" ng-if="form.OwningClusters.$error.required">Owning cluster is mandatory.</span>
     </div>
     <div class="form-group">
-        <label class="col-md-1 control-label text-left nowrap">Description:</label>
-        <div class="col-md-2">
+        <label class="col-sm-2 control-label text-left nowrap">Description:</label>
+        <div class="col-sm-2">
             <textarea ng-model="vm.service.Value.Description"
                       ng-readonly="!vm.canUser('edit')"></textarea>
         </div>
     </div>
     <div class="form-group" ng-class="{'has-error': form.ApplicationId.$invalid}">
-        <label class="col-md-1 control-label text-left nowrap">Application ID:</label>
-        <div class="col-md-1">
+        <label class="col-sm-2 control-label text-left nowrap">Application ID:</label>
+        <div class="col-sm-1">
             <input type="text"
                    name="ApplicationId"
                    class="form-control"
@@ -61,8 +61,8 @@
         <span class="help-block" ng-if="form.ApplicationId.$dirty && form.ApplicationId.$error.pattern">Application ID must be a number.</span>
     </div>
     <div class="form-group" ng-class="{'has-error': form.BluePort.$invalid}">
-        <label class="col-md-1 control-label text-left nowrap">Blue Port:</label>
-        <div class="col-md-1">
+        <label class="col-sm-2 control-label text-left nowrap">Blue Port:</label>
+        <div class="col-sm-1">
             <input type="number"
                    name="BluePort"
                    class="form-control"
@@ -75,7 +75,7 @@
         <span class="help-block" ng-if="form.BluePort.$dirty && form.BluePort.$invalid">Blue Port must be between 40000 and 41000.</span>
     </div>
     <div class="form-group" ng-class="{'has-error': form.GreenPort.$invalid}">
-        <label class="col-md-1 control-label text-left nowrap">Green Port:</label>
+        <label class="col-sm-2 control-label text-left nowrap">Green Port:</label>
         <div class="col-md-1">
             <input type="number"
                    name="GreenPort"
@@ -90,7 +90,7 @@
     </div>
     <!-- TODO: validate blue and green ports not the same number -->
     <div class="form-group">
-        <div class="col-md-offset-1 col-md-3">
+        <div class="col-md-offset-1 col-sm-3">
             <button type="button"
                     class="btn btn-default"
                     ng-click="vm.cancel()">

--- a/client/app/configuration/em-services/service.html
+++ b/client/app/configuration/em-services/service.html
@@ -67,7 +67,6 @@
             <input type="text"
                    name="GotoPerson"
                    class="form-control"
-                   required=""
                    autofocus
                    maxlength="50"
                    ng-model="vm.service.Value.GotoPerson"
@@ -81,7 +80,6 @@
             <input type="text"
                    name="ServiceDocumentationUrl"
                    class="form-control"
-                   required=""
                    autofocus
                    maxlength="256"
                    ng-model="vm.service.Value.ServiceDocumentationUrl"

--- a/client/app/configuration/em-services/service.html
+++ b/client/app/configuration/em-services/service.html
@@ -104,7 +104,7 @@
                    ng-keyup="vm.checkBluePort()" />
 
                 <span class="input-group-btn">
-                    <button class="btn btn-default" type="button" ng-click="vm.service.Value.BluePort = vm.getBluePort()">Next Free Port</button>
+                    <button class="btn btn-default" type="button" ng-click="vm.service.Value.BluePort = vm.getBluePort()">Next Free Port <span class="glyphicon glyphicon-step-forward"></span></button>
                 </span>
             </div>
         </div>
@@ -126,7 +126,7 @@
                    ng-keyup="vm.checkGreenPort()" />
 
                 <span class="input-group-btn">
-                    <button class="btn btn-default" type="button" ng-click="vm.service.Value.GreenPort = vm.getGreenPort()">Next Free Port</button>
+                    <button class="btn btn-default" type="button" ng-click="vm.service.Value.GreenPort = vm.getGreenPort()">Next Free Port <span class="glyphicon glyphicon-step-forward"></span></button>
                 </span>
             </div>
         </div>


### PR DESCRIPTION
UI changed here: Configuration -> Services -> [Create New]

|> Labels for the form have been widened. 
|> Columns have been altered on the form inputs to spread things out.
|> "Goto-person" and "Service + Documentation URL" added. They were part of the wiki page for ports management. I added them with the same text as the wiki and in the same order as they appeared in the wiki table.
|> Get next available port button added. 
|> Warning added when a port has been entered that is already in use. 
|> When editing the form, deleting and selecting the same port will not give you a warning - the port which is already in use, is in use by your service, so you're ok. 
|> TODO comment in the code requested prevention of duplicate ports across blue and green. The save button is disabled if the ports are indeed duplicated. 
