### PR TITLE
Fix Express Application Initialisation Race Condition

### DIFF
--- a/server/api/error-handler/defaultErrorHandler.js
+++ b/server/api/error-handler/defaultErrorHandler.js
@@ -35,7 +35,6 @@ function defaultErrorHandler(err, req, res, next) {
     };
   }
 
-  logger.error(err.stack);
   res.json(friendlyError);
 }
 

--- a/server/modules/express-middleware/configureExpressWinston.js
+++ b/server/modules/express-middleware/configureExpressWinston.js
@@ -25,7 +25,7 @@ function loggerOptions({ requestWhitelist }) {
    * Only log requests if the corresponding response has a non-success status code
    */
   function skip(req, res) {
-    return res.statusCode <= 400;
+    return res && typeof res.statusCode === 'number' && res.statusCode <= 400;
   }
 
   /**

--- a/server/modules/express-middleware/swaggerAuthorizerMiddleware.js
+++ b/server/modules/express-middleware/swaggerAuthorizerMiddleware.js
@@ -1,0 +1,30 @@
+/* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
+
+'use strict';
+
+let _ = require('lodash');
+let authorization = require('modules/authorization');
+
+function authorize(req, res, next) {
+  if (req.swagger === undefined) {
+    next();
+    return;
+  }
+
+  let authorizerName = req.swagger.operation['x-authorizer'] || 'simple';
+  let authorizer = require(`modules/authorizers/${authorizerName}`);
+
+  // We need to rewrite this for authorizers to work with swagger
+  // TODO(filip): remove this once we move to v1 API and drop old one
+  _.each(req.swagger.params, (param, key) => {
+    req.params[key] = param.value;
+  });
+
+  if (req.url !== '/token' && req.url !== '/login' && req.url !== '/logout') {
+    authorization(authorizer, req, res, next);
+  } else {
+    next();
+  }
+}
+
+module.exports = () => authorize;


### PR DESCRIPTION
This change fixes a race condition in Express application initialisation, which caused unpredictable logging behaviour.

The order of calls to [`app.use`](https://expressjs.com/en/4x/api.html#app.use) determines how the Express application is initialised.

[`v1.setup(app)`](https://github.com/trainline/environment-manager/compare/trainline:e99252d...Merlin-Taylor:af8c281#diff-e2c8aa269def6d2326cb2b81cab3498dL87) called `app.use` from inside a callback, making it impossible to guarantee the order of calls to `app.use`.

This change locates all calls to `app.use` within [`MainServer.createExpressApp`](https://github.com/trainline/environment-manager/compare/trainline:e99252d...Merlin-Taylor:af8c281#diff-09d0e1318515b923fdccea8b3d35d38bL29) so that the order of calls is clearly visible.