### PR TITLE
Making changes requested to the UI

### DIFF
--- a/client/app/compare/compare-services.html
+++ b/client/app/compare/compare-services.html
@@ -11,9 +11,11 @@
       <td width="300px">{{ service.key }}</td>
       <td width="300px">
         <service-cell data="service.primary" ng-if="service.primary"></service-cell>
+        <span ng-if="!service.primary"><span class="glyphicon glyphicon-info-sign"></span> Service not found in this environment. </span>
       </td>
       <td width="300px" class="text-nowrap" ng-repeat="env in vm.selected.environments" ng-init='comparison = service.comparisons[env.EnvironmentName]'>
         <service-cell data="comparison" ng-if="comparison"></service-cell>
+        <span ng-if="!comparison"><span class="glyphicon glyphicon-info-sign"></span> Service not found in this environment.</span>
       </td>
     </tr>
   </tbody>

--- a/client/app/compare/compare.html
+++ b/client/app/compare/compare.html
@@ -2,6 +2,7 @@
   <div class="row">
     <div class="col-md-12">
       <h2>Compare</h2>
+      <h3>Unless a State is selected, all information will be shown here. That information may not be comparable.</h3>
     </div>
   </div>
   <form id="SearchFilter" class="form-inline">
@@ -9,20 +10,33 @@
       <label class="control-label text-left">Compare:</label>
     </div>
     <div class="form-group">
-      <select class="form-control" ng-model="vm.selected.comparable" ng-options="cr as cr.name for cr in vm.comparableResources" ng-change="vm.onSelectionChanged()"></select>
+      <select class="form-control" ng-model="vm.selected.comparable" ng-options="cr as cr.name for cr in vm.comparableResources"
+        ng-change="vm.onSelectionChanged()"></select>
       <br />
     </div>
+
+    <div class="form-group" ng-if="vm.selected.comparable.key === 'versions'">
+      <label class="control-label text-left">State:</label>
+    </div>
+    <div class="form-group" ng-if="vm.selected.comparable.key === 'versions'">
+      <select class="form-control" ng-model="vm.selected.state" ng-change="vm.onSelectionChanged()">
+        <option ng-repeat="s in vm.states" ng-selected="{{s == vm.selected.state}}" value="{{s}}">{{s}}</option>
+      </select>
+    </div>
+
     <div class="form-group">
       <label class="control-label text-left">Primary Environment:</label>
     </div>
     <div class="form-group">
-      <select class="form-control" ng-model="vm.selected.primaryEnvironment" ng-options="env as env.EnvironmentName for env in vm.environments" ng-change="vm.onSelectionChanged()"></select>
+      <select class="form-control" ng-model="vm.selected.primaryEnvironment" ng-options="env as env.EnvironmentName for env in vm.environments"
+        ng-change="vm.onSelectionChanged()"></select>
     </div>
     <div ng-show="vm.selected.primaryEnvironment" class="form-group">
       <label class="control-label text-left">Compare With:</label>
     </div>
     <div ng-show="vm.selected.primaryEnvironment" class="form-group">
-      <ui-select style="width: 330px;" multiple limit="5" ng-model="vm.selected.environments" ng-change="vm.onSelectionChanged()" theme="bootstrap">
+      <ui-select style="width: 330px;" multiple limit="5" ng-model="vm.selected.environments" ng-change="vm.onSelectionChanged()"
+        theme="bootstrap">
         <ui-select-match placeholder="Select up to 5 environments..">
           {{ $item.EnvironmentName }}
         </ui-select-match>
@@ -37,15 +51,6 @@
     <div class="form-group" ng-if="vm.selected.comparable.key === 'versions'">
       <select class="form-control" ng-model="vm.selected.cluster" ng-change="vm.onSelectionChanged()">
         <option ng-repeat="c in vm.clustersList" ng-selected="{{c == vm.selected.cluster}}" value="{{c}}">{{c}}</option>
-      </select>
-    </div>
-
-    <div class="form-group" ng-if="vm.selected.comparable.key === 'versions'">
-      <label class="control-label text-left">State:</label>
-    </div>
-    <div class="form-group" ng-if="vm.selected.comparable.key === 'versions'">
-      <select class="form-control" ng-model="vm.selected.state" ng-change="vm.onSelectionChanged()">
-        <option ng-repeat="s in vm.states" ng-selected="{{s == vm.selected.state}}" value="{{s}}">{{s}}</option>
       </select>
     </div>
   </form>

--- a/client/app/compare/directives/serviceCell.html
+++ b/client/app/compare/directives/serviceCell.html
@@ -1,24 +1,28 @@
 <div class="service-cell" uib-popover popover-trigger="'mouseenter'" uib-popover-html="$ctrl.popoverHtml" popover-placement="left">
