### PR TITLE
Default to an endtimeStamp when there is a failure and show the dates…

### DIFF
--- a/client/app/operations/deployments/DeploymentDetailsModalController.js
+++ b/client/app/operations/deployments/DeploymentDetailsModalController.js
@@ -9,6 +9,7 @@ function deploymentView(deploymentRecord, clusters) {
   function getDuration() {
     var startTime = moment(deployment.StartTimestamp);
 
+    console.log(deployment)
     if (deployment.Status.toLowerCase() === 'in progress') {
       return {
         label: 'Started',
@@ -17,12 +18,21 @@ function deploymentView(deploymentRecord, clusters) {
     }
 
     var endTime = moment(deployment.EndTimestamp);
-    var diff = moment(endTime.diff(startTime)).format('m[m] s[s]');
-
+    var diff = createDiffString(startTime, endTime);
+    
     return {
       label: 'Duration',
-      value: diff + ' (' + startTime.format('YYYY-MM-DD, HH:mm:ss') + ' - ' + endTime.format('HH:mm:ss') + ')'
+      value: diff + ' (' + startTime.format('YYYY-MM-DD, HH:mm:ss') + ' - ' + endTime.format('YYYY-MM-DD, HH:mm:ss') + ')'
     };
+  }
+
+  function createDiffString(startTime, endTime) {
+    var diff = moment.duration(endTime.diff(startTime));
+    var duration = [
+      _.pad(diff.get('hours'), 2, 0), 
+      _.pad(diff.get('minutes'), 2, 0), 
+      _.pad(diff.get('seconds'), 2, 0)].join(':');
+    return duration;
   }
 
   function getError() {
@@ -47,7 +57,7 @@ function deploymentView(deploymentRecord, clusters) {
     var startEnd = startTime.format('HH:mm:ss');
     if (endTime) startEnd += ' - ' + endTime.format('HH:mm:ss');
 
-    var duration = moment(endTime.diff(startTime)).format('m[m] s[s]');
+    var duration = createDiffString(startTime, endTime);
     return duration + ' (' + startEnd + ')';
   }
 

--- a/client/app/operations/deployments/DeploymentDetailsModalController.js
+++ b/client/app/operations/deployments/DeploymentDetailsModalController.js
@@ -9,7 +9,6 @@ function deploymentView(deploymentRecord, clusters) {
   function getDuration() {
     var startTime = moment(deployment.StartTimestamp);
 
-    console.log(deployment)
     if (deployment.Status.toLowerCase() === 'in progress') {
       return {
         label: 'Started',

--- a/server/modules/DeploymentLogger.js
+++ b/server/modules/DeploymentLogger.js
@@ -57,21 +57,16 @@ module.exports = {
     return Promise.all([
       Promise.resolve(deploymentLogsStreamer.log(deploymentStatus.deploymentId, deploymentStatus.accountName, newStatus.reason))
         .then(() => deploymentLogsStreamer.flush(deploymentStatus.deploymentId))
-        .then(() => updateDeploymentDynamoTable(deploymentStatus, newStatus)).catch(error => logger.error(error)),
+        .then(() => updateDeploymentDynamoTable(deploymentStatus, newStatus))
+        .catch(error => logger.error(error)),
       updateDeploymentTargetState(deploymentStatus, newStatus).catch(error => logger.error(error))
     ]);
   }
 };
 
-
 function updateDeploymentDynamoTable(deploymentStatus, newStatus) {
-  let endTimestamp = newStatus.name !== Enums.DEPLOYMENT_STATUS.InProgress ? new Date().toISOString() : undefined;
-
-  let errorReason = null;
-  // No error
-  if (newStatus.name === Enums.DEPLOYMENT_STATUS.Failed && newStatus.reason !== undefined) {
-    errorReason = newStatus.reason;
-  }
+  let endTimestamp = createDefaultTimestampForInProgress();
+  let errorReason = setAttributesInCaseOfError();
 
   let command = {
     name: 'UpdateDynamoResource',
@@ -87,7 +82,24 @@ function updateDeploymentDynamoTable(deploymentStatus, newStatus) {
   };
 
   return sender.sendCommand({ command, user: systemUser });
+
+  function createDefaultTimestampForInProgress() {
+    return newStatus.name !== Enums.DEPLOYMENT_STATUS.InProgress ? new Date().toISOString() : undefined;
+  }
+
+  function setAttributesInCaseOfError() {
+    if (hasFailed()) {
+      errorReason = newStatus.reason;
+      endTimestamp = new Date().toISOString();
+    }
+
+    function hasFailed() {
+      return newStatus.name === Enums.DEPLOYMENT_STATUS.Failed && newStatus.reason !== undefined;
+    }
+  }
 }
+
+
 
 function updateDeploymentTargetState(deploymentStatus, newStatus) {
   let command = {

--- a/server/modules/DeploymentLogger.js
+++ b/server/modules/DeploymentLogger.js
@@ -99,8 +99,6 @@ function updateDeploymentDynamoTable(deploymentStatus, newStatus) {
   }
 }
 
-
-
 function updateDeploymentTargetState(deploymentStatus, newStatus) {
   let command = {
     name: 'UpdateTargetState',


### PR DESCRIPTION
… in a more friendly format on the modal UI

UI to show user friendly date string - providing hours, minutes and seconds. 

Deploy service to add an endtimeStamp in the event of an error, so that Moment.js isn't being provided with 'undefined' (resulting in a default of [now] being used for duration end date)