### PR TITLE
Prevent undefined from being sent to AD when the user doesn't send a …

### DIFF
--- a/server/modules/active-directory-adapter/activeDirectoryAdapter.prod.js
+++ b/server/modules/active-directory-adapter/activeDirectoryAdapter.prod.js
@@ -30,7 +30,8 @@ module.exports = function ActiveDirectoryAdapter() {
 
       // Get the user information
       let segments = credentials.username.split('\\');
-      let username = segments[1];
+
+      let username = segments.length < 2 ? segments[0] : segments[1];
 
       let groups = yield adClient.getGroupMembershipForUserAsync(username);
 


### PR DESCRIPTION
…username value with a domain

People not submitting a username that contained domain\ meant that the split was sending undefined to the activedirectory module. 

Not it will send the username to activedirectory even if the split returns a single item. 