### PR TITLE
Add account number to Environment config response

### DIFF
--- a/server/api/controllers/config/environments/environmentsConfigController.js
+++ b/server/api/controllers/config/environments/environmentsConfigController.js
@@ -19,7 +19,7 @@ let EnvironmentType = require('models/EnvironmentType');
 
 function attachMetadata(input) {
   return EnvironmentType.getByName(input.Value.EnvironmentType)
-    .then(environmentType => {
+    .then((environmentType) => {
       input.AWSAccountNumber = environmentType.AWSAccountNumber;
       return input;
     });
@@ -38,7 +38,7 @@ function getEnvironmentsConfig(req, res, next) {
   };
   filter = _.omitBy(filter, _.isUndefined);
 
-  return environmentTable.getAll(filter).then((arr) => Promise.all(arr.map(attachMetadata))).then(data => res.json(data)).catch(next);
+  return environmentTable.getAll(filter).then(arr => Promise.all(arr.map(attachMetadata))).then(data => res.json(data)).catch(next);
 }
 
 /**

--- a/server/api/swagger.yaml
+++ b/server/api/swagger.yaml
@@ -2587,6 +2587,8 @@ definitions:
     properties:
       EnvironmentName:
         type: string
+      AWSAccountNumber:
+        type: string
       Value:
         $ref: '#/definitions/EnvironmentConfigValue'
   EnvironmentConfigValue:


### PR DESCRIPTION
This change adds a property named `AWSAccountNumber` to each environment type in the response from the following API endpoints:

- GET /api/v1/config/environment-types
- GET /api/v1/config/environment-types/{name}

https://jira.thetrainline.com/browse/PD-108