### PR TITLE
Don’t allow desired size 0 in deployment map

### DIFF
--- a/client/app/common/launch-config/asg-size.html
+++ b/client/app/common/launch-config/asg-size.html
@@ -4,7 +4,7 @@
     <label class="control-label text-left nonbold inline">Min:</label>
     <input class="form-control inline" type="number" name="MinInstances" min="0" max="100" step="1" required="" ng-model="vm.target.ASG.MinCapacity" ng-readonly="!vm.canUser('edit')" />
     <label class="control-label text-left nonbold inline">Desired:</label>
-    <input class="form-control inline" name="NumberOfInstances" type="number" min="0" max="100" step="1" required="" ng-model="vm.target.ASG.DesiredCapacity" ng-readonly="!vm.canUser('edit')" />
+    <input class="form-control inline" name="NumberOfInstances" type="number" min="1" max="100" step="1" required="" ng-model="vm.target.ASG.DesiredCapacity" ng-readonly="!vm.canUser('edit')" />
     <label class="control-label text-left nonbold inline">Max:</label>
     <input class="form-control inline" name="MaxInstances" type="number" min="0" max="100" step="1" required="" ng-model="vm.target.ASG.MaxCapacity" ng-readonly="!vm.canUser('edit')" />
   </div>


### PR DESCRIPTION
Should not be possible to set Desired Size to 0 in Deployment Map.

I'm leaving the possibility of people setting desired to 0 on runtime ASG.

https://jira.thetrainline.com/browse/PD-113