### PR TITLE
Remove logging formatter for dev / local builds

### DIFF
--- a/server/modules/logger.js
+++ b/server/modules/logger.js
@@ -3,12 +3,15 @@
 'use strict';
 
 let winston = require('winston');
-
 let AWS = require('aws-sdk');
-
 let config = require('config/');
-const EM_LOG_LEVEL = config.get('EM_LOG_LEVEL').toLowerCase();
 let fp = require('lodash/fp');
+
+const EM_LOG_LEVEL = config.get('EM_LOG_LEVEL').toLowerCase();
+const IS_PROD = config.get('IS_PRODUCTION');
+
+let transportOpts = { level: EM_LOG_LEVEL, showLevel: false };
+if (IS_PROD) transportOpts.formatter = formatter;
 
 function formatter(options) {
   let entry = {
@@ -24,15 +27,11 @@ function formatter(options) {
 
 const logger = new (winston.Logger)({
   transports: [
-    new (winston.transports.Console)({
-      level: EM_LOG_LEVEL,
-      showLevel: false,
-      formatter
-    })
+    new (winston.transports.Console)(transportOpts)
   ]
 });
 
-if (config.get('IS_PRODUCTION') === true) {
+if (IS_PROD) {
   // Globally configure aws-sdk to log all activity.
   AWS.config.update({
     logger: {

--- a/server/modules/sender.js
+++ b/server/modules/sender.js
@@ -8,8 +8,6 @@ let commandMetadata = require('commands/utils/metadata');
 
 const COMMAND_TYPE = 'Command';
 const QUERY_TYPE = 'Query';
-const THIN_SEPARATOR = new Array(50).join('-');
-const THICK_SEPARATOR = new Array(50).join('=');
 
 module.exports = {
   sendCommand(parameters, callback) {
@@ -44,8 +42,6 @@ function prepareQuery(parameters) {
   }
 
   query.timestamp = new Date().toISOString();
-  // let message = getLogMessage(query);
-  // logger.debug(message);
   return query;
 }
 
@@ -80,28 +76,18 @@ function sendCommandOrQuery(commandOrQuery) {
 }
 
 function getLogMessage(commandOrQuery) {
-  let message = [
-    THICK_SEPARATOR,
+  return [
     `[${commandOrQuery.name}]`,
-    JSON.stringify(commandOrQuery, null, '  '),
-    THICK_SEPARATOR
+    JSON.stringify(commandOrQuery, null, '  ')
   ].join('\n');
-
-  return message;
 }
 
 function getErrorMessage(commandOrQuery, error) {
-  let message = [
+  return [
     'Error executing:',
-    THICK_SEPARATOR,
     `[${commandOrQuery.name}]`,
     JSON.stringify(commandOrQuery, null, '  '),
-    THIN_SEPARATOR,
     error.toString(true),
-    THIN_SEPARATOR,
-    JSON.stringify(error),
-    THICK_SEPARATOR
+    JSON.stringify(error)
   ].join('\n');
-
-  return message;
 }


### PR DESCRIPTION
This change prevents the logging formatter being applied when running local development builds, making it much easier to view stack traces and other multiline logs.

It also removes the `======....` delimieter strings from sender logs.