### PR TITLE
Consolidate running deployments and deployment history into one table each

### DIFF
--- a/client/app/operations/deployments/DeploymentDetailsModalController.js
+++ b/client/app/operations/deployments/DeploymentDetailsModalController.js
@@ -166,6 +166,7 @@ angular.module('EnvironmentManager.operations')
       cachedResources.config.clusters.all().then(function (list) {
         clusters = list;
         updateView(deployment);
+        refreshData();
       });
     }
 

--- a/client/app/operations/deployments/ops-deployment-details-modal.html
+++ b/client/app/operations/deployments/ops-deployment-details-modal.html
@@ -12,7 +12,6 @@
             <li><strong>Service:</strong> {{vm.view.ServiceName}} ({{vm.view.ServiceVersion}})</li>
             <li><strong>AutoScalingGroup:</strong> <a ng-href="{{vm.view.asgLink}}">{{vm.view.asgName}}</a></li>
             <li><strong>User:</strong> {{vm.view.User}} ({{vm.view.OwningCluster}})</li>
-            <li><strong>Deployment Type:</strong> {{vm.view.DeploymentType}}</li>
             <li><strong>Deployment ID:</strong> {{vm.view.DeploymentID}}</li>
             <li data-ng-if="vm.expectedNodesKnown"><strong>Nodes Deployed:</strong> {{vm.view.nodesCompleted}} / {{vm.view.expectedNodes}}</li>
         </ul>

