### PR TITLE
PD-256 Respond with 404 for non-existent resource

### DIFF
--- a/server/api/api-utils/ifNotFound.js
+++ b/server/api/api-utils/ifNotFound.js
@@ -1,0 +1,13 @@
+'use strict';
+
+let { hasValue, when } = require('modules/functional');
+
+let ifNotFound = when.bind(null, hasValue, data => res => res.json(data));
+
+let notFoundMessage = resourceType =>
+  () => res => res.status(404).json({ error: `The ${resourceType} was not found` });
+
+module.exports = {
+  ifNotFound,
+  notFoundMessage
+};

--- a/server/api/controllers/config/clusters/clusterController.js
+++ b/server/api/controllers/config/clusters/clusterController.js
@@ -9,6 +9,8 @@ let getMetadataForDynamoAudit = require('api/api-utils/requestMetadata').getMeta
 let param = require('api/api-utils/requestParam');
 let versionOf = require('modules/data-access/dynamoVersion').versionOf;
 let removeAuditMetadata = require('modules/data-access/dynamoAudit').removeAuditMetadata;
+let { hasValue, when } = require('modules/functional');
+let { ifNotFound, notFoundMessage } = require('api/api-utils/ifNotFound');
 
 function keyOf(value) {
   let t = {};
@@ -37,8 +39,10 @@ function getClustersConfig(req, res, next) {
 function getClusterConfigByName(req, res, next) {
   const key = param('name', req);
   return clusters.get(keyOf(key))
-    .then(convertToApiModel)
-    .then(data => res.json(data)).catch(next);
+    .then(when(hasValue, convertToApiModel))
+    .then(ifNotFound(notFoundMessage('cluster')))
+    .then(send => send(res))
+    .catch(next);
 }
 
 /**

--- a/server/api/controllers/config/deployment-maps/deploymentMapController.js
+++ b/server/api/controllers/config/deployment-maps/deploymentMapController.js
@@ -7,6 +7,8 @@ let getMetadataForDynamoAudit = require('api/api-utils/requestMetadata').getMeta
 let param = require('api/api-utils/requestParam');
 let versionOf = require('modules/data-access/dynamoVersion').versionOf;
 let removeAuditMetadata = require('modules/data-access/dynamoAudit').removeAuditMetadata;
+let { hasValue, when } = require('modules/functional');
+let { ifNotFound, notFoundMessage } = require('api/api-utils/ifNotFound');
 
 const KEY_NAME = 'DeploymentMapName';
 function keyOf(value) {
@@ -37,8 +39,9 @@ function getDeploymentMapsConfig(req, res, next) {
 function getDeploymentMapConfigByName(req, res, next) {
   let key = param('name', req);
   return deploymentMaps.get(keyOf(key))
-    .then(convertToApiModel)
-    .then(data => res.json(data))
+    .then(when(hasValue, convertToApiModel))
+    .then(ifNotFound(notFoundMessage('deployment map')))
+    .then(send => send(res))
     .catch(next);
 }
 

--- a/server/api/controllers/config/environment-types/environmentTypeController.js
+++ b/server/api/controllers/config/environment-types/environmentTypeController.js
@@ -8,6 +8,8 @@ let configEnvironmentTypes = require('modules/data-access/configEnvironmentTypes
 let getMetadataForDynamoAudit = require('api/api-utils/requestMetadata').getMetadataForDynamoAudit;
 let param = require('api/api-utils/requestParam');
 let { versionOf } = require('modules/data-access/dynamoVersion');
+let { hasValue, when } = require('modules/functional');
+let { ifNotFound, notFoundMessage } = require('api/api-utils/ifNotFound');
 
 function keyOf(value) {
   let t = {};
@@ -36,8 +38,10 @@ function getEnvironmentTypesConfig(req, res, next) {
 function getEnvironmentTypeConfigByName(req, res, next) {
   const key = param('name', req);
   return configEnvironmentTypes.get(keyOf(key))
-    .then(convertToApiModel)
-    .then(data => res.json(data)).catch(next);
+    .then(when(hasValue, convertToApiModel))
+    .then(ifNotFound(notFoundMessage('environment type')))
+    .then(send => send(res))
+    .catch(next);
 }
 
 /**

--- a/server/api/controllers/config/environments/environmentsConfigController.js
+++ b/server/api/controllers/config/environments/environmentsConfigController.js
@@ -23,6 +23,8 @@ let Environment = require('models/Environment');
 let EnvironmentType = require('models/EnvironmentType');
 
 let consul = require('modules/service-targets/consul');
+let { hasValue, when } = require('modules/functional');
+let { ifNotFound, notFoundMessage } = require('api/api-utils/ifNotFound');
 
 function attachMetadata(input) {
   input.Version = versionOf(input);
@@ -66,9 +68,10 @@ function getEnvironmentConfigByName(req, res, next) {
     EnvironmentName: param('name', req)
   };
   return configEnvironments.get(key)
-    .then(attachMetadata)
-    .then(removeAuditMetadata)
-    .then(data => res.json(data))
+    .then(when(hasValue, attachMetadata))
+    .then(when(hasValue, removeAuditMetadata))
+    .then(ifNotFound(notFoundMessage('environment')))
+    .then(send => send(res))
     .catch(next);
 }
 

--- a/server/api/controllers/config/notification-settings/notificationSettingsController.js
+++ b/server/api/controllers/config/notification-settings/notificationSettingsController.js
@@ -7,6 +7,8 @@ let getMetadataForDynamoAudit = require('api/api-utils/requestMetadata').getMeta
 let param = require('api/api-utils/requestParam');
 let versionOf = require('modules/data-access/dynamoVersion').versionOf;
 let removeAuditMetadata = require('modules/data-access/dynamoAudit').removeAuditMetadata;
+let { hasValue, when } = require('modules/functional');
+let { ifNotFound, notFoundMessage } = require('api/api-utils/ifNotFound');
 
 function convertToApiModel(persistedModel) {
   let apiModel = removeAuditMetadata(persistedModel);
@@ -31,8 +33,10 @@ function getNotificationSettingsById(req, res, next) {
     NotificationSettingsId: param('id', req)
   };
   return notificationSettings.get(key)
-    .then(convertToApiModel)
-    .then(data => res.json(data)).catch(next);
+    .then(when(hasValue, convertToApiModel))
+    .then(ifNotFound(notFoundMessage('notification setting')))
+    .then(send => send(res))
+    .catch(next);
 }
 
 /**

--- a/server/api/controllers/config/services/servicesConfigController.js
+++ b/server/api/controllers/config/services/servicesConfigController.js
@@ -7,6 +7,8 @@ let getMetadataForDynamoAudit = require('api/api-utils/requestMetadata').getMeta
 let param = require('api/api-utils/requestParam');
 let versionOf = require('modules/data-access/dynamoVersion').versionOf;
 let removeAuditMetadata = require('modules/data-access/dynamoAudit').removeAuditMetadata;
+let { hasValue, when } = require('modules/functional');
+let { ifNotFound, notFoundMessage } = require('api/api-utils/ifNotFound');
 
 function convertToApiModel(persistedModel) {
   let apiModel = removeAuditMetadata(persistedModel);
@@ -25,7 +27,7 @@ function getServicesConfig(req, res, next) {
 }
 
 /**
- * GET /config/services/{name}
+ * GET /config/services/{name}/{cluster}
  */
 function getServiceConfigByName(req, res, next) {
   let key = {
@@ -33,8 +35,10 @@ function getServiceConfigByName(req, res, next) {
     OwningCluster: param('cluster', req)
   };
   return services.get(key)
-    .then(convertToApiModel)
-    .then(data => res.json(data)).catch(next);
+    .then(when(hasValue, convertToApiModel))
+    .then(ifNotFound(notFoundMessage('service')))
+    .then(send => send(res))
+    .catch(next);
 }
 
 /**
@@ -68,7 +72,7 @@ function putServiceConfigByName(req, res, next) {
 }
 
 /**
- * DELETE /config/services/{name}/{infra}
+ * DELETE /config/services/{name}/{cluster}
  */
 function deleteServiceConfigByName(req, res, next) {
   let key = {

--- a/server/api/controllers/deployments/deploymentsController.js
+++ b/server/api/controllers/deployments/deploymentsController.js
@@ -9,6 +9,7 @@ let sender = require('modules/sender');
 let Enums = require('Enums');
 let activeDeploymentsStatusProvider = require('modules/monitoring/activeDeploymentsStatusProvider');
 let deploymentLogger = require('modules/DeploymentLogger');
+let { ifNotFound, notFoundMessage } = require('api/api-utils/ifNotFound');
 
 /**
  * GET /deployments
@@ -31,7 +32,9 @@ function getDeploymentById(req, res, next) {
   const key = req.swagger.params.id.value;
 
   return deploymentsHelper.get({ key })
-    .then(data => res.json(data)).catch(next);
+    .then(ifNotFound(notFoundMessage('deployment')))
+    .then(send => send(res))
+    .catch(next);
 }
 
 /**

--- a/server/models/OpsEnvironment.js
+++ b/server/models/OpsEnvironment.js
@@ -38,6 +38,10 @@ class OpsEnvironment {
     });
   }
 
+  isNothing() {
+    return Object.keys(this).length === 0;
+  }
+
   static getAll(filter = {}) {
     return opsEnvironment.scan()
       .then(list => list.map(env => new OpsEnvironment(env)));

--- a/server/modules/functional.js
+++ b/server/modules/functional.js
@@ -1,0 +1,12 @@
+'use strict';
+
+let when = (cond, fnTrue, fnFalse = () => null) =>
+  x => (cond(x) ? fnTrue(x) : fnFalse(x));
+
+let hasValue = x =>
+  (x !== null && x !== undefined);
+
+module.exports = {
+  when,
+  hasValue
+};

--- a/server/modules/queryHandlersUtil/deployments-helper.js
+++ b/server/modules/queryHandlersUtil/deployments-helper.js
@@ -8,7 +8,6 @@ let configurationCache = require('modules/configurationCache');
 let deployments = require('modules/data-access/deployments');
 let fp = require('lodash/fp');
 let { Clock, Instant, LocalDate, ZoneId } = require('js-joda');
-let ResourceNotFoundError = require('modules/errors/ResourceNotFoundError.class');
 let sender = require('modules/sender');
 
 function getTargetAccountName(deployment) {
@@ -57,7 +56,7 @@ function queryDeployment({ key }) {
   return deployments.get({ DeploymentID: key })
     .then((result) => {
       if (result === null) {
-        throw new ResourceNotFoundError(`Deployment ${key} not found`);
+        return null;
       } else {
         return getTargetAccountName(result).then((accountName) => {
           result.AccountName = accountName;
@@ -130,7 +129,7 @@ function queryDeploymentNodeStates(environment, key, accountName) {
 
 module.exports = {
 
-  get: query => queryDeployment(query).then(mapDeployment),
+  get: query => queryDeployment(query).then(x => (x !== null ? mapDeployment(x) : null)),
 
   scan: query => queryDeployments(query)
     .then((results) => {

--- a/server/test/modules/queryHandlersUtil/deployments-helperTest.js
+++ b/server/test/modules/queryHandlersUtil/deployments-helperTest.js
@@ -5,7 +5,6 @@
 require('should');
 let proxyquire = require('proxyquire').noCallThru();
 let sinon = require('sinon');
-let ResourceNotFoundError = require('modules/errors/ResourceNotFoundError.class');
 
 function commonStubs() {
   return {
@@ -21,12 +20,12 @@ function commonStubs() {
 
 describe('deployments-helper', () => {
   describe('queryDeployment', () => {
-    it('throws an error if the deployment is not found', () => {
+    it('returns null if the deployment is not found', () => {
       let get = sinon.spy(() => Promise.resolve(null));
       let sut = proxyquire('modules/queryHandlersUtil/deployments-helper', Object.assign(commonStubs(), {
         'modules/data-access/deployments': { get }
       }));
-      return sut.get({ key: '' }).should.be.rejectedWith(ResourceNotFoundError);
+      return sut.get({ key: '' }).should.finally.be.null();
     });
 
     it('returns a deployment with unknown number of expected nodes', () => {


### PR DESCRIPTION
This change is implemented for the following routes:

* GET /config/clusters/{name}
* GET /config/deployment-maps/{name}
* GET /config/environment-types/{name}
* GET /config/environments/{name}
* GET /config/notification-settings/{id}
* GET /config/services/{name}/{cluster}
* GET /deployments/{key}
* GET /environments/{name}