### PR TITLE
Widen maintenance input to allow new instance id

### DIFF
--- a/client/app/operations/maintenance/ops-maintenance-addserver-modal.html
+++ b/client/app/operations/maintenance/ops-maintenance-addserver-modal.html
@@ -21,7 +21,7 @@
         class="form-control"
         required=""
         autofocus
-        maxlength="15"
+        maxlength="19"
         ng-model="vm.serverSearch"
         ng-readonly="!canUser('edit')" />
       </div>


### PR DESCRIPTION
New AWS instance ids are up to 19 characters long