### PR TITLE
Bug/unhandled rejections not sent to kibana

### DIFF
--- a/client/gulp/eslint.js
+++ b/client/gulp/eslint.js
@@ -18,4 +18,3 @@ gulp.task('lint-fix', function () {
     .pipe(eslint.failAfterError())
     .pipe(gulp.dest('./app'));
 });
-

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -15,7 +15,6 @@ fs.readdirSync('./gulp').filter(function(file) {
   require('./gulp/' + file);
 });
 
-
 /**
  *  Default task clean temporaries directories and launch the
  *  main optimization build task

--- a/server/index.js
+++ b/server/index.js
@@ -27,13 +27,19 @@ const miniStack = require('modules/miniStack');
 const mini = miniStack.build();
 
 process.on('unhandledRejection', (err, promise) => {
-  let entry = {
-    error: {
-      message: fp.get(['message'])(err),
-      stack: fp.compose(fp.truncate({ length: 1400 }), mini, fp.get(['stack']))(err)
-    },
-    eventtype: 'UnhandledRejection'
-  };
+  let entry;
+  if (err instanceof Error) {
+    entry = {
+      error: {
+        message: fp.get(['message'])(err),
+        stack: fp.compose(fp.truncate({ length: 1400 }), mini, fp.get(['stack']))(err)
+      },
+      eventtype: 'UnhandledRejection'
+    };
+  } else {
+    entry = err;
+  }
+
   logger.warn('Promise rejection was unhandled: ', entry);
 });
 

--- a/server/index.js
+++ b/server/index.js
@@ -22,8 +22,19 @@ let cacheManager = require('modules/cacheManager');
 let co = require('co');
 let awsAccounts = require('modules/awsAccounts');
 
-process.on('unhandledRejection', (reason, promise) => {
-  logger.warn('Promise rejection was unhandled. ', reason);
+const fp = require('lodash/fp');
+const miniStack = require('modules/miniStack');
+const mini = miniStack.build();
+
+process.on('unhandledRejection', (err, promise) => {
+  let entry = {
+    error: {
+      message: fp.get(['message'])(err),
+      stack: fp.compose(fp.truncate({ length: 1400 }), mini, fp.get(['stack']))(err)
+    },
+    eventtype: 'UnhandledRejection'
+  };
+  logger.warn('Promise rejection was unhandled: ', entry);
 });
 
 let servers;

--- a/server/modules/express-middleware/loggingMiddleware.js
+++ b/server/modules/express-middleware/loggingMiddleware.js
@@ -8,7 +8,6 @@
 
 const fp = require('lodash/fp');
 const miniStack = require('modules/miniStack');
-const path = require('path');
 
 let redactSecrets = fp.cloneDeepWith((value, key) => (/password/i.test(key) ? '********' : undefined));
 
@@ -31,11 +30,7 @@ let tryParse = (str) => {
   }
 };
 
-let mini = (() => {
-  let basePath = path.dirname(require.resolve('package.json'));
-  let filePathTransform = fullPath => path.relative(basePath, fullPath);
-  return miniStack({ contextLines: 0, filePathTransform });
-})();
+let mini = miniStack.build();
 
 let loggerMiddleware = logger => (req, res, next) => {
   let log = () => {

--- a/server/modules/miniStack.js
+++ b/server/modules/miniStack.js
@@ -10,6 +10,8 @@ const FILE_LOCATION_REGEXP = /\((.*)(:[0-9]+:[0-9]+)\)/;
 const LINE_FILTER_REGEXP = /^\s*at\s+/i;
 const NOT_MY_CODE_REGEXP = /(node_modules)|(\([^\\\/]+:[0-9]+:[0-9]+\))|(\(native\))/;
 
+const path = require('path');
+
 let isMyCode = line => !NOT_MY_CODE_REGEXP.test(line);
 
 let enteredMyCode = (line, prev) => isMyCode(line) && !isMyCode(prev);
@@ -80,5 +82,11 @@ function create({ contextLines, filePathTransform }) {
 
   return minimize;
 }
+
+create.build = () => {
+  let basePath = path.dirname(require.resolve('package.json'));
+  let filePathTransform = fullPath => path.relative(basePath, fullPath);
+  return create({ contextLines: 0, filePathTransform });
+};
 
 module.exports = create;


### PR DESCRIPTION
…niStack' within the unhandledRejection event now.

- miniStack being used (from loggerMiddlware) within the index.js for unhandledRejection events. 
- 'build' method added to the miniStack function to share the previous IIFE from the loggerMiddleware. Both index.js for the server and the loggerMiddleware now use this miniStack.build() to create their minifying functions. 