### PR TITLE
Prefixed all names with 'infra' in the sns templates

### DIFF
--- a/setup/cloudformation/EnvironmentManagerEventAuditListeners/EnvironmentManagerEventsAuditListeners.template.yaml
+++ b/setup/cloudformation/EnvironmentManagerEventAuditListeners/EnvironmentManagerEventsAuditListeners.template.yaml
@@ -1,76 +1,76 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: Environment Manager Events
 Parameters: 
-  EnvironmentManagerEventsAdminRole:
+  InfraEnvironmentManagerEventsAdminRole:
     Type: String
     Description: Admin role ARN given to the Environment Manager events stack.
-  ConfigurationChangeEventTopic:
+  InfraConfigurationChangeEventTopic:
     Type: String
     Description: Configuration Change Event Topic ARN.
-  OperationsChangeEventTopic:
+  InfraOperationsChangeEventTopic:
     Type: String
     Description: Operations Change Event Topic ARN.
 Resources:
   #Item: Configuration Change
-  ConfigurationChangeAuditLambda:
+  InfraConfigurationChangeAuditLambda:
     Properties:
       Code:
         S3Bucket: cloudformation-eu-west-1-743871665500
         S3Key: EnvironmentManagerConfigurationChangeAudit.zip
       Description: Lambda to record Configuration Change events.
-      FunctionName: ConfigurationChangeAuditLambdaSubscription
+      FunctionName: InfraConfigurationChangeAuditLambdaSubscription
       Handler: index.handler
-      Role: !Ref EnvironmentManagerEventsAdminRole
+      Role: !Ref InfraEnvironmentManagerEventsAdminRole
       Runtime: nodejs4.3
     Type: AWS::Lambda::Function
-  ConfigurationChangeAuditLambdaSubscription:
+  InfraConfigurationChangeAuditLambdaSubscription:
     Properties:
       Endpoint:
         Fn::GetAtt:
-        - ConfigurationChangeAuditLambda
+        - InfraConfigurationChangeAuditLambda
         - Arn
       Protocol: lambda
       TopicArn:
-        Ref: ConfigurationChangeEventTopic
+        Ref: InfraConfigurationChangeEventTopic
     Type: AWS::SNS::Subscription
-  ConfigurationChangeAuditLambdaInvokePermission: 
+  InfraConfigurationChangeAuditLambdaInvokePermission: 
     Type: 'AWS::Lambda::Permission'
     Properties: 
       Action: 'lambda:InvokeFunction'
       Principal: 'sns.amazonaws.com'
-      SourceArn: !Ref ConfigurationChangeEventTopic
+      SourceArn: !Ref InfraConfigurationChangeEventTopic
       FunctionName: 
         Fn::GetAtt:
-        - ConfigurationChangeAuditLambda
+        - InfraConfigurationChangeAuditLambda
         - Arn
   #Item: Operations Change
-  OperationsChangeAuditLambda:
+  InfraOperationsChangeAuditLambda:
     Properties:
       Code:
         S3Bucket: cloudformation-eu-west-1-743871665500
         S3Key: EnvironmentManagerOperationsChangeAudit.zip
       Description: Lambda to record Operations Change events.
-      FunctionName: OperationsChangeAuditLambdaSubscription
+      FunctionName: InfraOperationsChangeAuditLambdaSubscription
       Handler: index.handler
-      Role: !Ref EnvironmentManagerEventsAdminRole
+      Role: !Ref InfraEnvironmentManagerEventsAdminRole
       Runtime: nodejs4.3
     Type: AWS::Lambda::Function
-  OperationsChangeAuditLambdaSubscription:
+  InfraOperationsChangeAuditLambdaSubscription:
     Properties:
       Endpoint:
         Fn::GetAtt:
-        - OperationsChangeAuditLambda
+        - InfraOperationsChangeAuditLambda
         - Arn
       Protocol: lambda
-      TopicArn: !Ref OperationsChangeEventTopic
+      TopicArn: !Ref InfraOperationsChangeEventTopic
     Type: AWS::SNS::Subscription
-  OperationsChangeAuditLambdaInvokePermission: 
+  InfraOperationsChangeAuditLambdaInvokePermission: 
     Type: 'AWS::Lambda::Permission'
     Properties: 
       Action: 'lambda:InvokeFunction'
       Principal: 'sns.amazonaws.com'
-      SourceArn: !Ref OperationsChangeEventTopic
+      SourceArn: !Ref InfraOperationsChangeEventTopic
       FunctionName: 
         Fn::GetAtt:
-        - OperationsChangeAuditLambda
+        - InfraOperationsChangeAuditLambda
         - Arn

--- a/setup/cloudformation/EnvironmentManagerEventPublication/EnvironmentManagerEvents.template.yaml
+++ b/setup/cloudformation/EnvironmentManagerEventPublication/EnvironmentManagerEvents.template.yaml
@@ -5,22 +5,22 @@ Resources:
   #Item: Configuration Change
   # This topic is a base path checked by SNS publish within EM. 
   # If the base path of an attempted publish to a topic doesn't contain this, it will not be allowed.