-  <div ng-repeat="deployment in $ctrl.data.deployments">
+  <span ng-if="$ctrl.data.deployments.Comparable === false"><span class="glyphicon glyphicon-question-sign"></span> Unable to determine
+  'Active' slice.</span>
+  <span ng-if="$ctrl.data.deployments.Comparable !== false">
+    <div ng-repeat="deployment in $ctrl.data.deployments">
     <span ng-if="!$ctrl.data.Active">
     {{ deployment.version }} <span ng-if="deployment.slice !== 'none'">(<span class="slice-symbol" ng-class="deployment.slice"></span>{{
-    deployment.slice }} )</span>
-    <span ng-if="deployment.versionCompare.toUpperCase() === 'SAME'"><span class="glyphicon glyphicon-minus"></span></span>
-    <span ng-if="deployment.versionCompare.toUpperCase() === 'NEWER'"><span class="glyphicon glyphicon-chevron-up"></span></span>
-    <span ng-if="deployment.versionCompare.toUpperCase() === 'OLDER'"><span class="glyphicon glyphicon-chevron-down"></span></span>
-    </span>
+  deployment.slice }} )</span>
+  <span ng-if="deployment.versionCompare.toUpperCase() === 'SAME'"><span class="glyphicon glyphicon-minus"></span></span>
+  <span ng-if="deployment.versionCompare.toUpperCase() === 'NEWER'"><span class="glyphicon glyphicon-chevron-up"></span></span>
+  <span ng-if="deployment.versionCompare.toUpperCase() === 'OLDER'"><span class="glyphicon glyphicon-chevron-down"></span></span>
+  </span>
 
-    <span ng-if="$ctrl.data.Comparable && $ctrl.data.Active">
+  <span ng-if="$ctrl.data.Comparable && $ctrl.data.Active">
     {{ deployment.version }} <span ng-if="deployment.slice !== 'none'">(<span class="slice-symbol" ng-class="deployment.slice"></span>{{
-    deployment.slice }} )</span>
-    <span ng-if="deployment.versionCompare.toUpperCase() === 'SAME'"><span class="glyphicon glyphicon-minus"></span></span>
-    <span ng-if="deployment.versionCompare.toUpperCase() === 'NEWER'"><span class="glyphicon glyphicon-chevron-up"></span></span>
-    <span ng-if="deployment.versionCompare.toUpperCase() === 'OLDER'"><span class="glyphicon glyphicon-chevron-down"></span></span>
-    </span>
+  deployment.slice }} )</span>
+  <span ng-if="deployment.versionCompare.toUpperCase() === 'SAME'"><span class="glyphicon glyphicon-minus"></span></span>
+  <span ng-if="deployment.versionCompare.toUpperCase() === 'NEWER'"><span class="glyphicon glyphicon-chevron-up"></span></span>
+  <span ng-if="deployment.versionCompare.toUpperCase() === 'OLDER'"><span class="glyphicon glyphicon-chevron-down"></span></span>
+  </span>
 
-    <span ng-if="!$ctrl.data.Comparable && $ctrl.data.Active">
+  <span ng-if="!$ctrl.data.Comparable && $ctrl.data.Active">
       <span ng-if="deployment.slice !== 'none'">Unable to determine 'Active' slice.</span>
-    <span ng-if="deployment.slice === 'none'">{{ deployment.version }}</span>
-    </span>
-  </div>
+  <span ng-if="deployment.slice === 'none'">{{ deployment.version }}</span>
+  </span>
+</div>
+</span>
 </div>

--- a/client/app/compare/services/serviceComparison.js
+++ b/client/app/compare/services/serviceComparison.js
@@ -27,8 +27,6 @@ angular.module('EnvironmentManager.compare').factory('serviceComparison',
             comparisons: getComparisons(primary, key)
           };
         });
-
-        decorateItemsWithVersionInformation(items);
         return items;
       }
 
@@ -44,7 +42,6 @@ angular.module('EnvironmentManager.compare').factory('serviceComparison',
         getComparisonsList(item).forEach(function (comparisonKey) {
           createVersionCompareInformation(item, comparisonKey, getLatestDeploymentVersion(item.primary));          
         });
-
       }
 
       function createVersionCompareInformation(item, comparisonKey, latestPrimaryDeploymentVersion) {
@@ -102,7 +99,8 @@ angular.module('EnvironmentManager.compare').factory('serviceComparison',
 
       var keys = getKeys();
       return {
-        items: getItems(keys)
+        items: getItems(keys),
+        compare: decorateItemsWithVersionInformation
       };
     };
   }

--- a/setup/cloudformation/EnvironmentManagerChangeEvents.template.yaml
+++ b/setup/cloudformation/EnvironmentManagerChangeEvents.template.yaml
@@ -1,0 +1,38 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Publication of Environment Manager Change Events
+Resources:
+  EnvironmentManagerCongfigurationChange:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.configurationChange
+      Runtime: nodejs4.3
+      CodeUri: file
+      Policies: AmazonDynamoDBReadOnlyAccess
+      # Environment:
+      #   Variables:
+      #     TABLE_NAME: !Ref Table
+      Events:
+        PutResourcee :
+          Type: Api
+          Properties:
+            Path: /events/configuration
+            Method: put
+  EnvironmentManagerOperationsChange:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.operationsChange
+      Runtime: nodejs4.3
+      # CodeUri: s3://bucketName/codepackage.zip
+      Policies: AmazonDynamoDBFullAccess
+      # Environment:
+      #   Variables:
+      #     TABLE_NAME: !Ref Table
+      Events:
+        PutResource:
+          Type: Api
+          Properties:
+            Path: /events/operations
+            Method: put
+  # Table:
+  #   Type: AWS::Serverless::SimpleTable


### PR DESCRIPTION
- Default to "Service not found in this environment" when a comparison cell is empty. 
- Remove chevron status indicator from a non active display. 
- Move the "state" selection option to a more primary location. 
- Default state of deployments to 'active' when there is only one. 
- Lowercase the selection 'of "ACTIVE"
- If there are n deployments with a non determined state, where n is greater than 1, there should only be one cell to say that it could not determine the state. 