### PR TITLE
Support log messages longer than 2048 characters

### DIFF
--- a/server/deployment/code-deploy/on-after-install.sh
+++ b/server/deployment/code-deploy/on-after-install.sh
@@ -9,3 +9,5 @@ cp -f ${SRC_FILE} ${TARGET_FILE}
 chmod 644 ${TARGET_FILE}
 
 chown root.root ${TARGET_FILE}
+
+chmod 755 /opt/environment-manager/environment-manager

--- a/server/deployment/systemd/environment-manager.service
+++ b/server/deployment/systemd/environment-manager.service
@@ -1,11 +1,14 @@
+[Unit]
+After=systemd-journald.socket
+
 [Service]
 EnvironmentFile=/etc/environment-manager.env
 WorkingDirectory=/opt/environment-manager/
-ExecStart=/usr/bin/node index.js mode=Release
+ExecStart=/opt/environment-manager/environment-manager
 
 Restart=always
-StandardOutput=syslog
-StandardError=syslog
+StandardOutput=null
+StandardError=null
 SyslogIdentifier=environment-manager
 
 [Install]

--- a/server/environment-manager
+++ b/server/environment-manager
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+log_each_line() {
+while read line
+do
+	/usr/bin/logger --journald <<-EOM
+		SYSLOG_IDENTIFIER=environment-manager
+		MESSAGE=$line
+	EOM
+done
+}
+
+
+/usr/bin/node index.js mode=Release 2>&1 | log_each_line

--- a/server/gulpfile.js
+++ b/server/gulpfile.js
@@ -9,6 +9,7 @@ function build() {
   let output = argv.o || './build';
 
   return gulp.src([
+    'environment-manager',
     '*api/**/*',
     '*commands/**/*',
     '*config/**/*',

--- a/server/index.js
+++ b/server/index.js
@@ -2,12 +2,12 @@
 
 'use strict';
 
+if (process.env.NEW_RELIC_APP_NAME !== undefined) {
+  require('newrelic'); // This line must be executed before any other call to require()
+}
+
 // Replace NodeJS built-in Promise with Bluebird Promise
 global.Promise = require('bluebird');
-
-if (process.env.NEW_RELIC_APP_NAME !== undefined) {
-  require('newrelic');
-}
 
 require('app-module-path').addPath(__dirname);
 

--- a/server/modules/express-middleware/configureExpressWinston.js
+++ b/server/modules/express-middleware/configureExpressWinston.js
@@ -27,7 +27,7 @@ function dynamicMeta(req, res) {
  */
 function requestFilter(req, propName) {
   if (propName === 'headers') {
-    return fp.omit(['authorization'])(req[propName]);
+    return fp.omit(['authorization', 'cookie'])(req[propName]);
   }
   return req[propName];
 }


### PR DESCRIPTION
This change works around a [systemd limitation](https://bugs.freedesktop.org/show_bug.cgi?id=86465) that splits log lines at 2048 characters. This renders long JSON messages un-parseable and prevents them from being propagated along our [logging pipeline](https://wiki.thetrainline.com/display/ELK/Linux+logging)

Messages are no longer emitted on standard output by the service and processed by `systemd`. Instead, messages are piped directly to `logger --journald`, avoiding the line length limit imposed by the former.

https://jira.thetrainline.com/browse/PD-133