### PR TITLE
Fix exception thrown by /api/vi/diagnostics/healthcheck after response sent

### DIFF
--- a/server/api/controllers/diagnostics/diagnosticsController.js
+++ b/server/api/controllers/diagnostics/diagnosticsController.js
@@ -5,7 +5,7 @@
 let config = require('config');
 
 function getHealthcheck(req, res, next) {
-  res.json({ OK: true, Version: config.get('APP_VERSION') }).catch(next);
+  res.json({ OK: true, Version: config.get('APP_VERSION') });
 }
 
 module.exports = {


### PR DESCRIPTION
The result of calling `res.json` is `undefined`, not `thenable`. Calling `.catch` on the result throws an error: _Cannot read property 'catch' of undefined_.

This change fixes this bug.

https://jira.thetrainline.com/browse/PD-178