### PR TITLE
Feature/get rid of config set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ server/configuration.json
 server/configuration.js
 
 .vscode
+.flowconfig
 dist/
 build/
 /Lambda/**/*.zip

--- a/server/api/api-utils/DynamoHelper.js
+++ b/server/api/api-utils/DynamoHelper.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const masterAccountName = require('config').getUserValue('masterAccountName');
 const exposeAudit = 'version-only';
 
 let getAllValues = require('queryHandlers/ScanDynamoResources');
@@ -13,6 +12,7 @@ let updateValue = require('commands/resources/UpdateDynamoResource');
 let createValue = require('commands/resources/CreateDynamoResource');
 let deleteValue = require('commands/resources/DeleteDynamoResource');
 let metadata = require('commands/utils/metadata');
+let awsAccounts = require('modules/awsAccounts');
 
 // TODO(Filip): once we move all tables to one master account, we can remove all options.accountName
 // and do all operations on masterAccount
@@ -30,88 +30,117 @@ class DynamoHelper {
    * Get all resources in a Dynamo table
    */
   getAll(filter, options = {}) {
-    let accountName = options.accountName || masterAccountName;
-    return getAllValues({ resource: this.resource, exposeAudit, accountName, filter });
+    return awsAccounts.getMasterAccountName()
+      .then((masterAccountName) => {
+        let accountName = options.accountName || masterAccountName;
+        return getAllValues({ resource: this.resource, exposeAudit, accountName, filter });
+      });
   }
 
   /**
    * Get a specific resource from a Dynamo table
    */
   getByKey(key, options = {}) {
-    let accountName = options.accountName || masterAccountName;
-    return getValue({ resource: this.resource, key, exposeAudit, accountName });
+    return awsAccounts.getMasterAccountName()
+      .then((masterAccountName) => {
+        let accountName = options.accountName || masterAccountName;
+        return getValue({ resource: this.resource, key, exposeAudit, accountName });
+      });
   }
 
   /**
    * Get a specific resource from a Dynamo table that has includes sort key
    */
   getBySortKey(partitionKey, sortKey, options = {}) {
-    let accountName = options.accountName || masterAccountName;
-    return getValue({ key: partitionKey, range: sortKey, resource: this.resource, exposeAudit, accountName });
+    return awsAccounts.getMasterAccountName()
+      .then((masterAccountName) => {
+        let accountName = options.accountName || masterAccountName;
+        return getValue({ key: partitionKey, range: sortKey, resource: this.resource, exposeAudit, accountName });
+      });
   }
 
   /**
    * Query resources from a Dynamo table with partition key
    */
   queryRangeByKey(partitionKey, options = {}) {
-    let accountName = options.accountName || masterAccountName;
-    return queryRange({ key: partitionKey, resource: this.resource, exposeAudit, accountName });
+    return awsAccounts.getMasterAccountName()
+      .then((masterAccountName) => {
+        let accountName = options.accountName || masterAccountName;
+        return queryRange({ key: partitionKey, resource: this.resource, exposeAudit, accountName });
+      });
   }
 
   /**
    * Create a resource in a Dynamo table
    */
   create(key, item, user, options = {}) {
-    let accountName = options.accountName || masterAccountName;
-    const newItem = metadata.addMetadata({ resource: this.resource, key, item, accountName, user });
-    return createValue(newItem);
+    return awsAccounts.getMasterAccountName()
+      .then((masterAccountName) => {
+        let accountName = options.accountName || masterAccountName;
+        const newItem = metadata.addMetadata({ resource: this.resource, key, item, accountName, user });
+        return createValue(newItem);
+      });
   }
 
   /**
    * Create a resource in a Dynamo table that includes a sort key
    */
   createWithSortKey(partitionKey, sortKey, item, user, options = {}) {
-    let accountName = options.accountName || masterAccountName;
-    const newItem = metadata.addMetadata({ key: partitionKey, range: sortKey, resource: this.resource, item, accountName, user });
-    return createValue(newItem);
+    return awsAccounts.getMasterAccountName()
+      .then((masterAccountName) => {
+        let accountName = options.accountName || masterAccountName;
+        const newItem = metadata.addMetadata({ key: partitionKey, range: sortKey, resource: this.resource, item, accountName, user });
+        return createValue(newItem);
+      });
   }
 
   /**
    * Update (replace) a single Dynamo resource
    */
   update(key, item, expectedVersion, user, options = {}) {
-    let accountName = options.accountName || masterAccountName;
-    const updatedItem = metadata.addMetadata({ resource: this.resource, key, item, expectedVersion, accountName, user });
-    return updateValue(updatedItem);
+    return awsAccounts.getMasterAccountName()
+      .then((masterAccountName) => {
+        let accountName = options.accountName || masterAccountName;
+        const updatedItem = metadata.addMetadata({ resource: this.resource, key, item, expectedVersion, accountName, user });
+        return updateValue(updatedItem);
+      });
   }
 
   /**
    * Update (replace) a single Dynamo resource in a table that incldudes a sort key
    */
   updateWithSortKey(partitionKey, sortKey, item, expectedVersion, user, options = {}) {
-    let accountName = options.accountName || masterAccountName;
-    const updatedItem = metadata.addMetadata({ key: partitionKey, range: sortKey, resource: this.resource, item, expectedVersion, accountName, user });
-    return updateValue(updatedItem);
+    return awsAccounts.getMasterAccountName()
+      .then((masterAccountName) => {
+        let accountName = options.accountName || masterAccountName;
+        const updatedItem = metadata.addMetadata({ key: partitionKey, range: sortKey, resource: this.resource, item, expectedVersion, accountName, user });
+        return updateValue(updatedItem);
+      });
   }
 
   /**
    * Delete a single item from a Dynamo table
    */
   delete(key, user, options = {}) {
-    let accountName = options.accountName || masterAccountName;
-    const deletedItem = metadata.addMetadata({ resource: this.resource, key, accountName, user });
-    return deleteValue(deletedItem);
+    return awsAccounts.getMasterAccountName()
+      .then((masterAccountName) => {
+        let accountName = options.accountName || masterAccountName;
+        const deletedItem = metadata.addMetadata({ resource: this.resource, key, accountName, user });
+        return deleteValue(deletedItem);
+      });
   }
 
   /**
    * Delete a single item from a Dynamo table that includes a sort key
    */
   deleteWithSortKey(partitionKey, sortKey, user, options = {}) {
-    let accountName = options.accountName || masterAccountName;
-    const deletedItem = metadata.addMetadata({ resource: this.resource, key: partitionKey, range: sortKey, accountName, user });
-    return deleteValue(deletedItem);
+    return awsAccounts.getMasterAccountName()
+      .then((masterAccountName) => {
+        let accountName = options.accountName || masterAccountName;
+        const deletedItem = metadata.addMetadata({ resource: this.resource, key: partitionKey, range: sortKey, accountName, user });
+        return deleteValue(deletedItem);
+      });
   }
-
 }
 
 module.exports = DynamoHelper;

