### PR TITLE
zero padding required at the start of time strings

### DIFF
--- a/client/app/operations/deployments/DeploymentDetailsModalController.js
+++ b/client/app/operations/deployments/DeploymentDetailsModalController.js
@@ -27,9 +27,9 @@ function deploymentView(deploymentRecord, clusters, expectedNodes) {
   function createDiffString(startTime, endTime) {
     var diff = moment.duration(endTime.diff(startTime));
     var duration = [
-      _.pad(diff.get('hours'), 2, 0), 
-      _.pad(diff.get('minutes'), 2, 0), 
-      _.pad(diff.get('seconds'), 2, 0)].join(':');
+      _.padStart(diff.get('hours'), 2, 0), 
+      _.padStart(diff.get('minutes'), 2, 0), 
+      _.padStart(diff.get('seconds'), 2, 0)].join(':');
     return duration;
   }
 


### PR DESCRIPTION
'pad' will work on both left and right of string. 
'padStart' will only pad the start of the string. 

- 5 becomes 05 rather than 50 