--- a/server/commands/deployments/DeployService.js
+++ b/server/commands/deployments/DeployService.js
@@ -117,7 +117,6 @@ function deploy(deployment, destination, sourcePackage, command) {
 
     deploymentLogger.inProgress(
       deployment.id,
-      deployment.accountName,
       'Waiting for nodes to perform service deployment...'
     );
   }).catch((error) => {

--- a/server/commands/deployments/DeploymentCommandHandlerLogger.js
+++ b/server/commands/deployments/DeploymentCommandHandlerLogger.js
@@ -5,20 +5,25 @@
 let logger = require('modules/logger');
 let deploymentLogger = require('modules/DeploymentLogger');
 
-module.exports = function DeploymentCommandHandlerLogger(command) {
-  let deploymentId = command.commandId;
-  let accountName = command.accountName;
+module.exports = function DeploymentCommandHandlerLogger(commandOrDeploymentId) {
+  let deploymentId = (() => {
+    if (typeof commandOrDeploymentId === 'string') {
+      return commandOrDeploymentId;
+    } else {
+      return commandOrDeploymentId.deploymentId || commandOrDeploymentId.commandId;
+    }
+  })();
 
   this.debug = logger.debug.bind(logger);
 
   this.info = function (message) {
     logger.info(message);
-    deploymentLogger.inProgress(deploymentId, accountName, message);
+    deploymentLogger.inProgress(deploymentId, message);
   };
 
   this.warn = function (message) {
     logger.warn(message);
-    deploymentLogger.inProgress(deploymentId, accountName, message);
+    deploymentLogger.inProgress(deploymentId, message);
   };
 
   this.error = logger.error.bind(logger);

--- a/server/models/Deployment.js
+++ b/server/models/Deployment.js
@@ -3,9 +3,7 @@
 'use strict';
 
 let _ = require('lodash');
-let deploymentsHelper = require('modules/queryHandlersUtil/deployments-helper');
-let systemUser = require('modules/systemUser');
-let sender = require('modules/sender');
+let deployments = require('modules/data-access/deployments');
 
 class Deployment {
 
@@ -17,32 +15,8 @@ class Deployment {
   }
 
   static getById(key) {
-    return deploymentsHelper.get({ key });
+    return deployments.get({ DeploymentID: key });
   }
-
-  updateItemValue(itemValue) {
-    let command = {
-      name: 'UpdateDynamoResource',
-      resource: 'deployments/history',
-      accountName: this.AccountName,
-      key: this.DeploymentID,
-      item: itemValue
-    };
-    return sender.sendCommand({ command, user: systemUser });
-  }
-
-  addExecutionLogEntries(logs) {
-    let executionLog = this.Value.ExecutionLog;
-    let executionLogEntries = executionLog ? executionLog.split('\n') : [];
-    executionLogEntries = executionLogEntries.concat(logs);
-
-    this.Value.ExecutionLog = executionLogEntries.join('\n');
-
-    return this.updateItemValue({
-      'Value.ExecutionLog': this.Value.ExecutionLog
-    });
-  }
-
 }
 
 module.exports = Deployment;

--- a/server/modules/awsDynamo/dynamodbExpression.js
+++ b/server/modules/awsDynamo/dynamodbExpression.js
@@ -34,6 +34,7 @@ function compileOne(scope, expr) {
   let prefix = ([fn, ...args]) => `${fn}(${args.map(compile).join(', ')})`;
   let attr = ([, ...exprs]) => exprs.map(name => scope.nameExpressionAttributeName(name)).join('.');
   let val = ([, ...exprs]) => exprs.map(value => scope.nameExpressionAttributeValue(value)).join(', ');
+  let list = ([, sep, ...items]) => `${items.map(compile).join(sep)}`;
   let update = ([, ...args]) => {
     let assign = opargs => opargs.map(compile).join(' = ');
     let ref = opargs => opargs.map(compile).join(', ');
@@ -68,6 +69,7 @@ function compileOne(scope, expr) {
     'and': infix,
     'at': attr,
     'attr': attr,
+    'list': list,
     'or': infix,
     'update': update,
     'val': val

--- a/server/modules/data-access/deployments.js
+++ b/server/modules/data-access/deployments.js
@@ -1,0 +1,183 @@
+/* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
+
+'use strict';
+
+let { getTableName: physicalTableName } = require('modules/awsResourceNameProvider');
+let Promise = require('bluebird');
+let awsAccounts = require('modules/awsAccounts');
+let logger = require('modules/logger');
+let { mkArn } = require('modules/data-access/dynamoTableArn');
+let describeDynamoTable = require('modules/data-access/describeDynamoTable');
+let { hashKeyAttributeName, tableArn } = require('modules/data-access/dynamoTableDescription');
+let { DateTimeFormatterBuilder, LocalDate, ZoneId } = require('js-joda');
+let { makeWritable } = require('modules/data-access/dynamoItemFilter');
+let dynamoTable = require('modules/data-access/dynamoTable');
+let fp = require('lodash/fp');
+
+const DEFAULT_SCAN_EXPRESSIONS = {
+  ProjectionExpression: ['list', ', ',
+    ['at', 'AccountName'],
+    ['at', 'DeploymentID'],
+    ['at', 'Value', 'EndTimestamp'],
+    ['at', 'Value', 'EnvironmentName'],
+    ['at', 'Value', 'EnvironmentType'],
+    ['at', 'Value', 'Nodes'],
+    ['at', 'Value', 'OwningCluster'],
+    ['at', 'Value', 'RuntimeServerRoleName'],
+    ['at', 'Value', 'ServerRoleName'],
+    ['at', 'Value', 'ServiceName'],
+    ['at', 'Value', 'ServiceSlice'],
+    ['at', 'Value', 'ServiceVersion'],
+    ['at', 'Value', 'StartTimestamp'],
+    ['at', 'Value', 'Status'],
+    ['at', 'Value', 'User']]
+};
+
+const ES_DATETIME_FORMAT = new DateTimeFormatterBuilder().appendInstant(3).toFormatter();
+
+function otherAccounts() {
+  return awsAccounts.all()
+    .then(fp.flow(
+      fp.filter(x => !x.IsMaster),
+      fp.map('AccountNumber'),
+      fp.uniq));
+}
+
+function factory({ archivedDeploymentsTable, archivedDeploymentsIndex, runningDeploymentsTable }) {
+  let tableDescriptionPromise = args => mkArn(args).then(describeDynamoTable);
+
+  let tableNames = [archivedDeploymentsTable, runningDeploymentsTable];
+
+  function myTables() {
+    return Promise.resolve(tableNames.map(tableName => mkArn({ tableName })));
+  }
+
+  function otherTables() {
+    return otherAccounts()
+      .then(fp.reduce((result, account) =>
+        [...result, ...tableNames.map(tableName => mkArn({ account, tableName }))], []));
+  }
+
+  function create(item) {
+    return tableDescriptionPromise({ tableName: runningDeploymentsTable }).then(description =>
+      fp.flow(
+        makeWritable,
+        record => ({
+          record,
+          expressions: {
+            ConditionExpression: ['attribute_not_exists', ['at', hashKeyAttributeName(description)]]
+          }
+        }),
+        dynamoTable.create.bind(null, tableArn(description))
+      )(item)
+    );
+  }
+
+  function get(key) {
+    let firstFoundOrNull = fp.flow(fp.find(x => x !== null), fp.defaultTo(null));
+    let logAndReturnNull = (error) => { logger.warn(error); return null; };
+
+    let getFromMyTables = () => Promise.map(myTables(), arn => dynamoTable.get(arn, key))
+      .then(firstFoundOrNull);
+    let getFromOtherTables = () => Promise.map(otherTables(), arn => dynamoTable.get(arn, key).catch(logAndReturnNull))
+      .then(firstFoundOrNull);
+
+    return getFromMyTables()
+      .then(result => (result !== null ? Promise.resolve(result) : getFromOtherTables()));
+  }
+
+  function scanRunning(expressions) {
+    return mkArn({ tableName: runningDeploymentsTable })
+      .then(table => dynamoTable.scan(table, Object.assign({}, DEFAULT_SCAN_EXPRESSIONS, expressions)));
+  }
+
+  function queryByDateRange(minInstant, maxInstant, expressions) {
+    function scanArchived() {
+      function next(prevKey) {
+        return prevKey.minusDays(1);
+      }
+
+      let createQuery = date => ({
+        IndexName: archivedDeploymentsIndex,
+        KeyConditionExpression: ['and',
+          ['=', ['at', 'StartDate'], ['val', date.toString()]],
+          ['>=', ['at', 'StartTimestamp'], ['val', ES_DATETIME_FORMAT.format(minInstant)]]],
+        Limit: 100,
+        ScanIndexForward: false
+      });
+
+      function loop(table, partition, lowerBound, results) {
+        let partitionContainingLowerBound = LocalDate.ofInstant(lowerBound, ZoneId.UTC);
+        if (partition.isBefore(partitionContainingLowerBound)) {
+          return results;
+        } else {
+          return dynamoTable.query(table, Object.assign({}, DEFAULT_SCAN_EXPRESSIONS, expressions, createQuery(partition)))
+            .then((result) => {
+              results.push(...result);
+              return loop(table, next(partition), lowerBound, results);
+            });
+        }
+      }
+
+      let tables = Promise.join(
+        mkArn({ tableName: archivedDeploymentsTable }),
+        Promise.map(otherAccounts(), account => mkArn({ account, tableName: archivedDeploymentsTable })),
+        (mine, others) => [mine, ...others]
+      );
+
+      let firstPartition = LocalDate.ofInstant(maxInstant, ZoneId.UTC);
+      return Promise.map(tables, table => Promise.resolve().then(() => loop(table, firstPartition, minInstant, [])).catch((error) => {
+        logger.warn(error);
+        return [];
+      })).then(fp.flatten);
+    }
+
+    return Promise.join(
+      scanRunning(expressions),
+      scanArchived(),
+      (running, archived) => [...running, ...archived]);
+  }
+
+  function update(expression) {
+    return tableDescriptionPromise({ tableName: runningDeploymentsTable }).then(description =>
+      fp.flow(
+        ({ key, updateExpression }) => ({
+          key,
+          expressions: { UpdateExpression: updateExpression }
+        }),
+        dynamoTable.update.bind(null, tableArn(description))
+      )(expression)
+    );
+  }
+
+  function appendLogEntries({ key, logEntries }) {
+    let updateExpression = [
+      'update',
+      ['set',
+        ['at', 'Value', 'ExecutionLog'],
+        ['list_append',
+          ['at', 'Value', 'ExecutionLog'],
+          ['val', logEntries]]]
+    ];
+
+    return update({
+      key,
+      updateExpression
+    });
+  }
+
+  return {
+    appendLogEntries,
+    create,
+    get,
+    queryByDateRange,
+    scanRunning,
+    update
+  };
+}
+
+module.exports = factory({
+  archivedDeploymentsTable: physicalTableName('ConfigCompletedDeployments'),
+  archivedDeploymentsIndex: 'StartDate-StartTimestamp-index',
+  runningDeploymentsTable: physicalTableName('ConfigDeploymentExecutionStatus')
+});

--- a/server/test/commandHandlers/deployment/DeployServiceTest.js
+++ b/server/test/commandHandlers/deployment/DeployServiceTest.js
@@ -214,9 +214,8 @@ describe('DeployService', function () {
     });
 
     it('should pass deployment to logger.inProgress', (done) => {
-      deploymentLogger.inProgress = function (id, accountName) {
+      deploymentLogger.inProgress = function (id) {
         assert.equal(id, command.commandId);
-        assert.equal(accountName, ACCOUNT_NAME);
         done();
       };
       sut(command);

--- a/server/test/modules/DeploymentLogsStreamerTest.js
+++ b/server/test/modules/DeploymentLogsStreamerTest.js
@@ -1,86 +1,78 @@
-/* TODO: enable linting and fix resulting errors */
-/* eslint-disable */
+/* eslint-disable func-names */
+
 'use strict';
 
-let memoize = require('modules/memoize');
 let proxyquire = require('proxyquire').noCallThru();
-let should = require('should');
-let sinon = require('sinon');
+require('should');
 
 describe('DeploymentLogsStreamer', function () {
-    let deploymentLogsStreamer;
-    let fakeTimer;
-    let loggedMessages;
-    let deploymentLogs;
-    beforeEach(function () {
+  let deploymentLogsStreamer;
+  let fakeTimer;
+  let loggedMessages;
+  let deploymentLogs;
+  beforeEach(function () {
+    deploymentLogs = [];
+    let fakeDeployment = {
+      appendLogEntries: ({ key: { DeploymentID: deploymentId }, logEntries }) => {
+        logEntries.forEach(entry => deploymentLogs.push({ deploymentId, entry }));
+        return Promise.resolve();
+      }
+    };
 
-        deploymentLogs = [];
-        let fakeDeployment = {
-            getById: deploymentId => Promise.resolve({
-                addExecutionLogEntries: entries => {
-                    entries.forEach(entry => deploymentLogs.push({ deploymentId, entry }));
-                }
-            }),
+    loggedMessages = [];
+    let fakeLogger = (() => {
+      let logger = {};
+      ['error', 'warn', 'info', 'debug'].forEach((level) => {
+        logger[level] = (message) => {
+          loggedMessages.push({ level, message });
         };
+      });
+      return logger;
+    })();
 
-        loggedMessages = [];
-        let fakeLogger = (() => {
-            let logger = {};
-            ['error', 'warn', 'info', 'debug'].forEach(level => {
-                logger[level] = message => {
-                    loggedMessages.push({ level, message });
-                }
-            });
-            return logger;
-        })();
+    fakeTimer = (() => {
+      let callbacks = [];
+      return {
+        elapse: () => Promise.all(callbacks.map(fn => Promise.resolve(fn()))),
+        setInterval: (fn, _) => callbacks.push(fn)
+      };
+    })();
 
-        fakeTimer = (() => {
-            let callbacks = []
-            return {
-                elapse: () => Promise.all(callbacks.map(fn => Promise.resolve(fn()))),
-                setInterval: (fn, _) => callbacks.push(fn),
-            }
-        })();
-
-        let DeploymentLogsStreamer = proxyquire('modules/DeploymentLogsStreamer', {
-            'models/Deployment': fakeDeployment,
-            'modules/logger': fakeLogger,
-            'timers': fakeTimer,
-        });
-        deploymentLogsStreamer = new DeploymentLogsStreamer();
+    let DeploymentLogsStreamer = proxyquire('modules/DeploymentLogsStreamer', {
+      'modules/data-access/deployments': fakeDeployment,
+      'modules/logger': fakeLogger,
+      'timers': fakeTimer
     });
-    describe('log', function () {
-        context('once the flush period has elapsed', function () {
-            it('adds the messages to the correct deployment', function () {
-                let deploymentId = 'my-deployment-id';
-                let accountName = 'my-account-name';
-                ['one', 'two'].forEach(message => deploymentLogsStreamer.log('deployment-1', accountName, message));
-                ['three'].forEach(message => deploymentLogsStreamer.log('deployment-2', accountName, message));
-                return fakeTimer.elapse().then(() => deploymentLogs).should.finally.match([
+    deploymentLogsStreamer = new DeploymentLogsStreamer();
+  });
+  describe('log', function () {
+    context('once the flush period has elapsed', function () {
+      it('adds the messages to the correct deployment', function () {
+        ['one', 'two'].forEach(message => deploymentLogsStreamer.log('deployment-1', message));
+        ['three'].forEach(message => deploymentLogsStreamer.log('deployment-2', message));
+        return fakeTimer.elapse().then(() => deploymentLogs).should.finally.match([
                     { deploymentId: 'deployment-1', entry: /one/ },
                     { deploymentId: 'deployment-1', entry: /two/ },
-                    { deploymentId: 'deployment-2', entry: /three/ },
-                ]);
-            });
-        });
+                    { deploymentId: 'deployment-2', entry: /three/ }
+        ]);
+      });
     });
-    describe('flush', function () {
-        it('flushes all the log entries for the specified deployment', function () {
-            let deploymentId = 'my-deployment-id';
-            let accountName = 'my-account-name';
-            ['one', 'two'].forEach(message => deploymentLogsStreamer.log(deploymentId, accountName, message));
-            return deploymentLogsStreamer.flush(deploymentId).then(() => deploymentLogs).should.finally.match([
+  });
+  describe('flush', function () {
+    it('flushes all the log entries for the specified deployment', function () {
+      let deploymentId = 'my-deployment-id';
+      ['one', 'two'].forEach(message => deploymentLogsStreamer.log(deploymentId, message));
+      return deploymentLogsStreamer.flush(deploymentId).then(() => deploymentLogs).should.finally.match([
                 { deploymentId, entry: /one/ },
-                { deploymentId, entry: /two/ },
-            ]);
-        });
-        it('does not double up entries if called twice', function () {
-            let deploymentId = 'my-deployment-id';
-            let accountName = 'my-account-name';
-            deploymentLogsStreamer.log(deploymentId, accountName, 'hello');
-            let flush = () => deploymentLogsStreamer.flush(deploymentId);
-            return Promise.all([flush(), flush()]).then(() => deploymentLogs).should.finally.have.length(1);
-        });
+                { deploymentId, entry: /two/ }
+      ]);
     });
+    it('does not double up entries if called twice', function () {
+      let deploymentId = 'my-deployment-id';
+      deploymentLogsStreamer.log(deploymentId, 'hello');
+      let flush = () => deploymentLogsStreamer.flush(deploymentId);
+      return Promise.all([flush(), flush()]).then(() => deploymentLogs).should.finally.have.length(1);
+    });
+  });
 });
 

--- a/server/test/modules/awsDynamo/dynamodbExpressionTest.js
+++ b/server/test/modules/awsDynamo/dynamodbExpressionTest.js
@@ -149,6 +149,16 @@ describe('dynamodb expression', function () {
           'ADD #A1 = :val0, #A4 = :val3 DELETE :val1 REMOVE #A2 SET #A3 = :val2');
       });
     });
+    context('when I compile a list expression', function () {
+      let input = ['list', ', ',
+        ['at', 'a', 'b'],
+        ['at', 'c', 'd']];
+      let result = sut.compile(input);
+      it('the expression is correct.', function () {
+        result.Expression.should.eql(
+          '#a.#b, #c.#d');
+      });
+    });
   });
 });
 

--- a/server/test/modules/data-access/deploymentsTest.js
+++ b/server/test/modules/data-access/deploymentsTest.js
@@ -1,0 +1,208 @@
+/* eslint-disable func-names */
+
+'use strict';
+
+require('should');
+let fakeLogger = require('test/utils/fakeLogger');
+let { Instant } = require('js-joda');
+let proxyquire = require('proxyquire');
+let sinon = require('sinon');
+
+let defaults = {
+  'modules/awsAccounts': {
+    all: () => Promise.resolve(['child-account-1', 'child-account-2'].map(x => ({ AccountNumber: x })))
+  },
+  'modules/awsResourceNameProvider': { getTableName: x => x },
+  'modules/data-access/describeDynamoTable': arn => Promise.resolve({
+    Table: {
+      KeySchema: [{ KeyType: 'HASH', AttributeName: 'DeploymentID' }],
+      TableArn: arn
+    }
+  }),
+  'modules/data-access/dynamoTableArn': {
+    mkArn: ({ tableName, account }) =>
+      Promise.resolve(`${account || 'master-account'}:${tableName}`)
+  },
+  'modules/logger': fakeLogger
+};
+
+describe('deployments', function () {
+  describe('get', function () {
+    let withDynamoGet = get => proxyquire('modules/data-access/deployments',
+      Object.assign({}, defaults, {
+        'modules/data-access/dynamoTable': { get }
+      }));
+    it('returns null when the deployment is not found', function () {
+      let sut = withDynamoGet(() => Promise.resolve(null));
+      return sut.get({ DeploymentID: '' }).should.finally.be.null();
+    });
+    it('requests a deployment with the specified key', function () {
+      let get = sinon.spy(() => Promise.resolve(null));
+      let sut = withDynamoGet(get);
+      return sut.get({ DeploymentID: 'my-deployment' }).then(() =>
+        sinon.assert.alwaysCalledWith(get, sinon.match.any, { DeploymentID: 'my-deployment' }));
+    });
+    context('when the deployment is found in one table', function () {
+      let scenarios = [
+        ['master-account', 'ConfigDeploymentExecutionStatus'],
+        ['master-account', 'ConfigCompletedDeployments'],
+        ['child-account-2', 'ConfigDeploymentExecutionStatus'],
+        ['child-account-2', 'ConfigCompletedDeployments']
+      ];
+      scenarios.forEach(([account, table]) => {
+        it(`returns the deployment if it is found in ${table} in ${account}`, function () {
+          let sut = withDynamoGet((arn, key) => (arn === `${account}:${table}`
+            ? Promise.resolve({})
+            : Promise.resolve(null)));
+          return sut.get({ DeploymentID: '' }).should.finally.eql({});
+        });
+      });
+    });
+    context('when a failure occurs accessing a table in the master account', function () {
+      let scenarios = [
+        ['master-account', 'ConfigDeploymentExecutionStatus'],
+        ['master-account', 'ConfigCompletedDeployments']
+      ];
+      scenarios.forEach(([account, table]) => {
+        it(`returns a rejected promise for ${table}`, function () {
+          let sut = withDynamoGet((arn, key) => (arn === `${account}:${table}`
+            ? Promise.reject(new Error('BOOM!'))
+            : Promise.resolve(null)));
+          return sut.get({ DeploymentID: '' }).should.be.rejected();
+        });
+      });
+    });
+    context('when a failure occurs accessing a table in a child account', function () {
+      let scenarios = [
+        ['child-account-2', 'ConfigDeploymentExecutionStatus'],
+        ['child-account-2', 'ConfigCompletedDeployments']
+      ];
+      scenarios.forEach(([account, table]) => {
+        it(`returns null for ${table}`, function () {
+          let sut = withDynamoGet((arn, key) => (arn === `${account}:${table}`
+            ? Promise.reject(new Error('BOOM!'))
+            : Promise.resolve(null)));
+          return sut.get({ DeploymentID: '' }).should.finally.be.null();
+        });
+      });
+    });
+    context('when the deployment is found in a child account but there are failures accessing others', function () {
+      let successTables = [
+        ['child-account-2', 'ConfigDeploymentExecutionStatus'],
+        ['child-account-2', 'ConfigCompletedDeployments']
+      ];
+      successTables.forEach(([account, table]) => {
+        it(`returns the deployment for ${table}`, function () {
+          let sut = withDynamoGet((arn, key) => {
+            if (arn === `${account}:${table}`) {
+              return Promise.resolve({});
+            } else if (arn.startsWith('master-account')) {
+              return Promise.resolve(null);
+            } else {
+              Promise.reject(new Error('BOOM!'));
+            }
+            return sut.get({ DeploymentID: '' }).should.finally.eql({});
+          });
+        });
+      });
+    });
+    context('when the deployment is found in a table in the master account', function () {
+      let scenarios = [
+        ['master-account', 'ConfigDeploymentExecutionStatus'],
+        ['master-account', 'ConfigCompletedDeployments']
+      ];
+      scenarios.forEach(([account, table]) => {
+        it(`the child accounts are not searched (${table})`, function () {
+          let get = sinon.spy((arn, key) => (arn === `${account}:${table}`
+            ? Promise.resolve({})
+            : Promise.resolve(null)));
+          let sut = withDynamoGet(get);
+          return sut.get({ DeploymentID: '' }).then(() =>
+            sinon.assert.neverCalledWith(get, sinon.match(/^child-account.*/)));
+        });
+      });
+    });
+  });
+  describe('queryByDateRange', function () {
+    let withScanAndQuery = ({ query, scan }) => proxyquire('modules/data-access/deployments',
+      Object.assign({}, defaults, {
+        'modules/data-access/dynamoTable': {
+          query: query || (() => Promise.resolve([])),
+          scan: scan || (() => Promise.resolve([]))
+        }
+      }));
+    it('scans the ConfigDeploymentExecutionStatus table', function () {
+      let scan = sinon.spy(() => Promise.resolve([]));
+      let sut = withScanAndQuery({ scan });
+      return sut.queryByDateRange(Instant.parse('2000-01-01T00:00:00Z'), Instant.parse('2000-01-01T00:00:00Z'))
+        .then(() => sinon.assert.alwaysCalledWith(scan, 'master-account:ConfigDeploymentExecutionStatus'));
+    });
+    context('queries the ConfigCompletedDeployments table', function () {
+      let query = sinon.spy(() => Promise.resolve([]));
+      let results;
+      before(function () {
+        let sut = withScanAndQuery({ query });
+        results = sut.queryByDateRange(Instant.parse('2000-01-01T03:00:00.000Z'), Instant.parse('2000-01-03T23:59:00Z'));
+      });
+      it('in each account', function () {
+        return results.then(() => {
+          sinon.assert.alwaysCalledWith(query, sinon.match(/:ConfigCompletedDeployments$/));
+          sinon.assert.calledWith(query, sinon.match(/^master-account:/));
+          sinon.assert.calledWith(query, sinon.match(/^child-account-1:/));
+          sinon.assert.calledWith(query, sinon.match(/^child-account-2:/));
+        });
+      });
+      it('for each day in the range', function () {
+        return results.then(() => {
+          sinon.assert.calledWith(query, sinon.match.any, sinon.match({
+            KeyConditionExpression: ['and',
+              ['=', ['at', 'StartDate'], ['val', '2000-01-03']],
+              ['>=', ['at', 'StartTimestamp'], ['val', '2000-01-01T03:00:00.000Z']]]
+          }));
+          sinon.assert.calledWith(query, sinon.match.any, sinon.match({
+            KeyConditionExpression: ['and',
+              ['=', ['at', 'StartDate'], ['val', '2000-01-02']],
+              ['>=', ['at', 'StartTimestamp'], ['val', '2000-01-01T03:00:00.000Z']]]
+          }));
+          sinon.assert.calledWith(query, sinon.match.any, sinon.match({
+            KeyConditionExpression: ['and',
+              ['=', ['at', 'StartDate'], ['val', '2000-01-01']],
+              ['>=', ['at', 'StartTimestamp'], ['val', '2000-01-01T03:00:00.000Z']]]
+          }));
+        });
+      });
+      it('with the expected parameters', function () {
+        return results.then(() =>
+          sinon.assert.alwaysCalledWith(query, sinon.match.any, sinon.match(
+            {
+              IndexName: 'StartDate-StartTimestamp-index',
+              ScanIndexForward: false
+            }
+          )));
+      });
+    });
+    it('returns the set of results from all tables', function () {
+      let query = table => Promise.resolve([{ table, type: 'query' }]);
+      let scan = table => Promise.resolve([{ table, type: 'scan' }]);
+      let sut = withScanAndQuery({ query, scan });
+      // one query result for each day for each child account plus one scan result.
+      return sut.queryByDateRange(Instant.parse('2000-01-01T00:00:00Z'), Instant.parse('2000-01-03T23:59:00Z')).should.finally.have.length((3 * 3) + 1);
+    });
+    context('when the scan of ConfigDeploymentExecutionStatus fails', function () {
+      it('returns a rejected promise', function () {
+        let query = () => Promise.resolve([{}]);
+        let scan = () => Promise.reject(new Error('BOOM!'));
+        let sut = withScanAndQuery({ query, scan });
+        return sut.queryByDateRange(Instant.parse('2000-01-01T00:00:00Z'), Instant.parse('2000-01-03T23:59:00Z')).should.be.rejected();
+      });
+    });
+    context('when the query of ConfigCompletedDeployments fails', function () {
+      it('returns the rest of the results', function () {
+        let query = () => Promise.reject(new Error('BOOM!'));
+        let scan = () => Promise.resolve([{}]);
+        let sut = withScanAndQuery({ query, scan });
+        return sut.queryByDateRange(Instant.parse('2000-01-01T00:00:00Z'), Instant.parse('2000-01-03T23:59:00Z')).should.finally.eql([{}]);
+      });
+    });
+  });
+});

--- a/server/test/modules/queryHandlersUtil/deployments-helperTest.js
+++ b/server/test/modules/queryHandlersUtil/deployments-helperTest.js
@@ -1,114 +1,47 @@
-/* TODO: enable linting and fix resulting errors */
-/* eslint-disable */
+/* eslint-disable func-names */
+
 'use strict';
 
 require('should');
 let proxyquire = require('proxyquire').noCallThru();
 let sinon = require('sinon');
-
-let accounts = [
-  { AccountName: 'master-account', IsMaster: true },
-  { AccountName: 'child-account', IsMaster: false },
-];
-
-let accountNames = ['master-account', 'child-account'];
-let tableNames = ['ConfigDeploymentExecutionStatus', 'ConfigCompletedDeployments'];
-
-function stubGet(value) {
-  return { promise: () => Promise.resolve(value || {}) };
-}
+let ResourceNotFoundError = require('modules/errors/ResourceNotFoundError.class');
 
 function commonStubs() {
   return {
-    'modules/awsAccounts': {
-      all: () => Promise.resolve(accounts),
+    'modules/data-access/deployments': {
+      get: () => Promise.resolve(null)
     },
-    'modules/awsResourceNameProvider': {
-      getTableName: str => str,
-    },
-    'modules/amazon-client/childAccountClient': {},
     'modules/configurationCache': {},
-    'modules/logger': {
-      warn: () => { },
-    },
     'modules/sender': {
       sendQuery: () => Promise.resolve({})
-    },
+    }
   };
 }
 
 describe('deployments-helper', () => {
-  describe('when I get a single deployment by ID', () => {
-    describe('queries are submitted to DynamoDB', () => {
-      let allQueriesSubmitted;
-      before(() => {
-        let dynamoGet = {
-          'child-account': sinon.spy(query => stubGet()),
-          'master-account': sinon.spy(query => stubGet()),
-        };
-        let createDynamoClient = sinon.spy(accountName => Promise.resolve({
-          get: dynamoGet[accountName],
-        }));
-        let sut = proxyquire('modules/queryHandlersUtil/deployments-helper', Object.assign(commonStubs(), {
-          'modules/amazon-client/childAccountClient': {
-            createDynamoClient,
-          },
-        }));
-        allQueriesSubmitted = sut.get({ key: 'deployment-id' }).catch(() => dynamoGet);
-      });
-      accountNames.forEach((account) => {
-        tableNames.forEach((table) => {
-          it(`a query is executed against the "${table}" table in the "${account}" account`, () =>
-            allQueriesSubmitted.then(dynamo => sinon.assert.calledWith(dynamo[account], sinon.match({ TableName: table })))
-          );
-        });
-        it(`all queries executed in "${account}" are for the correct key`, () =>
-          allQueriesSubmitted.then(receiver => sinon.assert.alwaysCalledWith(receiver[account], sinon.match({ Key: { DeploymentID: 'deployment-id' } })))
-        );
-      });
-    });
-
-    it('dynamo queries use prefixed table names', () => {
-      let get = sinon.spy(() => stubGet());
+  describe('queryDeployment', () => {
+    it('throws an error if the deployment is not found', () => {
+      let get = sinon.spy(() => Promise.resolve(null));
       let sut = proxyquire('modules/queryHandlersUtil/deployments-helper', Object.assign(commonStubs(), {
-        'modules/awsResourceNameProvider': {
-          getTableName: str => `my-prefix-${str}`,
-        },
-        'modules/amazon-client/childAccountClient': {
-          createDynamoClient: () => Promise.resolve({ get }),
-        },
+        'modules/data-access/deployments': { get }
       }));
-      return sut.get({ key: 'deployment-id' }).catch(() => sinon.assert.calledWith(get, sinon.match({ TableName: 'my-prefix-ConfigDeploymentExecutionStatus' })));
-    });
-
-    it('if there is no such deployment I get an error', () => {
-      let sut = proxyquire('modules/queryHandlersUtil/deployments-helper', Object.assign(commonStubs(), {
-        'modules/amazon-client/childAccountClient': {
-          createDynamoClient: {
-            get: () => stubGet(),
-          },
-        },
-      }));
-      return sut.get({ key: 'deployment-id' }).should.be.rejected();
+      return sut.get({ key: '' }).should.be.rejectedWith(ResourceNotFoundError);
     });
 
     it('returns a deployment with unknown number of expected nodes', () => {
       let Deployment = require('models/Deployment');
       let expected = new Deployment({
         Value: { Status: 'success' },
-        AccountName: 'master-account',
+        AccountName: 'master-account'
       });
-      let get = sinon.stub();
-      get.onCall(0).returns({ promise: () => Promise.reject(new Error('oops')) });
-      get.onCall(1).returns(stubGet());
-      get.onCall(2).returns(stubGet());
-      get.onCall(3).returns(stubGet({ Item: { Value: { Status: 'success' } } }));
+      let get = () => Promise.resolve({ Value: { Status: 'success' } });
       let sut = proxyquire('modules/queryHandlersUtil/deployments-helper', Object.assign(commonStubs(), {
-        'modules/amazon-client/childAccountClient': {
-          createDynamoClient: () => Promise.resolve({ get }),
+        'modules/data-access/deployments': {
+          get
         },
         'modules/configurationCache': {
-          getEnvironmentTypeByName: envType => Promise.resolve({ AWSAccountName: 'master-account' }),
+          getEnvironmentTypeByName: envType => Promise.resolve({ AWSAccountName: 'master-account' })
         }
       }));
 
@@ -118,25 +51,21 @@ describe('deployments-helper', () => {
     it('returns a deployment with expected number nodes', () => {
       const expectedNodes = 14;
       let stubs = commonStubs();
-      stubs['modules/sender'] = { sendQuery: () => Promise.resolve({ value:{ ExpectedNodeDeployments:expectedNodes} }) };
+      stubs['modules/sender'] = { sendQuery: () => Promise.resolve({ value: { ExpectedNodeDeployments: expectedNodes } }) };
 
       let Deployment = require('models/Deployment');
       let expected = new Deployment({
         Value: { Status: 'success' },
         AccountName: 'master-account',
-        ExpectedNodes:expectedNodes
+        ExpectedNodes: expectedNodes
       });
-      let get = sinon.stub();
-      get.onCall(0).returns({ promise: () => Promise.reject(new Error('oops')) });
-      get.onCall(1).returns(stubGet());
-      get.onCall(2).returns(stubGet());
-      get.onCall(3).returns(stubGet({ Item: { Value: { Status: 'success' } } }));
+      let get = () => Promise.resolve({ Value: { Status: 'success' } });
       let sut = proxyquire('modules/queryHandlersUtil/deployments-helper', Object.assign(stubs, {
-        'modules/amazon-client/childAccountClient': {
-          createDynamoClient: () => Promise.resolve({ get }),
+        'modules/data-access/deployments': {
+          get
         },
         'modules/configurationCache': {
-          getEnvironmentTypeByName: envType => Promise.resolve({ AWSAccountName: 'master-account' }),
+          getEnvironmentTypeByName: envType => Promise.resolve({ AWSAccountName: 'master-account' })
         }
       }));
 
@@ -146,49 +75,30 @@ describe('deployments-helper', () => {
     it('returns multiple deployments with expected number nodes', () => {
       const expectedNodes = 6;
       let stubs = commonStubs();
-      stubs['modules/sender'] = { sendQuery: () => Promise.resolve([
-        { value:{ ExpectedNodeDeployments:expectedNodes } },
-        { value:{ ExpectedNodeDeployments:expectedNodes * 2 } }
-      ]) };
+      stubs['modules/sender'] = {
+        sendQuery: () => Promise.resolve([
+          { value: { ExpectedNodeDeployments: expectedNodes } },
+          { value: { ExpectedNodeDeployments: expectedNodes * 2 } }
+        ])
+      };
 
       let Deployment = require('models/Deployment');
       let expected = new Deployment({
         Value: { Status: 'success' },
         AccountName: 'master-account',
-        ExpectedNodes:expectedNodes
+        ExpectedNodes: expectedNodes
       });
-      let get = sinon.stub();
-      get.onCall(0).returns({ promise: () => Promise.reject(new Error('oops')) });
-      get.onCall(1).returns(stubGet());
-      get.onCall(2).returns(stubGet());
-      get.onCall(3).returns(stubGet({ Item: { Value: { Status: 'success' } } }));
+      let get = () => Promise.resolve({ Value: { Status: 'success' } });
       let sut = proxyquire('modules/queryHandlersUtil/deployments-helper', Object.assign(stubs, {
-        'modules/amazon-client/childAccountClient': {
-          createDynamoClient: () => Promise.resolve({ get }),
+        'modules/data-access/deployments': {
+          get
         },
         'modules/configurationCache': {
-          getEnvironmentTypeByName: envType => Promise.resolve({ AWSAccountName: 'master-account' }),
+          getEnvironmentTypeByName: envType => Promise.resolve({ AWSAccountName: 'master-account' })
         }
       }));
 
       return sut.get({ key: 'deployment-id' }).should.finally.be.eql(expected);
-    });
-    
-    it('if a query throws an error it is logged', () => {
-      let expectedError = new Error('oops');
-      let get = sinon.stub();
-      get.onCall(0).returns({ promise: () => Promise.reject(expectedError) });
-      get.onCall(1).returns(stubGet());
-      get.onCall(2).returns(stubGet());
-      get.onCall(3).returns(stubGet());
-      let warn = sinon.spy(() => { });
-      let sut = proxyquire('modules/queryHandlersUtil/deployments-helper', Object.assign(commonStubs(), {
-        'modules/logger': { warn },
-        'modules/amazon-client/childAccountClient': {
-          createDynamoClient: () => Promise.resolve({ get }),
-        },
-      }));
-      return sut.get({ key: 'deployment-id' }).catch(() => sinon.assert.calledWith(warn, sinon.match(expectedError)));
     });
   });
 });


### PR DESCRIPTION
Environment Manager previously wrote each deployment record to a DynamoDB table in the AWS account targeted by that deployment. This change updates Environment Manager to write all deployment records to a single table in the AWS account that hosts Environment Manager. Deployment records are still read from the the hosting account and the managed accounts.

https://jira.thetrainline.com/browse/PD-217