--- a/server/api/controllers/config/export/exportController.js
+++ b/server/api/controllers/config/export/exportController.js
@@ -2,10 +2,8 @@
 
 'use strict';
 
-let config = require('config');
 let ScanDynamoResources = require('queryHandlers/ScanDynamoResources');
-
-const masterAccountName = config.getUserValue('masterAccountName');
+let awsAccounts = require('modules/awsAccounts');
 
 /**
  * GET /config/export/{resource}
@@ -13,12 +11,16 @@ const masterAccountName = config.getUserValue('masterAccountName');
 function getResourceExport(req, res, next) {
   const resourceParam = req.swagger.params.resource.value;
   const account = req.swagger.params.account.value;
-  const accountName = account || masterAccountName;
 
-  let resource = `config/${resourceParam}`;
+  return awsAccounts.getMasterAccountName()
+    .then((masterAccountName) => {
+      const accountName = account || masterAccountName;
 
-  return ScanDynamoResources({ resource, exposeAudit: 'full', accountName })
-    .then(data => res.json(data)).catch(next);
+      let resource = `config/${resourceParam}`;
+
+      return ScanDynamoResources({ resource, exposeAudit: 'full', accountName  })
+        .then(data => res.json(data)).catch(next);
+    });
 }
 
 module.exports = {

--- a/server/commands/aws/AddAWSaccount.js
+++ b/server/commands/aws/AddAWSaccount.js
@@ -2,26 +2,26 @@
 
 'use strict';
 
-let config = require('config');
 let sender = require('modules/sender');
 let awsAccounts = require('modules/awsAccounts');
 let accountValidator = require('../validators/awsAccountValidator');
 
 function AddAWSAccount(command) {
   try {
-    const masterAccountName = config.getUserValue('masterAccountName');
     let account = command.account;
+    return awsAccounts.getMasterAccountName()
+      .then((masterAccountName) => {
+        return accountValidator.validate(account).then((_) => {
+          let dynamoCommand = {
+            name: 'CreateDynamoResource',
+            resource: 'config/accounts',
+            item: account,
+            accountName: masterAccountName
+          };
 
-    return accountValidator.validate(account).then((_) => {
-      let dynamoCommand = {
-        name: 'CreateDynamoResource',
-        resource: 'config/accounts',
-        item: account,
-        accountName: masterAccountName
-      };
-
-      return sender.sendCommand({ command: dynamoCommand, parent: command }).then(awsAccounts.flush);
-    });
+          return sender.sendCommand({ command: dynamoCommand, parent: command }).then(awsAccounts.flush);
+        });
+      });
   } catch (error) {
     return Promise.reject(error);
   }

--- a/server/commands/aws/RemoveAWSaccount.js
+++ b/server/commands/aws/RemoveAWSaccount.js
@@ -2,25 +2,26 @@
 
 'use strict';
 
-let config = require('config');
 let sender = require('modules/sender');
 let awsAccounts = require('modules/awsAccounts');
 let accountValidator = require('../validators/awsAccountValidator');
 
 function RemoveAWSAccount(command) {
   try {
-    const masterAccountName = config.getUserValue('masterAccountName');
 
-    let accountNumber = +command.accountNumber;
-    accountValidator.validateAccountNumber(accountNumber);
+    return awsAccounts.getMasterAccountName()
+      .then((masterAccountName) => {
+        let accountNumber = +command.accountNumber;
+        accountValidator.validateAccountNumber(accountNumber);
 
-    let dynamoCommand = {
-      name: 'DeleteDynamoResource',
-      resource: 'config/accounts',
-      key: accountNumber,
-      accountName: masterAccountName
-    };
-    return sender.sendCommand({ command: dynamoCommand, parent: command }).then(awsAccounts.flush);
+        let dynamoCommand = {
+          name: 'DeleteDynamoResource',
+          resource: 'config/accounts',
+          key: accountNumber,
+          accountName: masterAccountName
+        };
+        return sender.sendCommand({ command: dynamoCommand, parent: command }).then(awsAccounts.flush);
+      });
   } catch (error) {
     return Promise.reject(error);
   }

--- a/server/commands/aws/RemoveAWSaccount.js
+++ b/server/commands/aws/RemoveAWSaccount.js
@@ -8,7 +8,6 @@ let accountValidator = require('../validators/awsAccountValidator');
 
 function RemoveAWSAccount(command) {
   try {
-
     return awsAccounts.getMasterAccountName()
       .then((masterAccountName) => {
         let accountNumber = +command.accountNumber;

--- a/server/commands/aws/UpdateAWSaccount.js
+++ b/server/commands/aws/UpdateAWSaccount.js
@@ -9,19 +9,21 @@ let accountValidator = require('../validators/awsAccountValidator');
 
 function UpdateAWSAccount(command) {
   try {
-    const masterAccountName = config.getUserValue('masterAccountName');
-    let account = command.account;
+    return awsAccounts.getMasterAccountName()
+      .then((masterAccountName) => {
+        let account = command.account;
 
-    return accountValidator.validate(account).then((_) => {
-      let dynamoCommand = {
-        name: 'UpdateDynamoResource',
-        resource: 'config/accounts',
-        item: account,
-        accountName: masterAccountName
-      };
+        return accountValidator.validate(account).then((_) => {
+          let dynamoCommand = {
+            name: 'UpdateDynamoResource',
+            resource: 'config/accounts',
+            item: account,
+            accountName: masterAccountName
+          };
 
-      return sender.sendCommand({ command: dynamoCommand, parent: command }).then(awsAccounts.flush);
-    });
+          return sender.sendCommand({ command: dynamoCommand, parent: command }).then(awsAccounts.flush);
+        });
+      });
   } catch (error) {
     return Promise.reject(error);
   }

--- a/server/commands/aws/UpdateAWSaccount.js
+++ b/server/commands/aws/UpdateAWSaccount.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-let config = require('config');
 let sender = require('modules/sender');
 let awsAccounts = require('modules/awsAccounts');
 let accountValidator = require('../validators/awsAccountValidator');

--- a/server/commands/utils/toggleSlices.js
+++ b/server/commands/utils/toggleSlices.js
@@ -3,17 +3,17 @@
 'use strict';
 
 let co = require('co');
-let config = require('config');
 let sender = require('modules/sender');
 let _ = require('lodash');
 
 let ResourceNotFoundError = require('modules/errors/ResourceNotFoundError.class');
 let InconsistentSlicesStatusError = require('modules/errors/InconsistentSlicesStatusError.class');
+let awsAccounts = require('modules/awsAccounts');
 
 function ToggleUpstreamByServiceVerifier(toggleCommand) {
   this.verifyUpstreams = (upstreams) => {
-    const masterAccountName = config.getUserValue('masterAccountName');
     return co(function* () {
+      let masterAccountName = yield awsAccounts.getMasterAccountName();
       let query = {
         name: 'ScanDynamoResources',
         resource: 'config/services',

--- a/server/index.js
+++ b/server/index.js
@@ -20,6 +20,7 @@ let ConfigurationProvider = require('modules/configuration/ConfigurationProvider
 let checkAppPrerequisites = require('modules/checkAppPrerequisites');
 let cacheManager = require('modules/cacheManager');
 let co = require('co');
+let awsAccounts = require('modules/awsAccounts');
 
 process.on('unhandledRejection', (reason, promise) => {
   logger.warn('Promise rejection was unhandled. ', reason);
@@ -32,8 +33,9 @@ function start() {
     let configurationProvider = new ConfigurationProvider();
     yield configurationProvider.init();
     yield cacheManager.flush();
+    let masterAccountName = yield awsAccounts.getMasterAccountName();
 
-    if (config.getUserValue('masterAccountName') === undefined) {
+    if (masterAccountName === undefined) {
       logger.error('No Master account found. Check the Accounts Dynamo Table.');
       process.exit(1);
     }

--- a/server/models/Service.js
+++ b/server/models/Service.js
@@ -3,10 +3,8 @@
 'use strict';
 
 let _ = require('lodash');
-let config = require('config');
 let sender = require('modules/sender');
-
-const masterAccountName = config.getUserValue('masterAccountName');
+let awsAccounts = require('modules/awsAccounts');
 
 class Service {
 
@@ -15,13 +13,16 @@ class Service {
   }
 
   static getByName(name) {
-    let query = {
-      name: 'ScanDynamoResources',
-      resource: 'config/services',
-      accountName: masterAccountName,
-      filter: { ServiceName: name }
-    };
-    return sender.sendQuery({ query }).then(obj => new Service(obj));
+    return awsAccounts.getMasterAccountName()
+      .then((masterAccountName) => {
+        let query = {
+          name: 'ScanDynamoResources',
+          resource: 'config/services',
+          accountName: masterAccountName,
+          filter: { ServiceName: name }
+        };
+        return sender.sendQuery({ query }).then(obj => new Service(obj));
+      });
   }
 }
 

--- a/server/modules/authorizers/asgs.js
+++ b/server/modules/authorizers/asgs.js
@@ -2,20 +2,21 @@
 
 'use strict';
 
-let config = require('config');
+let awsAccounts = require('modules/awsAccounts');
 
 function getEnvironment(name, user) {
-  const masterAccountName = config.getUserValue('masterAccountName');
+  return awsAccounts.getMasterAccountName()
+    .then((masterAccountName) => {
+      let sender = require('modules/sender');
+      let query = {
+        name: 'GetDynamoResource',
+        key: name,
+        resource: 'config/environments',
+        accountName: masterAccountName
+      };
 
-  let sender = require('modules/sender');
-  let query = {
-    name: 'GetDynamoResource',
-    key: name,
-    resource: 'config/environments',
-    accountName: masterAccountName
-  };
-
-  return sender.sendQuery({ query, user });
+      return sender.sendQuery({ query, user });
+    });
 }
 
 function getModifyPermissionsForEnvironment(environmentName, user) {

--- a/server/modules/authorizers/environments-schedule.js
+++ b/server/modules/authorizers/environments-schedule.js
@@ -3,23 +3,25 @@
 'use strict';
 
 let co = require('co');
-let config = require('config');
 let environmentProtection = require('./environmentProtection');
+let awsAccounts = require('modules/awsAccounts');
 
 const ACTION = environmentProtection.SCHEDULE_ENVIRONMENT;
 
 function getCurrentEnvironment(name, user) {
-  const masterAccountName = config.getUserValue('masterAccountName');
   let sender = require('modules/sender');
 
-  let query = {
-    name: 'GetDynamoResource',
-    key: name,
-    resource: 'config/environments',
-    accountName: masterAccountName
-  };
+  return awsAccounts.getMasterAccountname()
+    .then((masterAccountName) => {
+      let query = {
+        name: 'GetDynamoResource',
+        key: name,
+        resource: 'config/environments',
+        accountName: masterAccountName
+      };
 
-  return sender.sendQuery({ query, user });
+      return sender.sendQuery({ query, user });
+    });
 }
 
 function* getRules(request) {

--- a/server/modules/authorizers/environments.js
+++ b/server/modules/authorizers/environments.js
@@ -3,20 +3,22 @@
 'use strict';
 
 let _ = require('lodash');
-let config = require('config');
+let awsAccounts = require('modules/awsAccounts');
 
 function getCurrentEnvironment(name, user) {
-  const masterAccountName = config.getUserValue('masterAccountName');
-  let sender = require('modules/sender');
+  return awsAccounts.getMasterAccountName()
+    .then((masterAccountName) => {
+      let sender = require('modules/sender');
 
-  let query = {
-    name: 'GetDynamoResource',
-    key: name,
-    resource: 'config/environments',
-    accountName: masterAccountName
-  };
+      let query = {
+        name: 'GetDynamoResource',
+        key: name,
+        resource: 'config/environments',
+        accountName: masterAccountName
+      };
 
-  return sender.sendQuery({ query, user });
+      return sender.sendQuery({ query, user });
+    });
 }
 
 exports.getRules = (request) => {

--- a/server/modules/authorizers/load-balancer-settings.js
+++ b/server/modules/authorizers/load-balancer-settings.js
@@ -2,22 +2,23 @@
 
 'use strict';
 
-﻿let _ = require('lodash');
-let config = require('config');
-
+let _ = require('lodash');
+let awsAccounts = require('modules/awsAccounts');
 
 function getEnvironment(name, user) {
-  const masterAccountName = config.getUserValue('masterAccountName');
-  let sender = require('modules/sender');
+  return awsAccounts.getMasterAccountName()
+    .then((masterAccountName) => {
+      let sender = require('modules/sender');
 
-  let query = {
-    name: 'GetDynamoResource',
-    key: name,
-    resource: 'config/environments',
-    accountName: masterAccountName
-  };
+      let query = {
+        name: 'GetDynamoResource',
+        key: name,
+        resource: 'config/environments',
+        accountName: masterAccountName
+      };
 
-  return sender.sendQuery({ query, user });
+      return sender.sendQuery({ query, user });
+    });
 }
 
 function getModifyPermissionsForEnvironment(environmentName, user) {

--- a/server/modules/authorizers/upstreams.js
+++ b/server/modules/authorizers/upstreams.js
@@ -2,10 +2,10 @@
 
 'use strict';
 
-let config = require('config');
 let co = require('co');
 let Environment = require('models/Environment');
 let logger = require('modules/logger');
+let awsAccounts = require('modules/awsAccounts');
 
 function getUpstream(accountName, upstreamName) {
   let sender = require('modules/sender');
@@ -21,16 +21,18 @@ function getUpstream(accountName, upstreamName) {
 }
 
 function getEnvironment(name) {
-  const masterAccountName = config.getUserValue('masterAccountName');
-  let sender = require('modules/sender');
-  let query = {
-    name: 'GetDynamoResource',
-    key: name,
-    resource: 'config/environments',
-    accountName: masterAccountName
-  };
+  return awsAccounts.getMasterAccountName()
+    .then((masterAccountName) => {
+      let sender = require('modules/sender');
+      let query = {
+        name: 'GetDynamoResource',
+        key: name,
+        resource: 'config/environments',
+        accountName: masterAccountName
+      };
 
-  return sender.sendQuery({ query });
+      return sender.sendQuery({ query });
+    });
 }
 
 function getModifyPermissionsForEnvironment(environmentName) {

--- a/server/modules/awsAccounts.js
+++ b/server/modules/awsAccounts.js
@@ -6,7 +6,6 @@ const TEN_MINUTES = 10 * 60;
 const CACHE_KEY = 'AWSAccounts';
 
 let _ = require('lodash');
-let config = require('config');
 let ResourceNotFoundError = require('modules/errors/ResourceNotFoundError.class');
 let fetchAccounts = require('queryHandlers/GetAWSaccounts');
 let cacheManager = require('modules/cacheManager');

--- a/server/modules/awsAccounts.js
+++ b/server/modules/awsAccounts.js
@@ -47,7 +47,6 @@ function getAllAccounts() {
 
 function flush() {
   accountsCache.flushAll();
-  return getMasterAccount().then(account => config.setUserValue('masterAccountName', account.AccountName));
 }
 
 module.exports = {

--- a/server/modules/awsAccounts.js
+++ b/server/modules/awsAccounts.js
@@ -33,6 +33,10 @@ function getMasterAccount() {
   return getAllAccounts().then(accounts => accounts.find(a => a.IsMaster));
 }
 
+function getMasterAccountName() {
+  return getMasterAccount().then(masterAccount => masterAccount.AccountName);
+}
+
 function getAMIsharingAccounts() {
   return getAllAccounts().then(accounts => accounts.filter(a => a.IncludeAMIs).map(a => a.AccountNumber));
 }
@@ -51,5 +55,6 @@ module.exports = {
   all: getAllAccounts,
   getByName,
   getMasterAccount,
+  getMasterAccountName,
   getAMIsharingAccounts
 };

--- a/server/modules/checkAppPrerequisites.js
+++ b/server/modules/checkAppPrerequisites.js
@@ -1,10 +1,11 @@
 'use strict';
 
 let co = require('co');
-let config = require('config');
 let resourceProvider = require('modules/resourceProvider');
 let logger = require('modules/logger');
 let guid = require('node-uuid');
+let config = require('config');
+let awsAccounts = require('modules/awsAccounts');
 
 let permissionsResource;
 
@@ -58,7 +59,8 @@ function insertDefaultAdminPermission() {
 module.exports = () => {
   return co(function* () {
     if (permissionsResource === undefined) {
-      let parameters = { accountName: config.getUserValue('masterAccountName') };
+      let masterAccountName = yield awsAccounts.getMasterAccountName();
+      let parameters = { accountName: masterAccountName };
       permissionsResource = yield resourceProvider.getInstanceByName('config/permissions', parameters);
     }
     return checkAppPrerequisites();

--- a/server/modules/configuration/ConfigurationProvider.js
+++ b/server/modules/configuration/ConfigurationProvider.js
@@ -25,7 +25,6 @@ module.exports = function ConfigurationProvider() {
     }
 
     return awsAccounts.getMasterAccount()
-      .then(account => config.setUserValue('masterAccountName', account.AccountName))
       .then(loadConfiguration());
   };
 };

--- a/server/modules/environmentDatabase.js
+++ b/server/modules/environmentDatabase.js
@@ -4,47 +4,49 @@
 
 let ConfigurationError = require('modules/errors/ConfigurationError.class');
 let DynamoItemNotFoundError = require('modules/errors/DynamoItemNotFoundError.class');
-let config = require('config');
 let sender = require('modules/sender');
+let awsAccounts = require('modules/awsAccounts');
 
 function getEnvironmentByName(environmentName) {
-  const masterAccountName = config.getUserValue('masterAccountName');
+  return awsAccounts.getMasterAccountName()
+    .then((masterAccountName) => {
+      let query = {
+        name: 'GetDynamoResource',
+        resource: 'config/environments',
+        accountName: masterAccountName,
+        key: environmentName
+      };
 
-  let query = {
-    name: 'GetDynamoResource',
-    resource: 'config/environments',
-    accountName: masterAccountName,
-    key: environmentName
-  };
-
-  return sender
-    .sendQuery({ query })
-    .then(
-      environment => Promise.resolve(environment.Value),
-      error => Promise.reject(error instanceof DynamoItemNotFoundError ?
-        new ConfigurationError(`Environment "${environmentName}" not found.`) :
-        new Error(`An error has occurred retrieving "${environmentName}" environment: ${error.message}`)
-      ));
+      return sender
+        .sendQuery({ query })
+        .then(
+        environment => Promise.resolve(environment.Value),
+        error => Promise.reject(error instanceof DynamoItemNotFoundError ?
+          new ConfigurationError(`Environment "${environmentName}" not found.`) :
+          new Error(`An error has occurred retrieving "${environmentName}" environment: ${error.message}`)
+        ));
+    });
 }
 
 function getEnvironmentTypeByName(environmentTypeName) {
-  const masterAccountName = config.getUserValue('masterAccountName');
+  return awsAccounts.getMasterAccountName()
+    .then((masterAccountName) => {
+      let query = {
+        name: 'GetDynamoResource',
+        resource: 'config/environmenttypes',
+        accountName: masterAccountName,
+        key: environmentTypeName
+      };
 
-  let query = {
-    name: 'GetDynamoResource',
-    resource: 'config/environmenttypes',
-    accountName: masterAccountName,
-    key: environmentTypeName
-  };
-
-  return sender
-    .sendQuery({ query })
-    .then(
-      environmentType => Promise.resolve(environmentType.Value),
-      error => Promise.reject(error instanceof DynamoItemNotFoundError ?
-        new ConfigurationError(`Environment type "${environmentTypeName}" not found.`) :
-        new Error(`An error has occurred retrieving "${environmentTypeName}" environment type: ${error.message}`)
-      ));
+      return sender
+        .sendQuery({ query })
+        .then(
+        environmentType => Promise.resolve(environmentType.Value),
+        error => Promise.reject(error instanceof DynamoItemNotFoundError ?
+          new ConfigurationError(`Environment type "${environmentTypeName}" not found.`) :
+          new Error(`An error has occurred retrieving "${environmentTypeName}" environment type: ${error.message}`)
+        ));
+    });
 }
 
 module.exports = {

--- a/server/modules/queryHandlersUtil/getSlices.js
+++ b/server/modules/queryHandlersUtil/getSlices.js
@@ -6,7 +6,7 @@ let sender = require('modules/sender');
 let co = require('co');
 let _ = require('lodash');
 let ResourceNotFoundError = require('modules/errors/ResourceNotFoundError.class');
-let awsAccounts = require('modules/awsAccounts')
+let awsAccounts = require('modules/awsAccounts');
 
 function hostFilter(active) {
   if (active === true) {

--- a/server/modules/queryHandlersUtil/getSlices.js
+++ b/server/modules/queryHandlersUtil/getSlices.js
@@ -4,9 +4,9 @@
 
 let sender = require('modules/sender');
 let co = require('co');
-let config = require('config');
 let _ = require('lodash');
 let ResourceNotFoundError = require('modules/errors/ResourceNotFoundError.class');
+let awsAccounts = require('modules/awsAccounts')
 
 function hostFilter(active) {
   if (active === true) {
@@ -19,7 +19,7 @@ function hostFilter(active) {
 }
 
 function* handleQuery(query, resourceName, upstreamFilter) {
-  const masterAccountName = config.getUserValue('masterAccountName');
+  const masterAccountName = yield awsAccounts.getMasterAccountName();
 
   // Get all LoadBalancer upstreams from DynamoDB without apply any filter.
   // NOTE: If it ever becomes a DynamoDB map item then filtering this query

--- a/server/modules/sslComponentsRepository/sslComponentsRepository.prod.js
+++ b/server/modules/sslComponentsRepository/sslComponentsRepository.prod.js
@@ -4,7 +4,7 @@
 
 let async = require('async');
 let S3GetObjectRequest = require('modules/S3GetObjectRequest');
-let config = require('config');
+let awsAccounts = require('modules/awsAccounts');
 let amazonClientFactory = require('modules/amazon-client/childAccountClient');
 let sslComponentsCache = null;
 
@@ -28,49 +28,50 @@ module.exports = function SSLComponentsRepository() {
   };
 
   function loadSSLComponentsFromS3(mainCallback) {
-    const masterAccountName = config.getUserValue('masterAccountName');
+    awsAccounts.getMasterAccountName()
+      .then((masterAccountName) => {
+        async.waterfall([
+          // Creates a new instance of S3 client
+          (callback) => {
+            amazonClientFactory.createS3Client(masterAccountName).then(
+              client => callback(null, client),
+              error => callback(error)
+            );
+          },
 
-    async.waterfall([
-      // Creates a new instance of S3 client
-      (callback) => {
-        amazonClientFactory.createS3Client(masterAccountName).then(
-          client => callback(null, client),
-          error => callback(error)
-        );
-      },
+          // SSL private key and certificate files are stored on S3.
+          // Following function creates a couple of request in order to download
+          // these two S3 objects.
+          (client, callback) => {
+            let privateKeyRequestParameters = {
+              bucketName: sslComponentsRepositoryConfiguration.getBucketName(),
+              objectPath: sslComponentsRepositoryConfiguration.getPrivateKeyObjectPath()
+            };
 
-      // SSL private key and certificate files are stored on S3.
-      // Following function creates a couple of request in order to download
-      // these two S3 objects.
-      (client, callback) => {
-        let privateKeyRequestParameters = {
-          bucketName: sslComponentsRepositoryConfiguration.getBucketName(),
-          objectPath: sslComponentsRepositoryConfiguration.getPrivateKeyObjectPath()
-        };
+            let privateKeyRequest = new S3GetObjectRequest(client, privateKeyRequestParameters);
 
-        let privateKeyRequest = new S3GetObjectRequest(client, privateKeyRequestParameters);
+            let certificateRequestParameters = {
+              bucketName: sslComponentsRepositoryConfiguration.getBucketName(),
+              objectPath: sslComponentsRepositoryConfiguration.getCertificateObjectPath()
+            };
 
-        let certificateRequestParameters = {
-          bucketName: sslComponentsRepositoryConfiguration.getBucketName(),
-          objectPath: sslComponentsRepositoryConfiguration.getCertificateObjectPath()
-        };
+            let certificateRequest = new S3GetObjectRequest(client, certificateRequestParameters);
 
-        let certificateRequest = new S3GetObjectRequest(client, certificateRequestParameters);
+            async.parallel({
+              privateKeyS3Object: privateKeyRequest.execute,
+              certificateS3Object: certificateRequest.execute
+            }, callback);
+          },
 
-        async.parallel({
-          privateKeyS3Object: privateKeyRequest.execute,
-          certificateS3Object: certificateRequest.execute
-        }, callback);
-      },
-
-      // Previous function returns a couple of S3 objects. The following one
-      // gets their content.
-      (response, callback) => {
-        callback(null, {
-          privateKey: response.privateKeyS3Object.Body.toString('utf8'),
-          certificate: response.certificateS3Object.Body.toString('utf8')
-        });
-      }
-    ], mainCallback);
+          // Previous function returns a couple of S3 objects. The following one
+          // gets their content.
+          (response, callback) => {
+            callback(null, {
+              privateKey: response.privateKeyS3Object.Body.toString('utf8'),
+              certificate: response.certificateS3Object.Body.toString('utf8')
+            });
+          }
+        ], mainCallback);
+      });
   }
 };

--- a/server/modules/userRolesProvider.js
+++ b/server/modules/userRolesProvider.js
@@ -3,12 +3,10 @@
 'use strict';
 
 let _ = require('lodash');
-let config = require('config');
+let awsAccounts = require('modules/awsAccounts');
 let sender = require('modules/sender');
 
 module.exports = function UserRolesProvider() {
-  const masterAccountName = config.getUserValue('masterAccountName');
-
   this.getPermissionsFor = (names) => {
     if (!names) {
       return Promise.resolve([]);
@@ -57,13 +55,16 @@ module.exports = function UserRolesProvider() {
   };
 
   let getPermissions = function (name) {
-    let query = {
-      accountName: masterAccountName,
-      name: 'ScanDynamoResources',
-      resource: 'config/permissions',
-      filter: { Name: name }
-    };
+    return awsAccounts.getMasterAccountName()
+      .then((masterAccountName) => {
+        let query = {
+          accountName: masterAccountName,
+          name: 'ScanDynamoResources',
+          resource: 'config/permissions',
+          filter: { Name: name }
+        };
 
-    return sender.sendQuery({ query });
+        return sender.sendQuery({ query });
+      });
   };
 };

--- a/server/modules/validate/rule/serviceExists.js
+++ b/server/modules/validate/rule/serviceExists.js
@@ -5,10 +5,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 let log = require('modules/logger'); // eslint-disable import/no-extraneous-dependencies
 let sender = require('modules/sender');
-/* eslint-enable import/no-extraneous-dependencies */
-let config = require('config');
-
-const masterAccountName = config.getUserValue('masterAccountName');
+let awsAccounts = require('modules/awsAccounts');
 
 /* Returns an error in the format specified at http://jsonapi.org/format/#errors
  * if the service does not exist.
@@ -22,15 +19,18 @@ function serviceExists(service) {
     title: 'Duplicate Service Found',
     detail: `service name: ${service}`
   });
-  return sender.sendQuery({
-    query: {
-      accountName: masterAccountName,
-      name: 'ScanDynamoResources',
-      resource: 'config/services',
-      filter: { ServiceName: service }
-    }
-  }).then(
-    (rsp) => {
+  return awsAccounts.getMasterAccountName()
+    .then((masterAccountName) => {
+      return sender.sendQuery({
+        query: {
+          accountName: masterAccountName,
+          name: 'ScanDynamoResources',
+          resource: 'config/services',
+          filter: { ServiceName: service }
+        }
+      });
+    })
+    .then((rsp) => {
       if (rsp.length === 1) {
         return [];
       } else if (rsp.length < 1) {

--- a/server/queryHandlers/GetAWSaccounts.js
+++ b/server/queryHandlers/GetAWSaccounts.js
@@ -5,13 +5,10 @@
 let config = require('config');
 
 function getAwsAccounts(query) {
-  const masterAccountName = config.getUserValue('masterAccountName');
-
   let sender = require('modules/sender');
   let dynamoQuery = {
     name: 'ScanDynamoResources',
-    resource: 'config/accounts',
-    accountName: masterAccountName
+    resource: 'config/accounts'
   };
   let childQuery = { query: dynamoQuery, parent: query };
   if (query.user) childQuery.user = query.user;

--- a/server/queryHandlers/GetAWSaccounts.js
+++ b/server/queryHandlers/GetAWSaccounts.js
@@ -2,8 +2,6 @@
 
 'use strict';
 
-let config = require('config');
-
 function getAwsAccounts(query) {
   let sender = require('modules/sender');
   let dynamoQuery = {

--- a/server/queryHandlers/ScanInstancesScheduleStatus.js
+++ b/server/queryHandlers/ScanInstancesScheduleStatus.js
@@ -5,7 +5,7 @@
 let co = require('co');
 let _ = require('lodash');
 let sender = require('modules/sender');
-let config = require('config');
+let awsAccounts = require('modules/awsAccounts');
 let scheduling = require('modules/scheduling');
 
 module.exports = function ScanInstancesScheduleStatusQueryHandler(query) {
@@ -104,17 +104,19 @@ function getAllInstances(query) {
 }
 
 function getAllEnvironments(query) {
-  let masterAccountName = config.getUserValue('masterAccountName');
-  return sender.sendQuery({
-    query: {
-      name: 'ScanDynamoResources',
-      accountName: masterAccountName,
-      resource: 'ops/environments',
-      queryId: query.queryId,
-      username: query.username,
-      timestamp: query.timestamp
-    }
-  });
+  return awsAccounts.getMasterAccountName()
+    .then((masterAccountName) => {
+      return sender.sendQuery({
+        query: {
+          name: 'ScanDynamoResources',
+          accountName: masterAccountName,
+          resource: 'ops/environments',
+          queryId: query.queryId,
+          username: query.username,
+          timestamp: query.timestamp
+        }
+      });
+    });
 }
 
 function getAllASGs(query) {

--- a/server/routes/api/dynamo/exportRouteHandlerDescriptor.js
+++ b/server/routes/api/dynamo/exportRouteHandlerDescriptor.js
@@ -7,7 +7,7 @@ let send = require('modules/helpers/send');
 let route = require('modules/helpers/route');
 let make = require('modules/utilities').make;
 let resourceDescriptorProvider = require('modules/resourceDescriptorProvider');
-let config = require('config');
+let awsAccounts = require('modules/awsAccounts');
 
 module.exports = resourceDescriptorProvider
   .all()
@@ -28,20 +28,21 @@ module.exports = resourceDescriptorProvider
       docs.perAccount = resource.perAccount;
     }
 
-    const masterAccountName = config.getUserValue('masterAccountName');
-
     return route
       .get(url)
       .named(resource.name)
       .withDocs(docs)
       .do((request, response) => {
-        let query = {
-          name: 'ScanDynamoResources',
-          resource: resource.name,
-          exposeAudit: 'full',
-          accountName: resource.perAccount ? request.params.account : masterAccountName
-        };
+        awsAccounts.getMasterAccountName()
+          .then((masterAccountName) => {
+            let query = {
+              name: 'ScanDynamoResources',
+              resource: resource.name,
+              exposeAudit: 'full',
+              accountName: resource.perAccount ? request.params.account : masterAccountName
+            };
 
-        send.query(query, request, response);
+            send.query(query, request, response);
+          });
       });
   });

--- a/server/routes/api/dynamo/scanRouteHandlerDescriptor.js
+++ b/server/routes/api/dynamo/scanRouteHandlerDescriptor.js
@@ -7,7 +7,7 @@ let utilities = require('modules/utilities');
 let send = require('modules/helpers/send');
 let route = require('modules/helpers/route');
 let make = require('modules/utilities').make;
-let config = require('config');
+let awsAccounts = require('modules/awsAccounts');
 let resourceDescriptorProvider = require('modules/resourceDescriptorProvider');
 
 module.exports = resourceDescriptorProvider
@@ -26,21 +26,23 @@ module.exports = resourceDescriptorProvider
       docs.verb = 'scan';
       docs.perAccount = resource.perAccount;
     }
-    const masterAccountName = config.getUserValue('masterAccountName');
 
     return route
       .get(url)
       .named(resource.name)
       .withDocs(docs)
       .do((request, response) => {
-        let query = {
-          name: 'ScanDynamoResources',
-          resource: resource.name,
-          filter: utilities.extractQuery(request),
-          exposeAudit: 'version-only',
-          accountName: resource.perAccount ? request.params.account : masterAccountName
-        };
+        awsAccounts.getMasterAccountName()
+          .then((masterAccountName) => {
+            let query = {
+              name: 'ScanDynamoResources',
+              resource: resource.name,
+              filter: utilities.extractQuery(request),
+              exposeAudit: 'version-only',
+              accountName: resource.perAccount ? request.params.account : masterAccountName
+            };
 
-        send.query(query, request, response);
+            send.query(query, request, response);
+          });
       });
   });

--- a/server/routes/api/ops/environmentsRouteHandlerDescriptor.js
+++ b/server/routes/api/ops/environmentsRouteHandlerDescriptor.js
@@ -5,21 +5,23 @@
 let send = require('modules/helpers/send');
 let route = require('modules/helpers/route');
 let authorizer = require('modules/authorizers/environments-schedule');
-let config = require('config');
+let awsAccounts = require('modules/awsAccounts');
 
 module.exports = route.put('/ops/environments/:key')
   .withDocs({ disableDocs: true })
   .withAuthorizer(authorizer)
   .do((request, response) => {
-    const masterAccountName = config.getUserValue('masterAccountName');
-    let command = {
-      name: 'UpdateDynamoResource',
-      resource: 'ops/environments',
-      key: request.params.key,
-      item: request.body,
-      expectedVersion: request.headers['expected-version'],
-      accountName: masterAccountName
-    };
+    awsAccounts.getMasterAccountName()
+      .then((masterAccountName) => {
+        let command = {
+          name: 'UpdateDynamoResource',
+          resource: 'ops/environments',
+          key: request.params.key,
+          item: request.body,
+          expectedVersion: request.headers['expected-version'],
+          accountName: masterAccountName
+        };
 
-    send.command(command, request, response);
+        send.command(command, request, response);
+      });
   });

--- a/server/test/bootstrap.js
+++ b/server/test/bootstrap.js
@@ -9,6 +9,4 @@ var path = require('path');
 var config = require('config');
 let localConfig = require('configuration.sample');
 
-config.setUserValue('masterAccountName', 'Sandbox');
 config.setUserValue('local', localConfig);
-


### PR DESCRIPTION
This has my head spinning round in circles. 

On a search for 'masterAccountName' string now, the problem area has been reduced to a more manageable size. The issue with calling for a value that doesn't exist yet still remains I think - it's less likely with an async call on request, but still possible!

Figuring out where to pull out the existing logic into a pre-requisite population of the account is driving me loopy. If you think it's worth it and can see a nice way to do this, by all means let me know. 

For each file change in this branch: 

- I re-ran the app to make sure it started. 
- I flicked through each top level menu in the UI (including Environment -> C50 -> 0Servers, Schedule, Settings]
- Ran the unit tests to make sure they all still passed. 