### PR TITLE
When accept allows for JSON, that is what will come back from this en…

### DIFF
--- a/server/api/controllers/package-upload-url/dynamicResponseCreator.js
+++ b/server/api/controllers/package-upload-url/dynamicResponseCreator.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = function create(request, status, value) {
+  if (request.accepts('application/json')) {
+    return response => response.status(status).json({ url: value });
+  }
+
+  return response => response.status(status).send(value);
+};

--- a/server/api/controllers/package-upload-url/dynamicResponseCreator.js
+++ b/server/api/controllers/package-upload-url/dynamicResponseCreator.js
@@ -1,9 +1,8 @@
 'use strict';
 
-module.exports = function create(request, status, value) {
-  if (request.accepts('application/json')) {
-    return response => response.status(status).json({ url: value });
-  }
-
-  return response => response.status(status).send(value);
+module.exports = function create(status, value) {
+  return response => response.format({
+    'text/plain': () => response.status(status).send(value), // This is the default if no "Accept" header specified; see https://expressjs.com/en/api.html#res.format
+    'application/json': () => response.status(status).json({ url: value })
+  });
 };

--- a/server/api/controllers/package-upload-url/packageUploadUrlController.js
+++ b/server/api/controllers/package-upload-url/packageUploadUrlController.js
@@ -42,9 +42,9 @@ function respondWithPreSignedUrl(request) {
       s3.getSignedUrl('putObject', params, (err, url) => {
         if (err) {
           log.error(`Creation of pre-signed package upload URL failed: ${err.message}\n${err.stack}`);
-          resolve(dynamicResponseCreator(request, 500));
+          resolve(response => response.status(500).send());
         } else {
-          resolve(dynamicResponseCreator(request, 200, url));
+          resolve(dynamicResponseCreator(200, url));
         }
       });
     }));

--- a/server/api/controllers/package-upload-url/packageUploadUrlController.js
+++ b/server/api/controllers/package-upload-url/packageUploadUrlController.js
@@ -13,6 +13,7 @@ let makeValidationFunction = require('modules/validate');
 let masterAccountClient = require('modules/amazon-client/masterAccountClient'); // eslint-disable-line import/no-extraneous-dependencies
 let s3PackageLocator = require('modules/s3PackageLocator');
 let serviceExistsRule = require('modules/validate/rule/serviceExists');
+let dynamicResponseCreator = require('api/controllers/package-upload-url/dynamicResponseCreator');
 /* eslint-enable import/no-extraneous-dependencies */
 
 let config = require('config');
@@ -41,9 +42,9 @@ function respondWithPreSignedUrl(request) {
       s3.getSignedUrl('putObject', params, (err, url) => {
         if (err) {
           log.error(`Creation of pre-signed package upload URL failed: ${err.message}\n${err.stack}`);
-          resolve(response => response.status(500).send());
+          resolve(dynamicResponseCreator(request, 500));
         } else {
-          resolve(response => response.status(200).send(url));
+          resolve(dynamicResponseCreator(request, 200, url));
         }
       });
     }));

--- a/server/package.json
+++ b/server/package.json
@@ -86,6 +86,7 @@
     "mocha": "^3.2.0",
     "mocha-duplicate-reporter": "^0.2.1",
     "mocha-teamcity-reporter": "^1.1.1",
+    "mock-express-response": "^0.2.0",
     "proxyquire": "^1.7.10",
     "rewire": "^2.5.2",
     "should": "^11.1.1",

--- a/server/test/test-api/dynamicResponseCreator.spec.js
+++ b/server/test/test-api/dynamicResponseCreator.spec.js
@@ -4,70 +4,76 @@ const assert = require('assert');
 const sinon = require('sinon');
 const MockExpressRequest = require('mock-express-request');
 const MockExpressResponse = require('mock-express-response');