-  ConfigurationChangeTopic:
+  InfraConfigurationChangeTopic:
     Properties:
-      DisplayName: ConfigurationChange
-      TopicName: EnvironmentManagerConfigurationChange
+      DisplayName: InfraConfigurationChange
+      TopicName: InfraEnvironmentManagerConfigurationChange
     Type: AWS::SNS::Topic
   #Item: Operations Change
   # This topic is a base path checked by SNS publish within EM. 
   # If the base path of an attempted publish to a topic doesn't contain this, it will not be allowed.
-  OperationsChangeTopic:
+  InfraOperationsChangeTopic:
     Properties:
-      DisplayName: OperationsChange
-      TopicName: EnvironmentManagerOperationsChange
+      DisplayName: InfraOperationsChange
+      TopicName: InfraEnvironmentManagerOperationsChange
     Type: AWS::SNS::Topic
   #Roles
   # Allow SNS subscribers/lambdas to write to Cloud Watch.
-  EnvironmentManagerEventsAdminRole:
+  InfraEnvironmentManagerEventsAdminRole:
     Properties:
       AssumeRolePolicyDocument:
         Statement:
@@ -41,21 +41,21 @@ Resources:
             Resource:
               - arn:aws:logs:*:*:*
           Version: '2012-10-17'
-        PolicyName: EnvironmentManagerEventsCloudWatchPolicy
+        PolicyName: InfraEnvironmentManagerEventsCloudWatchPolicy
     Type: AWS::IAM::Role
 # To allow lambdas to subscribe to the topic, we need to know the ARN's they have been created with. 
 # For the moment, this requires outputs being recorded from here and used in future stacks. 
 # There is a _need_ to make this nicer!
 Outputs:
-  ConfigurationChangeTopicARN:
+  InfraConfigurationChangeTopicARN:
     Description: Configuration Change Topic ARN
-    Value: !Ref ConfigurationChangeTopic
-  OperationsChangeTopicARN: 
+    Value: !Ref InfraConfigurationChangeTopic
+  InfraOperationsChangeTopicARN: 
     Description: Operations Change Topic ARN
-    Value: !Ref OperationsChangeTopic
-  EnvironmentManagerEventsAdminRoleARN:
+    Value: !Ref InfraOperationsChangeTopic
+  InfraEnvironmentManagerEventsAdminRoleARN:
     Description: Environment Manager Events Admin Role ARN.
     Value: 
       Fn::GetAtt:
-      - EnvironmentManagerEventsAdminRole
+      - InfraEnvironmentManagerEventsAdminRole
       - Arn

--- a/setup/cloudformation/lambda/InfraEnvironmentManagerConfigurationChangeAudit/index.js
+++ b/setup/cloudformation/lambda/InfraEnvironmentManagerConfigurationChangeAudit/index.js
@@ -4,14 +4,14 @@
 
 /* eslint-disable no-console */
 
-console.log('Loading EnvironmentManagerOperationsChangeAudit function');
+console.log('Loading InfraEnvironmentManagerConfigurationChangeAudit function');
 
 exports.handler = (event, context, callback) => {
-  console.log('function EnvironmentManagerOperationsChangeAudit starting...');
+  console.log('function InfraEnvironmentManagerConfigurationChangeAudit starting...');
   const attributes = event.Records[0].Sns.MessageAttributes;
   const attributeString = Object.keys(attributes).map(key => `${key}:${attributes[key].Value}`).join(',');
-  console.log('Operations Change Attributes:', attributeString);
+  console.log('Configuration Change Attributes:', attributeString);
   const message = event.Records[0].Sns.Message;
-  console.log('Operations Change SNS:', message);
+  console.log('Configuration Change SNS:', message);
   callback(null, message);
 };

--- a/setup/cloudformation/lambda/InfraEnvironmentManagerOperationsChangeAudit/index.js
+++ b/setup/cloudformation/lambda/InfraEnvironmentManagerOperationsChangeAudit/index.js
@@ -4,14 +4,14 @@
 
 /* eslint-disable no-console */
 
-console.log('Loading EnvironmentManagerConfigurationChangeAudit function');
+console.log('Loading InfraEnvironmentManagerOperationsChangeAudit function');
 
 exports.handler = (event, context, callback) => {
-  console.log('function EnvironmentManagerConfigurationChangeAudit starting...');
+  console.log('function InfraEnvironmentManagerOperationsChangeAudit starting...');
   const attributes = event.Records[0].Sns.MessageAttributes;
   const attributeString = Object.keys(attributes).map(key => `${key}:${attributes[key].Value}`).join(',');
-  console.log('Configuration Change Attributes:', attributeString);
+  console.log('Operations Change Attributes:', attributeString);
   const message = event.Records[0].Sns.Message;
-  console.log('Configuration Change SNS:', message);
+  console.log('Operations Change SNS:', message);
   callback(null, message);
 };


### PR DESCRIPTION
- All names which were previously missing an 'infra' prefix with SNS cloud formation templates have had their values changed. 