### PR TITLE
Log additional information about incoming HTTP requests

### DIFF
--- a/server/modules/express-middleware/loggingMiddleware.js
+++ b/server/modules/express-middleware/loggingMiddleware.js
@@ -10,7 +10,7 @@ const fp = require('lodash/fp');
 const miniStack = require('modules/miniStack');
 const path = require('path');
 
-let redactSecrets = fp.cloneDeepWith((value, key) => (/password/i.test(key) ? '********' : undefined))
+let redactSecrets = fp.cloneDeepWith((value, key) => (/password/i.test(key) ? '********' : undefined));
 
 let swaggerParams = fp.flow(
   fp.get(['swagger', 'params']),
@@ -65,6 +65,7 @@ let loggerMiddleware = logger => (req, res, next) => {
           'user-agent': fp.get(['headers', 'user-agent'])(req)
         },
         id: fp.get('id')(req),
+        ip: fp.get('ip')(req),
         method: fp.get('method')(req),
         originalUrl: fp.get('originalUrl')(req),
         params: req.originalUrl === '/api/token' ? redactSecrets(req.body) : swaggerParams(req)


### PR DESCRIPTION
This change logs additional information about each incoming HTTP request.

- Log the originating IP address for incoming HTTP requests
- Log the username field of requests to `/api/token`

https://jira.thetrainline.com/browse/PD-231