### PR TITLE
Fix missing properties in the 'New Servers' page

### DIFF
--- a/server/modules/merge.js
+++ b/server/modules/merge.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/**
+ * Merge the values of each property of the arguments into the corresponding property of the output.
+ * The value of each property of the returned object is the array of values of the same property of each argument object.
+ * @param {*} objects
+ */
+
+function merge(...objects) {
+  let result = objects
+    .filter(x => x !== undefined && x !== null)
+    .reduce((acc, nxt) => {
+      if (typeof nxt !== 'object') {
+        throw new Error('Each argument must be an object');
+      }
+      Object.keys(nxt).forEach((key) => {
+        if (acc[key] === undefined) {
+          acc[key] = [nxt[key]];
+        } else {
+          acc[key].unshift(nxt[key]);
+        }
+      });
+      return acc;
+    }, {});
+  Object.keys(result).forEach((key) => {
+    let value = result[key];
+    if (value.length === 1) {
+      result[key] = value[0];
+    }
+  });
+  return result;
+}
+
+module.exports = merge;

--- a/server/test/modules/mergeTest.js
+++ b/server/test/modules/mergeTest.js
@@ -1,0 +1,33 @@
+/* eslint-disable func-names */
+
+'use strict';
+
+let merge = require('modules/merge');
+let should = require('should');
+
+describe('merge', function () {
+  it('returns an empty object when given no arguments', function () {
+    should(merge()).eql({});
+  });
+  it('returns its argument when given one argument', function () {
+    should(merge({ a: 0, b: [1, 2, 3] })).eql({ a: 0, b: [1, 2, 3] });
+  });
+  it('returns an object with the union of the keys of its arguments', function () {
+    should(merge({ a: 0, b: 1 }, { b: 1, c: 2 })).have.properties(['a', 'b', 'c']);
+  });
+  it('returns an object with an array of the values of the property from the arguments', function () {
+    should(merge({ a: 0 }, { a: 1 }, { a: 2 })).property('a').length(3);
+  });
+  it('returns an object where the first item in the property array comes from the last argument', function () {
+    should(merge({ a: 0 }, { a: 1 }, { a: 2 })).eql({ a: [2, 1, 0] });
+  });
+  it('returns an object with a scalar property where that property has a value in a single argument', function () {
+    should(merge({ a: 0 }, { b: 1 }, { b: 2 })).property('a').eql(0);
+  });
+  it('throws an error if any of its arguments are not objects', function () {
+    should(() => merge('hello')).throw();
+  });
+  it('ignores null and undefined arguments', function () {
+    should(merge({ a: 1 }, null, undefined, { a: 2 })).eql(merge({ a: 1 }, { a: 2 }));
+  });
+});


### PR DESCRIPTION
This change fixes the following issues:
- _Environment_ was not displayed on the _New Servers_ page.
- _Auto Scaling Group_ was not displayed on the _New Servers_ page.
- _AccountName_, _InstanceId_ and _LaunchTime_ were being read as tags but are in fact properties of the instance.

These issues were caused by the response from _api/v1/instances_ no longer containing values from EC2 instance tags.

https://jira.thetrainline.com/browse/PD-230