### PR TITLE
Add logout implementation for non prod deployment

### DIFF
--- a/server/modules/user-service/index.js
+++ b/server/modules/user-service/index.js
@@ -9,7 +9,7 @@ let implementation;
 if (config.get('IS_PRODUCTION')) {
   implementation = new (require('./userService.prod'))();
 } else {
-  implementation = new (require('./userService.mock'))();
+  implementation = require('./userService.mock');
 }
 
 module.exports = implementation;

--- a/server/modules/user-service/userService.mock.js
+++ b/server/modules/user-service/userService.mock.js
@@ -5,41 +5,41 @@
 let ms = require('ms');
 let User = require('modules/user');
 let utils = require('modules/utilities');
-
 let ActiveDirectoryError = require('modules/errors/ActiveDirectoryError.class');
 
-module.exports = function UserService() {
-  this.authenticateUser = (credentials, duration) => {
-    if (!credentials.username) {
-      return Promise.reject(new Error('User must belong to "corp" domain.'));
-    }
+function authenticateUser(credentials, duration) {
+  if (!credentials.username) {
+    return Promise.reject(new Error('User must belong to "corp" domain.'));
+  }
+  let name = credentials.username.toLowerCase().replace('corp\\', '');
+  let groups = [];
+  let permissions = [{ Access: 'ADMIN', Resource: '**' }];
+  let expiration = getExpiration(duration);
+  let user = User.new(name, expiration, groups, permissions);
+  let userJson = JSON.stringify(user.toJson());
+  return Promise.resolve(new Buffer(userJson).toString('base64'));
+}
 
-    let name = credentials.username.toLowerCase().replace('corp\\', '');
-    let groups = [];
-    let permissions = [{ Access: 'ADMIN', Resource: '**' }];
-    let expiration = getExpiration(duration);
-    let user = User.new(name, expiration, groups, permissions);
+function getUserByToken(token) {
+  let userJson = new Buffer(token, 'base64').toString('utf8');
+  let data = utils.safeParseJSON(userJson);
+  if (!data) return Promise.reject(new ActiveDirectoryError('Wrong cookie'));
+  return Promise.resolve(User.new(data.name, data.expiration, data.groups, data.permissions));
+}
 
-    let userJson = JSON.stringify(user.toJson());
-    return Promise.resolve(new Buffer(userJson).toString('base64'));
-  };
-
-  this.getUserByToken = (token) => {
-    let userJson = new Buffer(token, 'base64').toString('utf8');
-    let data = utils.safeParseJSON(userJson);
-
-    if (!data) return Promise.reject(new ActiveDirectoryError('Wrong cookie'));
-
-    return Promise.resolve(User.new(data.name, data.expiration, data.groups, data.permissions));
-  };
-};
-
+function signOut(encryptedToken) {
+  return Promise.resolve();
+}
 
 function getExpiration(duration) {
   let durationMs = ms(duration);
-
   let dateNow = new Date();
   let dateEnd = new Date(dateNow.setMilliseconds(dateNow.getMilliseconds() + durationMs));
-
   return dateEnd.getTime();
 }
+
+module.exports = {
+  authenticateUser,
+  getUserByToken,
+  signOut
+};


### PR DESCRIPTION
Our "mock" implementation of the user service did not include a logout implementation. This fixes that.