### PR TITLE
Bug/compare page active state wording

### DIFF
--- a/client/app/compare/compare.html
+++ b/client/app/compare/compare.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-md-12">
       <h2>Compare</h2>
-      <h3 ng-if="vm.selected.state !== 'Active'">To compare active service versions, please select 'Active' state</h3>
+      <h3 ng-if="vm.selected.comparable.key === 'versions' && vm.selected.state !== 'Active'">To compare active service versions, please select 'Active' state</h3>
     </div>
   </div>
   <form id="SearchFilter" class="form-inline">

--- a/client/app/compare/compare.html
+++ b/client/app/compare/compare.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-md-12">
       <h2>Compare</h2>
-      <h3>Unless a State is selected, all information will be shown here. That information may not be comparable.</h3>
+      <h3 ng-if="vm.selected.state !== 'Active'">Unless a State is selected, all information will be shown here. That information may not be comparable.</h3>
     </div>
   </div>
   <form id="SearchFilter" class="form-inline">

--- a/client/app/compare/compare.html
+++ b/client/app/compare/compare.html
@@ -2,7 +2,6 @@
   <div class="row">
     <div class="col-md-12">
       <h2>Compare</h2>
-      <h3 ng-if="vm.selected.comparable.key === 'versions' && vm.selected.state !== 'Active'">To compare active service versions, please select 'Active' state</h3>
     </div>
   </div>
   <form id="SearchFilter" class="form-inline">
@@ -61,6 +60,7 @@
       <p>No data found to compare.</p>
     </div>
     <div class="col-md-12" ng-show="vm.view.items && vm.view.items.length > 0">
+      <h3 ng-if="vm.selected.comparable.key === 'versions' && vm.selected.state !== 'Active'">To compare active service versions, please select 'Active' state</h3>
       <div ng-include="'/app/compare/compare-services.html'"></div>
     </div>
   </div>

--- a/client/app/compare/compare.html
+++ b/client/app/compare/compare.html
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-md-12">
       <h2>Compare</h2>
-      <h3 ng-if="vm.selected.state !== 'Active'">Unless a State is selected, all information will be shown here. That information may not be comparable.</h3>
+      <h3 ng-if="vm.selected.state !== 'Active'">To compare active service versions, please select 'Active' state</h3>
     </div>
   </div>
   <form id="SearchFilter" class="form-inline">


### PR DESCRIPTION
- Heading should be visible within the results section of the page. 
- Heading should be visible if selected comparable 'versions' && selected state 'Active'.
- Wording should be passive voice.