### PR TITLE
Ports behaviour resolved.

### DIFF
--- a/client/app/configuration/em-services/ServiceController.js
+++ b/client/app/configuration/em-services/ServiceController.js
@@ -25,12 +25,18 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
       blue: {
         existing: null,
         taken: false,
-        current: null
+        current: null,
+        button: {
+          enabled: true
+        }
       },
       green: {
         existing: null,
         taken: false,
-        current: null
+        current: null,
+        button: {
+          enabled: true
+        }
       },
       used: []
     };
@@ -190,17 +196,22 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
           break;
         }
       }
+      if (!port) {
+        return 'No Free Ports Available.';
+      }
       return port;
     }
 
     vm.getNextFreeGreenPort = function () {
+      vm.ports.green.button.enabled = false;
       setGreenPortNumber(vm.getUnusedPort());
-      checkGreenPort();
+      vm.checkPorts();
     };
 
     vm.getNextFreeBluePort = function () {
+      vm.ports.blue.button.enabled = false;
       setBluePortNumber(vm.getUnusedPort());
-      checkBluePort();
+      vm.checkPorts();
     };
 
     vm.checkPorts = function () {
@@ -221,8 +232,16 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
       }
     }
 
+    vm.resetGreenPortButton = function () {
+      vm.ports.green.button.enabled = true;
+    };
+
+    vm.resetBluePortButton = function () {
+      vm.ports.blue.button.enabled = true;
+    }
+
     function checkBluePort() {
-      if(vm.ports.blue.existing.indexOf(vm.service.Value.BluePort) !== -1 
+      if(vm.ports.used.indexOf(vm.service.Value.BluePort) !== -1 
           && vm.service.Value.BluePort !== vm.ports.blue.current) {
         vm.ports.blue.taken = true;
       } else {
@@ -231,7 +250,7 @@ angular.module('EnvironmentManager.configuration').controller('ServiceController
     }
 
     function checkGreenPort() {
-      if(vm.ports.green.existing.indexOf(vm.service.Value.GreenPort) !== -1 
+      if(vm.ports.used.indexOf(vm.service.Value.GreenPort) !== -1 
           && vm.service.Value.GreenPort !== vm.ports.green.current) {
         vm.ports.green.taken = true;
       } else {

--- a/client/app/configuration/em-services/service.html
+++ b/client/app/configuration/em-services/service.html
@@ -101,10 +101,16 @@
                    min="40000"
                    max="41000"
                    ng-readonly="!vm.canUser('edit')"
-                   ng-change="vm.checkPorts()" />
+                   ng-change="vm.checkPorts(); vm.resetBluePortButton()" />
 
                 <span class="input-group-btn">
-                    <button class="btn btn-default" type="button" ng-click="vm.getNextFreeBluePort()">Get Free Port <span class="glyphicon glyphicon-step-forward"></span></button>
+                    <button class="btn btn-default" 
+                        title="Get the next, lowest available port number."
+                        ng-disabled="!vm.ports.blue.button.enabled" 
+                        type="button" 
+                        ng-click="vm.getNextFreeBluePort()">
+                            Get Available Port <span class="glyphicon glyphicon-step-forward"></span>
+                        </button>
                 </span>
             </div>
         </div>
@@ -125,10 +131,16 @@
                    min="40000"
                    max="41000"
                    ng-readonly="!vm.canUser('edit')"
-                   ng-change="vm.checkPorts()" />
+                   ng-change="vm.checkPorts(); vm.resetGreenPortButton()" />
 
                 <span class="input-group-btn">
-                    <button class="btn btn-default" type="button" ng-click="vm.getNextFreeGreenPort()">Get Free Port <span class="glyphicon glyphicon-step-forward"></span></button>
+                    <button class="btn btn-default"
+                        title="Get the next, lowest available port number." 
+                        ng-disabled="!vm.ports.green.button.enabled" 
+                        type="button" 
+                        ng-click="vm.getNextFreeGreenPort()">
+                            Get Available Port <span class="glyphicon glyphicon-step-forward"></span>
+                    </button>
                 </span>
             </div>
         </div>


### PR DESCRIPTION
Buttons to get next free port will now be disabled once used, until the control is changed manually by the user. If they change it, they will be able to select the next free port again. 

There is a change to the wording of the button and a title to try and better explain to the user what port number they will receive from this. 

A check has been added to provide something a little more intuitive when a range is totally full and they can't automatically select a port number. If this is the case though, there are probably bigger concerns. 