### PR TITLE
Fix/audit history paging

### DIFF
--- a/server/api/controllers/audit/auditController.js
+++ b/server/api/controllers/audit/auditController.js
@@ -23,7 +23,7 @@ function createAuditLogQuery(since, until, exclusiveStartKey, perPage, filter) {
     minDate: since.toString()
   };
   if (perPage) {
-    rq.limit = perPage || 10;
+    rq.limit = perPage;
   }
   if (exclusiveStartKey) {
     rq.exclusiveStartKey = exclusiveStartKey;

--- a/server/api/controllers/audit/auditController.js
+++ b/server/api/controllers/audit/auditController.js
@@ -19,10 +19,12 @@ let url = require('url');
 
 function createAuditLogQuery(since, until, exclusiveStartKey, perPage, filter) {
   let rq = {
-    limit: perPage || 10,
     maxDate: until.toString(),
     minDate: since.toString()
   };
+  if (perPage) {
+    rq.limit = perPage || 10;
+  }
   if (exclusiveStartKey) {
     rq.exclusiveStartKey = exclusiveStartKey;
   }

--- a/server/api/swagger.yaml
+++ b/server/api/swagger.yaml
@@ -292,6 +292,10 @@ paths:
           type: string
           format: date-time
           required: false
+        - name: per_page
+          in: query
+          type: integer
+          required: false
       responses:
         200:
           description: A list of Audit logs


### PR DESCRIPTION
- Stop the audit controller adding a limit if there isn't a limit provided. With the new filtering widget on this page (taken from services), we want to get all the data matching the query. 

- Added the "per_page" parameter to Swagger to make it clear to people using the API that it exists!