### PR TITLE
Ops Environment Admin and Endpoint changes

### DIFF
--- a/client/app/common/common-modal/CommonModalController.js
+++ b/client/app/common/common-modal/CommonModalController.js
@@ -13,6 +13,8 @@ angular.module('EnvironmentManager.common').controller('CommonModalController',
     vm.details = (configuration.details || []).map($sce.trustAsHtml);
     vm.infoMode = configuration.infomode || false;
     vm.cancelLabel = configuration.cancelLabel || 'Cancel';
+    vm.acknowledge = configuration.acknowledge;
+    vm.isAcknowledged = !vm.acknowledge
 
     vm.ok = function () {
       $uibModalInstance.close();

--- a/client/app/common/common-modal/CommonModalController.js
+++ b/client/app/common/common-modal/CommonModalController.js
@@ -14,7 +14,7 @@ angular.module('EnvironmentManager.common').controller('CommonModalController',
     vm.infoMode = configuration.infomode || false;
     vm.cancelLabel = configuration.cancelLabel || 'Cancel';
     vm.acknowledge = configuration.acknowledge;
-    vm.isAcknowledged = !vm.acknowledge
+    vm.isAcknowledged = !vm.acknowledge;
 
     vm.ok = function () {
       $uibModalInstance.close();

--- a/client/app/common/common-modal/common-modal.html
+++ b/client/app/common/common-modal/common-modal.html
@@ -8,9 +8,15 @@
     <ul ng-if="vm.infoMode">
         <li ng-repeat="detail in vm.details" ng-bind-html="detail"></li>
     </ul>
+    <div ng-if="vm.acknowledge">
+      <label>
+        <input type="checkbox" ng-model="vm.isAcknowledged" />
+        {{vm.acknowledge}}
+      </label>
+    </div>
 </div>
 
 <div class="modal-footer">
     <button ng-if="!vm.infoMode" class="btn btn-default" type="button" ng-click="vm.cancel()">{{vm.cancelLabel}}</button>
-    <button class="btn btn-{{vm.severity}}" type="button" ng-click="vm.ok()">{{vm.action}}</button>
+    <button ng-disabled="!vm.isAcknowledged" class="btn btn-{{vm.severity}}" type="button" ng-click="vm.ok()">{{vm.action}}</button>
 </div>

--- a/client/app/environments/settings/env-manage-settings.html
+++ b/client/app/environments/settings/env-manage-settings.html
@@ -99,6 +99,19 @@
                     </p>
                 </div>
             </div>
+            <div class="form-group" data-ng-if="vm.enableMaintenanceChanges">
+                <label class="col-md-2 control-label text-left">&nbsp;</label>
+                <div class="col-md-3">
+                    <label>
+                        <input type="checkbox" data-ng-model="vm.newEnvironment.InMaintenance" />
+                        <span class="glyphicon glyphicon-wrench" aria-hidden="true"></span> Maintenance Mode</label>
+                    <p>
+                        <em>
+                            This will cause users of publicly available services in this environment to see a maintenance page.
+                        </em>
+                    </p>
+                </div>
+            </div>
             <div class="form-group">
                 <label class="col-md-1 control-label">&nbsp;</label>
                 <div class="col-md-2">

--- a/client/app/environments/summary/env-summary.html
+++ b/client/app/environments/summary/env-summary.html
@@ -53,7 +53,8 @@
       <tbody>
         <tr ng-repeat="env in vm.data | orderBy : 'EnvironmentName'">
           <td>
-            <span class="glyphicon glyphicon-lock" data-ng-if="env.Configuration.IsLocked"></span>
+            <span class="glyphicon glyphicon-lock" data-ng-if="env.Operation.DeploymentsLocked"></span>
+            <span class="glyphicon glyphicon-wrench" data-ng-if="env.Operation.InMaintenance"></span>
           </td>
           <td>
             <a href="#/environment/servers?environment={{env.EnvironmentName}}">{{env.EnvironmentName}} <small ng-if="env.Configuration.EnvironmentType">({{env.Configuration.EnvironmentType}})</small></a>

--- a/server/api/controllers/environments/environmentsController.js
+++ b/server/api/controllers/environments/environmentsController.js
@@ -50,11 +50,11 @@ function getDeploymentLock(req, res, next) {
     .then((masterAccountName) => {
       const key = req.swagger.params.name.value;
       return GetDynamoResource({ resource: 'ops/environments', key, exposeAudit: 'version-only', accountName: masterAccountName });
-    })       
+    })
     .then(data => ({
       EnvironmentName: data.EnvironmentName,
       Value: {
-        DeploymentsLocked: !!data.Value.DeploymentsLocked,
+        DeploymentsLocked: !!data.Value.DeploymentsLocked
       },
       Version: data.Version
     }))
@@ -68,7 +68,7 @@ function putDeploymentLock(req, res, next) {
   const environmentName = req.swagger.params.name.value;
   const user = req.user;
 
-  let input = req.swagger.params.body.value
+  let input = req.swagger.params.body.value;
   let update = { DeploymentsLocked: input.DeploymentsLocked };
   let expectedVersion = req.swagger.params['expected-version'].value;
 
@@ -84,11 +84,11 @@ function getMaintenance(req, res, next) {
     .then((masterAccountName) => {
       const key = req.swagger.params.name.value;
       return GetDynamoResource({ resource: 'ops/environments', key, exposeAudit: 'version-only', accountName: masterAccountName });
-    })       
+    })
     .then(data => ({
       EnvironmentName: data.EnvironmentName,
       Value: {
-        InMaintenance: !!data.Value.EnvironmentInMaintenance,
+        InMaintenance: !!data.Value.EnvironmentInMaintenance
       },
       Version: data.Version
     }))
@@ -102,7 +102,7 @@ function putMaintenance(req, res, next) {
   const environmentName = req.swagger.params.name.value;
   const user = req.user;
 
-  let input = req.swagger.params.body.value
+  let input = req.swagger.params.body.value;
   let update = { EnvironmentInMaintenance: input.InMaintenance };
   let expectedVersion = req.swagger.params['expected-version'].value;
 
@@ -149,7 +149,7 @@ function getEnvironmentSchedule(req, res, next) {
     .then((masterAccountName) => {
       const key = req.swagger.params.name.value;
       return GetDynamoResource({ resource: 'ops/environments', key, exposeAudit: 'version-only', accountName: masterAccountName });
-    })       
+    })
     .then(data => ({
       EnvironmentName: data.EnvironmentName,
       Value: {
@@ -169,7 +169,7 @@ function putEnvironmentSchedule(req, res, next) {
   const environmentName = req.swagger.params.name.value;
   const user = req.user;
 
-  let update = req.swagger.params.body.value
+  let update = req.swagger.params.body.value;
   let expectedVersion = req.swagger.params['expected-version'].value;
 
   updateOpsEnvironment(environmentName, update, expectedVersion, user)

--- a/server/api/controllers/environments/environmentsController.js
+++ b/server/api/controllers/environments/environmentsController.js
@@ -12,6 +12,7 @@ let OpsEnvironment = require('models/OpsEnvironment');
 let Promise = require('bluebird');
 let environmentProtection = require('modules/authorizers/environmentProtection');
 let awsAccounts = require('modules/awsAccounts');
+let _ = require('lodash');
 
 /**
  * GET /environments
@@ -42,15 +43,71 @@ function isEnvironmentProtectedFromAction(req, res) {
 }
 
 /**
+ * GET /environments/{name}/deploy-lock
+ */
+function getDeploymentLock(req, res, next) {
+  awsAccounts.getMasterAccountName()
+    .then((masterAccountName) => {
+      const key = req.swagger.params.name.value;
+      return GetDynamoResource({ resource: 'ops/environments', key, exposeAudit: 'version-only', accountName: masterAccountName });
+    })       
+    .then(data => ({
+      EnvironmentName: data.EnvironmentName,
+      Value: {
+        DeploymentsLocked: !!data.Value.DeploymentsLocked,
+      },
+      Version: data.Version
+    }))
+    .then(data => res.json(data)).catch(next);
+}
+
+/**
+ * PUT /environments/{name}/deploy-lock
+ */
+function putDeploymentLock(req, res, next) {
+  const environmentName = req.swagger.params.name.value;
+  const user = req.user;
+
+  let input = req.swagger.params.body.value
+  let update = { DeploymentsLocked: input.DeploymentsLocked };
+  let expectedVersion = req.swagger.params['expected-version'].value;
+
+  updateOpsEnvironment(environmentName, update, expectedVersion, user)
+    .then(data => res.json(data)).catch(next);
+}
+
+/**
  * GET /environments/{name}/maintenance
  */
-function isEnvironmentInMaintenance(req, res, next) {
-  const environmentName = req.swagger.params.name.value;
+function getMaintenance(req, res, next) {
+  awsAccounts.getMasterAccountName()
+    .then((masterAccountName) => {
+      const key = req.swagger.params.name.value;
+      return GetDynamoResource({ resource: 'ops/environments', key, exposeAudit: 'version-only', accountName: masterAccountName });
+    })       
+    .then(data => ({
+      EnvironmentName: data.EnvironmentName,
+      Value: {
+        InMaintenance: !!data.Value.EnvironmentInMaintenance,
+      },
+      Version: data.Version
+    }))
+    .then(data => res.json(data)).catch(next);
+}
 
-  OpsEnvironment.getByName(environmentName)
-    .then((env) => {
-      res.json({ isInMaintenance: !!env.Value.EnvironmentInMaintenance });
-    }).catch(next);
+/**
+ * PUT /environments/{name}/maintenance
+ */
+function putMaintenance(req, res, next) {
+  const environmentName = req.swagger.params.name.value;
+  const user = req.user;
+
+  let input = req.swagger.params.body.value
+  let update = { EnvironmentInMaintenance: input.InMaintenance };
+  let expectedVersion = req.swagger.params['expected-version'].value;
+
+  updateOpsEnvironment(environmentName, update, expectedVersion, user)
+    .then(data => res.json(data)).catch(next);
 }
 
 /**
@@ -91,33 +148,54 @@ function getEnvironmentSchedule(req, res, next) {
   awsAccounts.getMasterAccountName()
     .then((masterAccountName) => {
       const key = req.swagger.params.name.value;
-
-      GetDynamoResource({ resource: 'ops/environments', key, exposeAudit: 'version-only', accountName: masterAccountName })
-        .then(data => res.json(data)).catch(next);
-    });
+      return GetDynamoResource({ resource: 'ops/environments', key, exposeAudit: 'version-only', accountName: masterAccountName });
+    })       
+    .then(data => ({
+      EnvironmentName: data.EnvironmentName,
+      Value: {
+        ManualScheduleUp: data.Value.ManualScheduleUp,
+        ScheduleAutomatically: data.Value.ScheduleAutomatically,
+        DefaultSchedule: data.Value.DefaultSchedule
+      },
+      Version: data.Version
+    }))
+    .then(data => res.json(data)).catch(next);
 }
 
 /**
  * PUT /environments/{name}/schedule
  */
 function putEnvironmentSchedule(req, res, next) {
-  awsAccounts.getMasterAccountName()
-    .then((masterAccountName) => {
-      const key = req.swagger.params.name.value;
-      const item = { Value: req.swagger.params.body.value };
-      const user = req.user;
+  const environmentName = req.swagger.params.name.value;
+  const user = req.user;
 
-      const command = {
-        name: 'UpdateDynamoResource',
-        resource: 'ops/environments',
-        key,
-        item,
-        expectedVersion: req.swagger.params['expected-version'].value,
-        accountName: masterAccountName
-      };
+  let update = req.swagger.params.body.value
+  let expectedVersion = req.swagger.params['expected-version'].value;
 
-      sender.sendCommand({ command, user }).then(data => res.json(data)).catch(next);
-    });
+  updateOpsEnvironment(environmentName, update, expectedVersion, user)
+    .then(data => res.json(data)).catch(next);
+}
+
+function updateOpsEnvironment(environmentName, update, expectedVersion, user) {
+  return co(function* () {
+    let { masterAccountName, environment } = {
+      masterAccountName: yield awsAccounts.getMasterAccountName(),
+      environment: yield OpsEnvironment.getByName(environmentName)
+    };
+
+    let item = { Value: _.assign({}, environment.Value, update) };
+
+    const command = {
+      name: 'UpdateDynamoResource',
+      resource: 'ops/environments',
+      key: environmentName,
+      item,
+      expectedVersion,
+      accountName: masterAccountName
+    };
+
+    return sender.sendCommand({ command, user });
+  });
 }
 
 /**
@@ -140,5 +218,8 @@ module.exports = {
   putEnvironmentSchedule,
   getEnvironmentSchedule,
   isEnvironmentProtectedFromAction,
-  isEnvironmentInMaintenance
+  getMaintenance,
+  putMaintenance,
+  getDeploymentLock,
+  putDeploymentLock
 };

--- a/server/api/swagger.yaml
+++ b/server/api/swagger.yaml
@@ -2711,8 +2711,6 @@ definitions:
         type: integer
       DeploymentMap:
         type: string
-      IsLocked:
-        type: boolean
   EnvironmentTypeConfig:
     type: object
     required:

--- a/server/api/swagger.yaml
+++ b/server/api/swagger.yaml
@@ -516,7 +516,7 @@ paths:
   /environments/{name}/maintenance:
     x-swagger-router-controller: environmentsController
     get:
-      operationId: isEnvironmentInMaintenance
+      operationId: getMaintenance
       summary: Find if environment is in maintenance
       tags:
         - Environment
@@ -531,8 +531,72 @@ paths:
           schema:
             type: object
             properties:
-              isInMaintenance:
+              InMaintenance:
                 type: boolean
+    put:
+      operationId: putMaintenance
+      summary: Update whether or not the environment is in maintenance
+      tags:
+        - Environment
+      parameters:
+        - name: name
+          in: path
+          type: string
+          required: true
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              InMaintenance:
+                type: boolean
+        - $ref: '#/parameters/ExpectedVersionHeader'
+      responses:
+        200:
+          description: OK
+  /environments/{name}/deploy-lock:
+    x-swagger-router-controller: environmentsController
+    get:
+      operationId: getDeploymentLock
+      summary: Find if deployments are currently disabled for this environment
+      tags:
+        - Environment
+      parameters:
+        - name: name
+          in: path
+          type: string
+          required: true
+      responses:
+        200:
+          description: The environment
+          schema:
+            type: object
+            properties:
+              DeploymentsLocked:
+                type: boolean
+    put:
+      operationId: putDeploymentLock
+      summary: Update whether or not deployments to the environment are locked
+      tags:
+        - Environment
+      parameters:
+        - name: name
+          in: path
+          type: string
+          required: true
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            properties:
+              DeploymentsLocked:
+                type: boolean
+        - $ref: '#/parameters/ExpectedVersionHeader'
+      responses:
+        200:
+          description: OK
   /environments/{name}/servers:
     x-swagger-router-controller: environmentsController
     get:

--- a/server/commands/deployments/DeployService.js
+++ b/server/commands/deployments/DeployService.js
@@ -16,6 +16,7 @@ let SupportedSliceNames = _.values(Enums.SliceName);
 let SupportedDeploymentModes = _.values(Enums.DeploymentMode);
 let s3PackageLocator = require('modules/s3PackageLocator');
 let EnvironmentHelper = require('models/Environment');
+let OpsEnvironment = require('models/OpsEnvironment');
 let ResourceLockedError = require('modules/errors/ResourceLockedError');
 
 module.exports = function DeployServiceCommandHandler(command) {
@@ -74,10 +75,11 @@ function validateCommandAndCreateDeployment(command) {
     }
 
     const environment = yield EnvironmentHelper.getByName(command.environmentName);
+    const opsEnvironment = yield OpsEnvironment.getByName(command.environmentName);
     const environmentType = yield environment.getEnvironmentType();
     command.accountName = environmentType.AWSAccountName;
 
-    if (environment.IsLocked) {
+    if (opsEnvironment.Value.DeploymentsLocked) {
       throw new ResourceLockedError(`The environment ${environmentName} is currently locked for deployments. Contact the environment owner.`);
     }
 

--- a/server/models/OpsEnvironment.js
+++ b/server/models/OpsEnvironment.js
@@ -24,7 +24,8 @@ class OpsEnvironment {
   toAPIOutput() {
     let self = this;
     return co(function* () {
-      let value = _.pick(self.Value, 'ManualScheduleUp', 'ScheduleAutomatically');
+      let value = _.pick(self.Value, 'ManualScheduleUp', 'ScheduleAutomatically', 'DeploymentsLocked');
+      value.InMaintenance = self.Value.EnvironmentInMaintenance;
 
       let accountName = yield Environment.getAccountNameForEnvironment(self.EnvironmentName);
       value.AccountName = accountName;

--- a/server/test/commandHandlers/deployment/DeployServiceTest.js
+++ b/server/test/commandHandlers/deployment/DeployServiceTest.js
@@ -11,7 +11,9 @@ describe('DeployService', function () {
   let sut;
   let s3PackageLocator;
   let EnvironmentHelper;
+  let OpsEnvironment;
   let environment;
+  let opsEnvironment;
   let environmentType;
   let infrastructureConfigurationProvider;
   let namingConventionProvider;
@@ -57,8 +59,14 @@ describe('DeployService', function () {
     environment = {
       getEnvironmentType: sinon.stub().returns(Promise.resolve(environmentType))
     };
+    opsEnvironment = {
+      Value: { DeploymentsLocked: false }
+    };
     EnvironmentHelper = {
       getByName: sinon.stub().returns(Promise.resolve(environment))
+    };
+    OpsEnvironment = {
+      getByName: sinon.stub().returns(Promise.resolve(opsEnvironment))
     };
     s3PackageLocator = {
       findDownloadUrl: sinon.stub().returns(Promise.resolve(S3_PACKAGE))
@@ -88,6 +96,7 @@ describe('DeployService', function () {
     sut.__set__({ // eslint-disable-line no-underscore-dangle
       s3PackageLocator,
       EnvironmentHelper,
+      OpsEnvironment,
       infrastructureConfigurationProvider,
       namingConventionProvider,
       DeploymentContract,
@@ -214,7 +223,7 @@ describe('DeployService', function () {
     });
 
     describe('locked environments', function () {
-      beforeEach(() => { environment.IsLocked = true; });
+      beforeEach(() => { opsEnvironment.Value.DeploymentsLocked = true; });
 
       it('should not allow deployments', (done) => {
         sut(command).catch((error) => {


### PR DESCRIPTION
This PR:

1. Introduces Maintenance Mode for Environments to the UI using new Endpoints
2. Moves the Deployment Locks for Environments to the Ops/Environments table where it should be
3. Adds a required acknowledgement feature to confirmation modals (used first by Maintenance feature).