+const sut = require('api/controllers/package-upload-url/dynamicResponseCreator');
+
+function createResponseForAcceptHeader(accept) {
+  let next = sinon.spy();
+  let response = new MockExpressResponse({
+    request: new MockExpressRequest({
+      headers: accept ? { Accept: accept } : {},
+      next
+    })
+  });
+  response.json = sinon.spy(response, 'json');
+  response.send = sinon.spy(response, 'send');
+  response.status = sinon.spy(response, 'status');
+  return { next, response };
+}
 
 describe('Creating a Dynamic Response based on the Express request Accept header', () => {
-  let sut;
-  let mockRequest;
-  let mockResponse;
-  let spyOnJson;
-  let spyOnSend;
-  let spyOnStatus;
-  let status;
-  let url;
-
-  beforeEach(() => {
-    sut = require('api/controllers/package-upload-url/dynamicResponseCreator');
-    mockRequest = new MockExpressRequest();
-    mockResponse = new MockExpressResponse();
-    spyOnJson = sinon.spy(mockResponse, 'json');
-    spyOnSend = sinon.spy(mockResponse, 'send');
-    spyOnStatus = sinon.spy(mockResponse, 'status');
-    status = 200;
-    url = 'http://something.com/location/blah';
-  });
+  const status = 200;
+  const url = 'http://something.com/location/blah';
 
   describe('a request with Accept for application/json', () => {
     it('should create responder that when invoked, calls the Express response.json()', () => {
-      mockRequest = createJsonRequest();
+      let { response } = createResponseForAcceptHeader('application/json');
 
-      sut(mockRequest, status, url)(mockResponse);
+      sut(status, url)(response);
 
-      assert.ok(spyOnStatus.calledWith(status));
-      assert.ok(spyOnJson.calledWith({ url }));
+      assert.ok(response.status.calledWith(status));
+      assert.ok(response.json.calledWith({ url }));
     });
   });
 
   describe('a request with Accept header that does not feature application/json', () => {
     it('should create a responder that when invoked, called the Express response.send()', () => {
-      mockResponse = new MockExpressResponse();
-      spyOnSend = sinon.spy(mockResponse, 'send');
-      spyOnJson = sinon.spy(mockResponse, 'json');
-      spyOnStatus = sinon.spy(mockResponse, 'status');
-      mockRequest = createNothingRequest();
+      let { response } = createResponseForAcceptHeader();
 
-      sut(mockRequest, status, url)(mockResponse);
+      sut(status, url)(response);
 
-      assert.ok(spyOnSend.calledWith(url));
-      assert.ok(spyOnStatus.calledWith(status));
-      assert.ok(spyOnJson.notCalled);
+      assert.ok(response.send.calledWith(url));
+      assert.ok(response.status.calledWith(status));
+      assert.ok(response.json.notCalled);
     });
   });
+
+  context('content type negotiation', function () {
+    function respondsWithText({ response }) {
+      sinon.assert.calledOnce(response.send);
+      sinon.assert.notCalled(response.json);
+    }
+
+    function respondsWithJson({ response }) {
+      sinon.assert.calledOnce(response.json);
+    }
+
+    function respondsWith406({ next }) {
+      sinon.assert.calledWith(next, sinon.match.instanceOf(Error).and(sinon.match({ status: 406 })));
+    }
+
+    let scenarios = [
+      { accept: undefined, assertion: respondsWithText },
+      { accept: 'text/plain', assertion: respondsWithText },
+      { accept: 'application/json', assertion: respondsWithJson },
+      { accept: 'text/html', assertion: respondsWith406 },
+      { accept: 'text/plain, application/json', assertion: respondsWithText },
+      { accept: 'text/plain; q=0.1, application/json; q=0.2', assertion: respondsWithJson }
+    ];
+    scenarios.forEach(({ accept, assertion }) =>
+      it(`when request accepts ${accept}, reponse ${assertion.name}`, function () {
+        let { next, response } = createResponseForAcceptHeader(accept);
+        sut(status, url)(response);
+        assertion({ response, next });
+      }));
+  });
 });
-
-function createJsonRequest() {
-  return new MockExpressRequest({
-    method: 'GET',
-    url: '/stuff?q=thing',
-    headers: {
-      Accept: 'application/json'
-    }
-  });
-}
-
-function createNothingRequest() {
-  return new MockExpressRequest({
-    headers: {
-      Accept: 'nothing at all please!'
-    }
-  });
-}

--- a/server/test/test-api/dynamicResponseCreator.spec.js
+++ b/server/test/test-api/dynamicResponseCreator.spec.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const assert = require('assert');
+const sinon = require('sinon');
+const MockExpressRequest = require('mock-express-request');
+const MockExpressResponse = require('mock-express-response');
+
+describe('Creating a Dynamic Response based on the Express request Accept header', () => {
+  let sut;
+  let mockRequest;
+  let mockResponse;
+  let spyOnJson;
+  let spyOnSend;
+  let spyOnStatus;
+  let status;
+  let url;
+
+  beforeEach(() => {
+    sut = require('api/controllers/package-upload-url/dynamicResponseCreator');
+    mockRequest = new MockExpressRequest();
+    mockResponse = new MockExpressResponse();
+    spyOnJson = sinon.spy(mockResponse, 'json');
+    spyOnSend = sinon.spy(mockResponse, 'send');
+    spyOnStatus = sinon.spy(mockResponse, 'status');
+    status = 200;
+    url = 'http://something.com/location/blah';
+  });
+
+  describe('a request with Accept for application/json', () => {
+    it('should create responder that when invoked, calls the Express response.json()', () => {
+      mockRequest = createJsonRequest();
+
+      sut(mockRequest, status, url)(mockResponse);
+
+      assert.ok(spyOnStatus.calledWith(status));
+      assert.ok(spyOnJson.calledWith({ url }));
+    });
+  });
+
+  describe('a request with Accept header that does not feature application/json', () => {
+    it('should create a responder that when invoked, called the Express response.send()', () => {
+      mockResponse = new MockExpressResponse();
+      spyOnSend = sinon.spy(mockResponse, 'send');
+      spyOnJson = sinon.spy(mockResponse, 'json');
+      spyOnStatus = sinon.spy(mockResponse, 'status');
+      mockRequest = createNothingRequest();
+
+      sut(mockRequest, status, url)(mockResponse);
+
+      assert.ok(spyOnSend.calledWith(url));
+      assert.ok(spyOnStatus.calledWith(status));
+      assert.ok(spyOnJson.notCalled);
+    });
+  });
+});
+
+function createJsonRequest() {
+  return new MockExpressRequest({
+    method: 'GET',
+    url: '/stuff?q=thing',
+    headers: {
+      Accept: 'application/json'
+    }
+  });
+}
+
+function createNothingRequest() {
+  return new MockExpressRequest({
+    headers: {
+      Accept: 'nothing at all please!'
+    }
+  });
+}


### PR DESCRIPTION
…d point now. If there is no acceptance of JSON, the response will be plain text as before.

If given an accept header that it can match to json, it will return a JSON value back. 

Any other time, you'll continue to receive the response.send(url) that you received before. This does mean that any clients who are sending */* in their accept at the moment may be in for a nasty surprise. 