### PR TITLE
Read deployments from tables in master account only

### DIFF
--- a/setup/cloudformation/EnvironmentManagerCommonResources.template.js
+++ b/setup/cloudformation/EnvironmentManagerCommonResources.template.js
@@ -259,80 +259,6 @@ module.exports = function ({ managedAccounts }) {
                     "TableName": "ConfigNotificationSettings"
                 }
             },
-            "ConfigDeploymentExecutionStatus": {
-                "Type": "AWS::DynamoDB::Table",
-                "Properties": {
-                    "AttributeDefinitions": [
-                        {
-                            "AttributeName": "DeploymentID",
-                            "AttributeType": "S"
-                        }
-                    ],
-                    "KeySchema": [
-                        {
-                            "AttributeName": "DeploymentID",
-                            "KeyType": "HASH"
-                        }
-                    ],
-                    "ProvisionedThroughput": {
-                        "ReadCapacityUnits": 10,
-                        "WriteCapacityUnits": 2
-                    },
-                    "TableName": "ConfigDeploymentExecutionStatus"
-                }
-            },
-            "ConfigCompletedDeployments": {
-                "Type": "AWS::DynamoDB::Table",
-                "Properties": {
-                    "AttributeDefinitions": [
-                        {
-                            "AttributeName": "DeploymentID",
-                            "AttributeType": "S"
-                        },
-                        {
-                            "AttributeName": "StartTimestamp",
-                            "AttributeType": "S"
-                        },
-                        {
-                            "AttributeName": "StartDate",
-                            "AttributeType": "S"
-                        }
-                    ],
-                    "GlobalSecondaryIndexes": [
-                        {
-                            "IndexName": "StartDate-StartTimestamp-index",
-                            "KeySchema": [
-                                {
-                                    "AttributeName": "StartDate",
-                                    "KeyType": "HASH"
-                                },
-                                {
-                                    "AttributeName": "StartTimestamp",
-                                    "KeyType": "RANGE"
-                                }
-                            ],
-                            "Projection": {
-                                "ProjectionType": "ALL"
-                            },
-                            "ProvisionedThroughput": {
-                                "ReadCapacityUnits": 10,
-                                "WriteCapacityUnits": 2
-                            }
-                        }
-                    ],
-                    "KeySchema": [
-                        {
-                            "AttributeName": "DeploymentID",
-                            "KeyType": "HASH"
-                        }
-                    ],
-                    "ProvisionedThroughput": {
-                        "ReadCapacityUnits": 10,
-                        "WriteCapacityUnits": 2
-                    },
-                    "TableName": "ConfigCompletedDeployments"
-                }
-            },
             "ConfigEnvironmentTypes": {
                 "Type": "AWS::DynamoDB::Table",
                 "Properties": {
@@ -686,7 +612,6 @@ module.exports = function ({ managedAccounts }) {
                                                 'ConfigDeploymentMaps',
                                                 'ConfigLBSettings',
                                                 'ConfigLBUpstream',
-                                                'ConfigDeploymentExecutionStatus',
                                                 'ConfigEnvironmentTypes',
                                                 'InfraAsgIPs',
                                                 'InfraConfigAccounts',
@@ -714,7 +639,6 @@ module.exports = function ({ managedAccounts }) {
                         "ConfigDeploymentMaps",
                         "ConfigLBSettings",
                         "ConfigLBUpstream",
-                        "ConfigDeploymentExecutionStatus",
                         "ConfigEnvironmentTypes",
                         "InfraAsgIPs",
                         "InfraChangeAudit",

--- a/setup/cloudformation/EnvironmentManagerMasterResources.template.js
+++ b/setup/cloudformation/EnvironmentManagerMasterResources.template.js
@@ -103,6 +103,80 @@ module.exports = function ({ managedAccounts }) {
             }
         },
         "Resources": {
+            "ConfigDeploymentExecutionStatus": {
+                "Type": "AWS::DynamoDB::Table",
+                "Properties": {
+                    "AttributeDefinitions": [
+                        {
+                            "AttributeName": "DeploymentID",
+                            "AttributeType": "S"
+                        }
+                    ],
+                    "KeySchema": [
+                        {
+                            "AttributeName": "DeploymentID",
+                            "KeyType": "HASH"
+                        }
+                    ],
+                    "ProvisionedThroughput": {
+                        "ReadCapacityUnits": 10,
+                        "WriteCapacityUnits": 2
+                    },
+                    "TableName": "ConfigDeploymentExecutionStatus"
+                }
+            },
+            "ConfigCompletedDeployments": {
+                "Type": "AWS::DynamoDB::Table",
+                "Properties": {
+                    "AttributeDefinitions": [
+                        {
+                            "AttributeName": "DeploymentID",
+                            "AttributeType": "S"
+                        },
+                        {
+                            "AttributeName": "StartTimestamp",
+                            "AttributeType": "S"
+                        },
+                        {
+                            "AttributeName": "StartDate",
+                            "AttributeType": "S"
+                        }
+                    ],
+                    "GlobalSecondaryIndexes": [
+                        {
+                            "IndexName": "StartDate-StartTimestamp-index",
+                            "KeySchema": [
+                                {
+                                    "AttributeName": "StartDate",
+                                    "KeyType": "HASH"
+                                },
+                                {
+                                    "AttributeName": "StartTimestamp",
+                                    "KeyType": "RANGE"
+                                }
+                            ],
+                            "Projection": {
+                                "ProjectionType": "ALL"
+                            },
+                            "ProvisionedThroughput": {
+                                "ReadCapacityUnits": 10,
+                                "WriteCapacityUnits": 2
+                            }
+                        }
+                    ],
+                    "KeySchema": [
+                        {
+                            "AttributeName": "DeploymentID",
+                            "KeyType": "HASH"
+                        }
+                    ],
+                    "ProvisionedThroughput": {
+                        "ReadCapacityUnits": 10,
+                        "WriteCapacityUnits": 2
+                    },
+                    "TableName": "ConfigCompletedDeployments"
+                }
+            },
             "loadBalancerEnvironmentManager": {
                 "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
                 "Properties": {


### PR DESCRIPTION
This change stops Environment Manager from attempting to read deployments from DynamoDB owned by each of the managed accounts. It now reads all deployments from the _ConfigDeploymentExecutionStatus_ and _ConfigCompletedDeployments_ tables owned by the master account

https://jira.thetrainline.com/browse/PD-245