### PR TITLE
service paging functionality now on audit history page

### DIFF
--- a/client/app/configuration/audit/AuditController.js
+++ b/client/app/configuration/audit/AuditController.js
@@ -29,6 +29,33 @@ angular.module('EnvironmentManager.configuration').controller('AuditController',
 
     $scope.Data = [];
 
+    vm.currentPage = 1;
+    vm.fullData;
+    vm.data;
+    vm.filteredData = [];
+    vm.itemsPerPage = 20;
+
+    vm.updatePagedData = function updatePagedData() {
+      vm.data = vm.filteredData.slice(vm.itemsPerPage * (vm.currentPage - 1), vm.itemsPerPage * vm.currentPage);
+    };
+
+    vm.updateFilter = function updateFilter() {
+      vm.currentPage = 1;
+      vm.filteredData = vm.fullData.filter(function (audit) {
+        var entityKey = angular.lowercase($scope.SelectedEntityKey);
+        var auditKey = angular.lowercase(audit.Entity.Key);
+
+        return (entityKey === '' || auditKey.indexOf(entityKey) != -1)
+      });
+
+      vm.updatePagedData();
+    };
+
+    function configureFiltering() {
+      vm.fullData = $scope.Data;
+      vm.updateFilter();
+    }
+
     $scope.EntityTypesList = [];
     $scope.ChangeTypesList = [];
     $scope.DateRangeList = [
@@ -169,6 +196,7 @@ angular.module('EnvironmentManager.configuration').controller('AuditController',
 
         return audit;
       });
+
       $scope.DataLoading = false;
     }
 

--- a/client/app/configuration/audit/audit.html
+++ b/client/app/configuration/audit/audit.html
@@ -12,19 +12,19 @@
     <label class="control-label text-left">Date:</label>
   </div>
   <div class="form-group">
-    <select class="form-control" ng-model="SelectedDateRangeValue" ng-options="d.Value as d.Name for d in DateRangeList"></select>
+    <select class="form-control" ng-change="vm.refresh()" ng-model="SelectedDateRangeValue" ng-options="d.Value as d.Name for d in DateRangeList"></select>
   </div>
   <div class="form-group">
     <label class="control-label text-left">Entity Type:</label>
   </div>
   <div class="form-group">
-    <select class="form-control" ng-model="SelectedEntityType" ng-options="e.Value as e.Name for e in EntityTypesList"></select>
+    <select class="form-control" ng-change="vm.refresh()" ng-model="SelectedEntityType" ng-options="e.Value as e.Name for e in EntityTypesList"></select>
   </div>
   <div class="form-group">
     <label class="control-label text-left">Change Type:</label>
   </div>
   <div class="form-group">
-    <select class="form-control" ng-model="SelectedChangeType">
+    <select class="form-control" ng-change="vm.refresh()" ng-model="SelectedChangeType">
       <option ng-repeat="changeType in ChangeTypesList" ng-selected="{{changeType == SelectedChangeType}}" value="{{changeType}}">{{changeType}}</option>
     </select>
   </div>
@@ -32,7 +32,7 @@
     <label class="control-label text-left">ID / Name:</label>
   </div>
   <div class="form-group">
-    <input type="search" name="EntityName" class="form-control" ng-model="SelectedEntityKey" />
+    <input type="search" ng-change="vm.updateFilter()" name="EntityName" class="form-control" ng-model="SelectedEntityKey" />
   </div>
   <div class="form-group" ng-if="SelectedEntityHasRange()">
     <label class="control-label text-left">Range:</label>
@@ -42,9 +42,6 @@
   </div>
   <div class="form-group">
     <button type="button" class="btn btn-default right" ng-click="vm.refresh()">Show Audits</button>
-  </div>
-  <div class="form-group" ng-if="hasNextPage">
-    <button type="button" class="btn btn-default right" ng-click="getPage(nextPage);">Next Page</button>
   </div>
 </form>
 
@@ -56,7 +53,8 @@
   <div class="col-md-12" ng-if="Data.length == 0 && SearchPerformed">
     <p>No matching audit records found.</p>
   </div>
-  <div class="col-md-12" ng-if="Data.length > 0">
+  <ul style="margin: 3px 0px" ng-if="vm.data.length > 0" uib-pagination total-items="vm.filteredData.length" ng-model="vm.currentPage" items-per-page="vm.itemsPerPage" max-size="10" class="pagination-sm" boundary-link-numbers="true" ng-change="vm.updatePagedData()"></ul>
+  <div class="col-md-12">
     <table class="table" id="AuditHistory" style="table-layout: fixed">
       <thead>
         <tr>
@@ -69,7 +67,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr ng-repeat="audit in Data | orderBy: '-Timestamp'">
+        <tr ng-repeat="audit in vm.data | orderBy: '-Timestamp'">
           <td style="overflow: hidden">
             <p>
               <span am-time-ago="audit.Timestamp"></span><br />


### PR DESCRIPTION
Added the same paging widget from Services page to the Audit page. 

Added required variables for the paging widget to work. Created some 'helper' variables so that looking between audit and service controllers looks the same - working with "vm.fullData" etc for this widget. 

