### PR TITLE
Only expand volume size to fit required AMI

### DIFF
--- a/client/app/configuration/deployment-maps/DeploymentMapTargetController.js
+++ b/client/app/configuration/deployment-maps/DeploymentMapTargetController.js
@@ -248,7 +248,7 @@ angular.module('EnvironmentManager.configuration').controller('DeploymentMapTarg
       instance.result.then(function (selectedAmi) {
         vm.target.ASG.LaunchConfig.AMI = selectedAmi.displayName;
         vm.requiredImageSize = selectedAmi.rootVolumeSize;
-        vm.target.ASG.LaunchConfig.Volumes[0].Size = selectedAmi.rootVolumeSize;
+        vm.target.ASG.LaunchConfig.Volumes[0].Size = _.max([vm.requiredImageSize, vm.target.ASG.LaunchConfig.Volumes[0].Size]);
       });
     };
 

--- a/client/app/environments/dialogs/ASGDetailsModalController.js
+++ b/client/app/environments/dialogs/ASGDetailsModalController.js
@@ -250,7 +250,7 @@ angular.module('EnvironmentManager.environments').controller('ASGDetailsModalCon
       instance.result.then(function (selectedAmi) {
         vm.target.ASG.LaunchConfig.AMI = selectedAmi.displayName;
         vm.requiredImageSize = selectedAmi.rootVolumeSize;
-        vm.target.ASG.LaunchConfig.Volumes[0].Size = selectedAmi.rootVolumeSize;
+        vm.target.ASG.LaunchConfig.Volumes[0].Size = _.max([vm.requiredImageSize, vm.target.ASG.LaunchConfig.Volumes[0].Size]);
         launchConfigForm.$setDirty(true);
       });
     };


### PR DESCRIPTION
> When selecting an AMI in the server role / ASG settings dialog, we automatically set the OS volume size to the minimum required by the image.
> 
> There are some situations where OS volume needs to be larger than the minimum image size, for example when 3rd party components need to be installed into the main OS volume.
> 
> Therefore, when selecting an AMI we should only update the OS Volume size if it is not already large enough for the image.
> 
> _Duncan Hall, Senior Engineer at Trainline_

Don’t shrink volume size when it’s bigger than selected AMI's required minimal size.