### PR TITLE
Feature/improve comparison of service versions

### DIFF
--- a/client/app/compare/CompareController.js
+++ b/client/app/compare/CompareController.js
@@ -214,7 +214,7 @@ angular.module('EnvironmentManager.compare').controller('CompareController',
               hasState = true;
             }
           });
-          
+
           if (!hasState) {
             d.Comparable = false;
           }
@@ -299,7 +299,6 @@ angular.module('EnvironmentManager.compare').controller('CompareController',
       var filterCluster = vm.selected.cluster === SHOW_ALL_OPTION ? null : vm.selected.cluster;
 
       if (vm.selected.comparable.key === 'versions') {
-
         vm.view = serviceComparison(data, primaryEnvironment, secondaryEnvironments);
 
         if (vm.selected.state.toUpperCase() === 'ACTIVE') {

--- a/client/app/compare/CompareController.js
+++ b/client/app/compare/CompareController.js
@@ -15,7 +15,7 @@ angular.module('EnvironmentManager.compare').controller('CompareController',
 
     function init() {
       vm.comparableResources = comparableResources;
-      vm.selected.comparable = vm.comparableResources[0];
+      vm.selected.comparable = getVersionsComparableResource();
 
 
       $q.all([
@@ -34,12 +34,16 @@ angular.module('EnvironmentManager.compare').controller('CompareController',
       });
     }
 
+    function getVersionsComparableResource() {
+      return vm.comparableResources[0];
+    }
+
     $scope.$on('$locationChangeSuccess', function () {
       setStateFromUrl();
     });
 
     function setStateFromUrl() {
-      var res = $location.search().res || vm.comparableResources[0].key;
+      var res = $location.search().res || getVersionsComparableResource().key;
       var compare = $location.search().compare || vm.environments[0].EnvironmentName;
       var to = $location.search().to || '';
       var cluster = $location.search().cluster || SHOW_ALL_OPTION;

--- a/client/app/compare/CompareController.js
+++ b/client/app/compare/CompareController.js
@@ -79,12 +79,11 @@ angular.module('EnvironmentManager.compare').controller('CompareController',
       var foundUpstreams = {};
 
       return activeStatusService.getAllUpstreamsData()
-        .then(function (statusData) {
+        .then(function findAndStoreUpstreamNamesThatMatchComparableItem(statusData) {
           comparableData.forEach(function (c) {
             var matches = statusData.data.filter(function (s) {
               return s.Value.EnvironmentName === c.EnvironmentName && s.Value.ServiceName === c.key;
             });
-
             if (matches.length > 0) {
               c.UpstreamName = matches[0].Value.UpstreamName;
               foundUpstreams[c.UpstreamName] = c;

--- a/client/app/compare/CompareController.js
+++ b/client/app/compare/CompareController.js
@@ -79,11 +79,12 @@ angular.module('EnvironmentManager.compare').controller('CompareController',
       var foundUpstreams = {};
 
       return activeStatusService.getAllUpstreamsData()
-        .then(function findAndStoreUpstreamNamesThatMatchComparableItem(statusData) {
+        .then(function (statusData) {
           comparableData.forEach(function (c) {
             var matches = statusData.data.filter(function (s) {
               return s.Value.EnvironmentName === c.EnvironmentName && s.Value.ServiceName === c.key;
             });
+
             if (matches.length > 0) {
               c.UpstreamName = matches[0].Value.UpstreamName;
               foundUpstreams[c.UpstreamName] = c;
@@ -140,7 +141,6 @@ angular.module('EnvironmentManager.compare').controller('CompareController',
     };
 
     function updateView(data) {
-      console.log(data)
       var primaryEnvironment = vm.selected.primaryEnvironment.EnvironmentName;
       var secondaryEnvironments = _.map(vm.selected.environments, 'EnvironmentName');
       var filterCluster = vm.selected.cluster === SHOW_ALL_OPTION ? null : vm.selected.cluster;

--- a/client/app/compare/compare-services.html
+++ b/client/app/compare/compare-services.html
@@ -14,7 +14,6 @@
       </td>
       <td width="300px" class="text-nowrap" ng-repeat="env in vm.selected.environments" ng-init='comparison = service.comparisons[env.EnvironmentName]'>
         <service-cell data="comparison" ng-if="comparison"></service-cell>
-
       </td>
     </tr>
   </tbody>

--- a/client/app/compare/compare.html
+++ b/client/app/compare/compare.html
@@ -39,6 +39,15 @@
         <option ng-repeat="c in vm.clustersList" ng-selected="{{c == vm.selected.cluster}}" value="{{c}}">{{c}}</option>
       </select>
     </div>
+
+    <div class="form-group" ng-if="vm.selected.comparable.key === 'versions'">
+      <label class="control-label text-left">State:</label>
+    </div>
+    <div class="form-group" ng-if="vm.selected.comparable.key === 'versions'">
+      <select class="form-control" ng-model="vm.selected.state" ng-change="vm.onSelectionChanged()">
+        <option ng-repeat="s in vm.states" ng-selected="{{s == vm.selected.state}}" value="{{s}}">{{s}}</option>
+      </select>
+    </div>
   </form>
   <hr />
   <spinner ng-show="vm.dataLoading"></spinner>

--- a/client/app/compare/directives/serviceCell.html
+++ b/client/app/compare/directives/serviceCell.html
@@ -1,5 +1,8 @@
 <div class="service-cell" uib-popover popover-trigger="'mouseenter'" uib-popover-html="$ctrl.popoverHtml" popover-placement="left">
   <div ng-repeat="deployment in $ctrl.data.deployments">
     {{ deployment.version }} <span ng-if="deployment.slice !== 'none'">(<span class="slice-symbol" ng-class="deployment.slice"></span>{{ deployment.slice }} )</span>
+    <span ng-if="deployment.versionCompare.toUpperCase() === 'SAME'"><span class="glyphicon glyphicon-minus"></span></span>
+    <span ng-if="deployment.versionCompare.toUpperCase() === 'NEWER'"><span class="glyphicon glyphicon-chevron-up"></span></span>
+    <span ng-if="deployment.versionCompare.toUpperCase() === 'OLDER'"><span class="glyphicon glyphicon-chevron-down"></span></span>
   </div>
 </div>

--- a/client/app/compare/directives/serviceCell.html
+++ b/client/app/compare/directives/serviceCell.html
@@ -1,8 +1,24 @@
 <div class="service-cell" uib-popover popover-trigger="'mouseenter'" uib-popover-html="$ctrl.popoverHtml" popover-placement="left">
   <div ng-repeat="deployment in $ctrl.data.deployments">
-    {{ deployment.version }} <span ng-if="deployment.slice !== 'none'">(<span class="slice-symbol" ng-class="deployment.slice"></span>{{ deployment.slice }} )</span>
+    <span ng-if="!$ctrl.data.Active">
+    {{ deployment.version }} <span ng-if="deployment.slice !== 'none'">(<span class="slice-symbol" ng-class="deployment.slice"></span>{{
+    deployment.slice }} )</span>
     <span ng-if="deployment.versionCompare.toUpperCase() === 'SAME'"><span class="glyphicon glyphicon-minus"></span></span>
     <span ng-if="deployment.versionCompare.toUpperCase() === 'NEWER'"><span class="glyphicon glyphicon-chevron-up"></span></span>
     <span ng-if="deployment.versionCompare.toUpperCase() === 'OLDER'"><span class="glyphicon glyphicon-chevron-down"></span></span>
+    </span>
+
+    <span ng-if="$ctrl.data.Comparable && $ctrl.data.Active">
+    {{ deployment.version }} <span ng-if="deployment.slice !== 'none'">(<span class="slice-symbol" ng-class="deployment.slice"></span>{{
+    deployment.slice }} )</span>
+    <span ng-if="deployment.versionCompare.toUpperCase() === 'SAME'"><span class="glyphicon glyphicon-minus"></span></span>
+    <span ng-if="deployment.versionCompare.toUpperCase() === 'NEWER'"><span class="glyphicon glyphicon-chevron-up"></span></span>
+    <span ng-if="deployment.versionCompare.toUpperCase() === 'OLDER'"><span class="glyphicon glyphicon-chevron-down"></span></span>
+    </span>
+
+    <span ng-if="!$ctrl.data.Comparable && $ctrl.data.Active">
+      <span ng-if="deployment.slice !== 'none'">Unable to determine 'Active' slice.</span>
+    <span ng-if="deployment.slice === 'none'">{{ deployment.version }}</span>
+    </span>
   </div>
 </div>

--- a/client/app/compare/directives/serviceCell.js
+++ b/client/app/compare/directives/serviceCell.js
@@ -19,7 +19,7 @@ angular.module('EnvironmentManager.compare').component('serviceCell', {
     }
 
     var html = '<table class="table service-hover-table">';
-    html += '<tr><th>Server role</th><th>Version</th></tr>';
+    html += '<tr><th>Server role</th><th>Version</th><th>State</th></tr>';
     _.forEach(this.data.serverRoles, function (deployments, serverRoleName) {
       deployments = deployments.sort(function (a, b) {
         return comparisons.semver(a.version, b.version);
@@ -30,6 +30,11 @@ angular.module('EnvironmentManager.compare').component('serviceCell', {
         html += '<td>' + deployment.version;
         if (deployment.slice !== 'none') {
           html += ' (<span class="slice-symbol ' + deployment.slice + '"></span>' + deployment.slice + ' )';
+        }
+        html += '</td>';
+        html += '<td>';
+        if (deployment.State) {
+          html += deployment.State;
         }
         html += '</td>';
         html += '</tr>';

--- a/client/app/compare/directives/serviceCell.js
+++ b/client/app/compare/directives/serviceCell.js
@@ -33,8 +33,8 @@ angular.module('EnvironmentManager.compare').component('serviceCell', {
         }
         html += '</td>';
         html += '<td>';
-        if (deployment.State) {
-          html += deployment.State;
+        if ($ctrl.data.State) {
+          html += $ctrl.data.State;
         }
         html += '</td>';
         html += '</tr>';

--- a/client/app/compare/directives/serviceCell.js
+++ b/client/app/compare/directives/serviceCell.js
@@ -33,8 +33,8 @@ angular.module('EnvironmentManager.compare').component('serviceCell', {
         }
         html += '</td>';
         html += '<td>';
-        if ($ctrl.data.State) {
-          html += $ctrl.data.State;
+        if (deployment.State) {
+          html += deployment.State;
         }
         html += '</td>';
         html += '</tr>';

--- a/client/app/compare/services/activeStatusService.js
+++ b/client/app/compare/services/activeStatusService.js
@@ -1,0 +1,26 @@
+/* TODO: enable linting and fix resulting errors */
+/* eslint-disable */
+/* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
+
+'use strict';
+
+angular.module('EnvironmentManager.compare').factory('activeStatusService',
+  function ($http) {
+
+    var baseUrl = '/api/v1/'
+    
+    function getAllUpstreamsData(environmentName) {
+      return $http.get(baseUrl + 'config/upstreams/');
+    }
+
+    function getSliceInformation(name, environment) {
+      return $http.get(baseUrl + 'upstreams/' + name + '/slices/', { params: { environment: environment } });
+    }
+
+    return {
+      getAllUpstreamsData: getAllUpstreamsData, 
+      getSliceInformation: getSliceInformation
+    }
+  }
+);
+

--- a/client/app/compare/services/serviceComparison.js
+++ b/client/app/compare/services/serviceComparison.js
@@ -29,7 +29,6 @@ angular.module('EnvironmentManager.compare').factory('serviceComparison',
         });
 
         decorateItemsWithVersionInformation(items);
-
         return items;
       }
 

--- a/client/app/compare/services/serviceComparison.js
+++ b/client/app/compare/services/serviceComparison.js
@@ -19,7 +19,7 @@ angular.module('EnvironmentManager.compare').factory('serviceComparison',
       }
 
       function getItems(keys) {
-        return keys.map(function (key) {
+        var items = keys.map(function (key) {
           var primary = getByKeyAndEnvironment(data, key, primaryEnvironmentName);
           return {
             key: key,
@@ -27,6 +27,54 @@ angular.module('EnvironmentManager.compare').factory('serviceComparison',
             comparisons: getComparisons(primary, key)
           };
         });
+
+        decorateItemsWithVersionInformation(items);
+
+        return items;
+      }
+
+      function decorateItemsWithVersionInformation(items) {
+        items.forEach(function (item) {
+          addVersionInformationToItem(item);
+        });
+      }
+
+      function addVersionInformationToItem(item) {
+        if (!hasDeployment(item.primary)) return;
+
+        getComparisonsList(item).forEach(function (comparisonKey) {
+          createVersionCompareInformation(item, comparisonKey, getLatestDeploymentVersion(item.primary));          
+        });
+
+      }
+
+      function createVersionCompareInformation(item, comparisonKey, latestPrimaryDeploymentVersion) {
+        if (item.comparisons[comparisonKey] && hasDeployment(item.comparisons[comparisonKey])) {
+            var check = comparisons.semver(latestPrimaryDeploymentVersion, getLatestDeploymentVersion(item.comparisons[comparisonKey]));
+            if (check === -1) {
+              getLatestDeployment(item.comparisons[comparisonKey]).versionCompare = "NEWER";
+            } else if (check === 1) {
+              getLatestDeployment(item.comparisons[comparisonKey]).versionCompare = "OLDER";
+            } else {
+              getLatestDeployment(item.comparisons[comparisonKey]).versionCompare = "SAME";
+            }
+          }
+      }
+
+      function getComparisonsList(item) {
+        return Object.keys(item.comparisons);
+      }
+
+      function hasDeployment(item) {
+        return item && item.deployments && Array.isArray(item.deployments);
+      }
+
+      function getLatestDeployment(item) {
+        return item.deployments[item.deployments.length - 1];
+      }
+
+      function getLatestDeploymentVersion(item) {
+        return getLatestDeployment(item).version;
       }
 
       function getByKeyAndEnvironment(items, key, environmentName) {

--- a/client/app/compare/services/upstreamService.js
+++ b/client/app/compare/services/upstreamService.js
@@ -4,22 +4,22 @@
 
 'use strict';
 
-angular.module('EnvironmentManager.compare').factory('activeStatusService',
+angular.module('EnvironmentManager.compare').factory('upstreamService',
   function ($http) {
 
     var baseUrl = '/api/v1/'
     
-    function getAllUpstreamsData(environmentName) {
+    function get() {
       return $http.get(baseUrl + 'config/upstreams/');
     }
 
-    function getSliceInformation(name, environment) {
+    function getSlice(name, environment) {
       return $http.get(baseUrl + 'upstreams/' + name + '/slices/', { params: { environment: environment } });
     }
 
     return {
-      getAllUpstreamsData: getAllUpstreamsData, 
-      getSliceInformation: getSliceInformation
+      get: get, 
+      getSlice: getSlice
     }
   }
 );

--- a/client/index.html
+++ b/client/index.html
@@ -119,7 +119,7 @@
   <script src="app/compare/compare.module.js"></script>
   <script src="app/compare/services/serviceComparison.js"></script>
   <script src="app/compare/services/comparableResources.js"></script>
-  <script src="app/compare/services/activeStatusService.js"></script>
+  <script src="app/compare/services/upstreamService.js"></script>
   <script src="app/compare/services/ResourceComparison.js"></script>
   <script src="app/compare/directives/serviceCell.js"></script>
   <script src="app/compare/diff-viewer/DiffViewerController.js"></script>

--- a/client/index.html
+++ b/client/index.html
@@ -119,6 +119,7 @@
   <script src="app/compare/compare.module.js"></script>
   <script src="app/compare/services/serviceComparison.js"></script>
   <script src="app/compare/services/comparableResources.js"></script>
+  <script src="app/compare/services/activeStatusService.js"></script>
   <script src="app/compare/services/ResourceComparison.js"></script>
   <script src="app/compare/directives/serviceCell.js"></script>
   <script src="app/compare/diff-viewer/DiffViewerController.js"></script>


### PR DESCRIPTION
Created a new Angular service for obtaining Upstreams information. 

Join all the current "Target State" data with the Upsteams data. Make some decisions on what makes those items "Comparable" or not. 

In the UI, there is a choice for "Active" items now. It will check whether the item is considered comparable and if it isn't, it will show an error. This is step one in order to identify how useful the current comparison screen is - what percentage of items in the production environment are considered comparable by our current rules? Unknown. 