### PR TITLE
Remove environment.CodeDeployBucket

### DIFF
--- a/client/app/environments/dialogs/env-create-environment-modal.html
+++ b/client/app/environments/dialogs/env-create-environment-modal.html
@@ -60,20 +60,6 @@
             <span><a href="#/config/deploymentmaps/{{Environment.Value.DeploymentMap}}" target="_blank">View Map</a> <small>(Launches new window)</small></span>
             <span class="help-block" ng-if="form.DeploymentMap.$dirty && form.DeploymentMap.$error.required">Deployment Map is mandatory.</span>
         </div>
-        <div class="form-group" ng-class="{'has-error': form.CodeDeployBucket.$invalid}">
-            <label class="col-md-4 control-label text-left ">Code Deploy Bucket: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
-            <div class="col-md-4">
-                <input type="text"
-                       name="CodeDeployBucket"
-                       class="form-control"
-                       required=""
-                       maxlength="60"
-                       ng-model="Environment.Value.CodeDeployBucket" />
-                       <!-- TODO: define bucket pattern, expect to start with tl-deployment pattern="[a-zA-Z]+[\w -]*" -->
-            </div>
-            <span class="help-block" ng-if="form.CodeDeployBucket.$dirty && form.CodeDeployBucket.$error.required">Code Deploy Bucket is mandatory.</span>
-            <span class="help-block" ng-if="form.CodeDeployBucket.$dirty && form.CodeDeployBucket.$error.pattern">Bucket path must be a valid S3 location.</span>
-        </div>
         <div class="form-group">
             <label class="col-md-4 control-label text-left">Description:</label>
             <div class="col-md-6">

--- a/client/app/environments/settings/ManageEnvironmentSettingsController.js
+++ b/client/app/environments/settings/ManageEnvironmentSettingsController.js
@@ -22,7 +22,6 @@ angular.module('EnvironmentManager.environments').controller('ManageEnvironmentS
     vm.newEnvironment = {
       OwningCluster: '',
       DeploymentMap: '',
-      CodeDeployBucket: '',
       Description: '',
       IsLocked: false
     };
@@ -79,7 +78,6 @@ angular.module('EnvironmentManager.environments').controller('ManageEnvironmentS
         vm.newEnvironment = {
           OwningCluster: configuration.Value.OwningCluster,
           DeploymentMap: configuration.Value.DeploymentMap,
-          CodeDeployBucket: configuration.Value.CodeDeployBucket,
           Description: configuration.Value.Description,
           AlertSettings: configuration.Value.AlertSettings,
           NotificationSettingsId: configuration.Value.NotificationSettingsId,
@@ -138,7 +136,6 @@ angular.module('EnvironmentManager.environments').controller('ManageEnvironmentS
       // Update Environment with form values
       vm.environment.Value.OwningCluster = vm.newEnvironment.OwningCluster;
       vm.environment.Value.DeploymentMap = vm.newEnvironment.DeploymentMap;
-      vm.environment.Value.CodeDeployBucket = vm.newEnvironment.CodeDeployBucket;
       vm.environment.Value.Description = vm.newEnvironment.Description;
       vm.environment.Value.AlertSettings = vm.newEnvironment.AlertSettings;
       vm.environment.Value.NotificationSettingsId = vm.newEnvironment.NotificationSettingsId;

--- a/client/app/environments/settings/env-manage-settings.html
+++ b/client/app/environments/settings/env-manage-settings.html
@@ -46,23 +46,6 @@
                 <span class="help-block" ng-if="form.DeploymentMap.$dirty && form.DeploymentMap.$error.required">Deployment Map is mandatory.</span>
                 <!-- TODO: changing a deployment map not necessarily a good idea, won't update existing AWS resources. Should warn user if they do before Save -->
             </div>
-            <div class="form-group" ng-class="{'has-error': form.CodeDeployBucket.$invalid}">
-                <label class="col-md-1 control-label text-left nowrap">Code Deploy Bucket: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
-                <div class="col-md-2" ng-if="vm.canUser('edit')">
-                    <input type="text"
-                           name="CodeDeployBucket"
-                           class="form-control"
-                           required=""
-                           maxlength="60"
-                           ng-model="vm.newEnvironment.CodeDeployBucket" />
-                    <!-- TODO: define bucket pattern, expect to start with 'tl-deployment'? pattern="[a-zA-Z]+*" -->
-                </div>
-                <div class="col-md-3" ng-if="!vm.canUser('edit')">
-                    <label class="control-label text-left nonbold">{{NewEnvironment.CodeDeployBucket}}</label>
-                </div>
-                <span class="help-block" ng-if="form.CodeDeployBucket.$dirty && form.CodeDeployBucket.$error.required">Code Deploy Bucket is mandatory.</span>
-                <span class="help-block" ng-if="form.CodeDeployBucket.$dirty && form.CodeDeployBucket.$error.pattern">Bucket path must be a valid S3 location.</span>
-            </div>
             <div class="form-group">
                 <label class="col-md-2 control-label text-left">Description:</label>
                 <div class="col-md-2">

--- a/server/api/swagger.yaml
+++ b/server/api/swagger.yaml
@@ -2607,8 +2607,6 @@ definitions:
         type: integer
       DeploymentMap:
         type: string
-      CodeDeployBucket:
-        type: string
       IsLocked:
         type: boolean
   EnvironmentTypeConfig:

--- a/server/test/commandHandlers/GetAccountByEnvironmentTest.js
+++ b/server/test/commandHandlers/GetAccountByEnvironmentTest.js
@@ -8,31 +8,30 @@ let assert = require('assert');
 let sinon = require('sinon');
 
 const CANNED_ENVIRONMENT = {
-  OwningCluster:"Code to Joy",
-  Description:"A Mock Environment",
-  EnvironmentType:"MockEnvironmentType",
-  SchemaVersion:1,
-  DeploymentMap:"MockDepMap",
-  CodeDeployBucket:"mock-codedeploy-bucket"
+  OwningCluster: "Code to Joy",
+  Description: "A Mock Environment",
+  EnvironmentType: "MockEnvironmentType",
+  SchemaVersion: 1,
+  DeploymentMap: "MockDepMap"
 };
 
 const CANNED_ENV_TYPE = {
-  DeploymentBucket:"tl-deployment-mock",
+  DeploymentBucket: "tl-deployment-mock",
   Consul:{
-    SecurityTokenPath:{
-      Key:"path/to/configuration.json",
-      Bucket:"tl-bucket-mock"
+    SecurityTokenPath: {
+      Key: "path/to/configuration.json",
+      Bucket: "tl-bucket-mock"
     },
-    Port:8500,
-    Servers:[],
-    DataCenter:"mock-dc"
+    Port: 8500,
+    Servers: [],
+    DataCenter: "mock-dc"
   },
-  LoadBalancers:[],
-  Subnets:{},
-  SchemaVersion:2,
-  AWSAccountNumber:9012342345664,
-  VpcId:"vpc-dfgh4f5g",
-  AWSAccountName:"MockAccount"
+  LoadBalancers: [],
+  Subnets: {},
+  SchemaVersion: 2,
+  AWSAccountNumber: 9012342345664,
+  VpcId: "vpc-dfgh4f5g",
+  AWSAccountName: "MockAccount"
 };
 
 describe('GetAccountByEnvironment', function() {


### PR DESCRIPTION
That removes CodeDeployBucket property from Environment object.

Please not that this doesn't affect existing data structures.

CodeDeployBucket property was previously used by Footplate to decide where to put deployed CodeDeploy packages.