### PR TITLE
Fix deployment of existing package

### DIFF
--- a/server/commands/deployments/DeployService.js
+++ b/server/commands/deployments/DeployService.js
@@ -55,7 +55,7 @@ module.exports = function DeployServiceCommandHandler(command) {
 
 function validateCommandAndCreateDeployment(command) {
   return co(function* () {
-    const { mode, packagePath, environmentName, serviceSlice, serviceName, serviceVersion } = command;
+    const { mode, environmentName, serviceSlice, serviceName, serviceVersion } = command;
 
     if (mode === 'overwrite' && serviceSlice !== undefined && serviceSlice !== 'none') {
       throw new Error('Slice must be set to \'none\' in overwrite mode.');
@@ -67,7 +67,7 @@ function validateCommandAndCreateDeployment(command) {
       throw new Error(`Unknown slice \'${serviceSlice}\'. Supported slices are: ${SupportedSliceNames.join(', ')}`);
     }
 
-    if (!packagePath) {
+    if (!command.packagePath) {
       let s3Package;
       try {
         s3Package = yield s3PackageLocator.findDownloadUrl({
@@ -86,7 +86,7 @@ function validateCommandAndCreateDeployment(command) {
       }
     }
 
-    command.packageType = validUrl.isUri(packagePath) ?
+    command.packageType = validUrl.isUri(command.packagePath) ?
       Enums.SourcePackageType.CodeDeployRevision :
       Enums.SourcePackageType.DeploymentMap;
 

--- a/server/test/.eslintrc.js
+++ b/server/test/.eslintrc.js
@@ -3,6 +3,8 @@ module.exports = {
     'mocha': true
   },
   'rules': {
-    'no-warning-comments': 1
+    'no-warning-comments': 1,
+    'no-warning-comments': 1,
+    'prefer-arrow-callback': 0
   }
 };


### PR DESCRIPTION
This change fixes discrimination between _CodeDeployRevision_ and _DeploymentMap_ package types. The root cause of the issue was [DeployService](https://github.com/trainline/environment-manager/compare/fix/deploy-wrong-type?expand=1#diff-b70226303724080a61bca59bdd3200d2) incorrectly inferring that packages already present in S3 were of type _DeploymentMap_; they are always of type _CodeDeployRevision_

https://jira.thetrainline.com/projects/PLATFORM/queues/issue/PLATFORM-590