### PR TITLE
Refactoring config upstream screen

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
   env: {
     browser: true,
+    jasmine: true,
     es6: false,
   },
   globals: {
@@ -9,11 +10,13 @@ module.exports = {
     moment: false,
     it: false,
     expect: false,
-    beforeEach: false
+    beforeEach: false,
+    inject: false,
+    Promise: false
   },
 
-  extends: "airbnb-base/legacy",
-  plugins: ['angular'],
+  extends: ["airbnb-base/legacy", "plugin:jasmine/recommended"],
+  plugins: ['jasmine', 'angular'],
 
   rules: {
     "indent": ['error', 2],

--- a/client/app/common/models/UpstreamConfig.js
+++ b/client/app/common/models/UpstreamConfig.js
@@ -7,6 +7,9 @@ angular.module('EnvironmentManager.common').factory('UpstreamConfig',
     var baseUrl = '/api/v1/config/upstreams';
 
     function UpstreamConfig(data) {
+      data.Value.Hosts.sort(function (a, b) {
+        return a.DnsName.localeCompare(b.DnsName);
+      });
       _.assign(this, data);
     }
 

--- a/client/app/configuration/lbupstreams/lbupstream.html
+++ b/client/app/configuration/lbupstreams/lbupstream.html
@@ -1,16 +1,12 @@
 <div class="row page-title">
   <div class="col-md-12">
-    <h2 ng-if="PageMode == 'New'">New Upstream</h2>
-    <h2 ng-if="PageMode == 'Copy'">Copy Upstream: {{CopyFromName}}</h2>
-    <h2 ng-if="PageMode == 'Edit'">Edit Upstream: {{LBUpstream.Value.UpstreamName}}</h2>
+    <h2>{{ vm.view.title }}</h2>
   </div>
 </div>
 
-<div ng-show="(PageMode == 'Edit' || PageMode == 'Copy') && !DataFound">No data found.</div>
+<form id="Upstream" name="form" class="form-horizontal" ng-show="vm.view.showForm">
 
-<form id="Upstream" name="form" class="form-horizontal" ng-show="DataFound || PageMode == 'New'">
-
-  <div class="form-group" ng-if="PageMode != 'Edit'" ng-class="{'has-error': form.Upstream.$invalid}">
+  <div class="form-group" ng-if="vm.view.showNameField" ng-class="{'has-error': form.Upstream.$invalid}">
     <label class="col-md-1 control-label text-left nowrap">Name: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
     <div class="col-md-2">
       <input type="text"
@@ -20,24 +16,24 @@
       autofocus
       maxlength="100"
       pattern="[a-zA-Z0-9-]+"
-      ng-model="LBUpstream.Value.UpstreamName"
-      ng-readonly="PageMode == 'Edit' || !canUser('edit')" />
+      ng-model="vm.upstream.Value.UpstreamName"
+      ng-readonly="vm.view.configFieldsDisabled" />
     </div>
     <span class="help-block" ng-if="form.Upstream.$dirty && form.Upstream.$error.required">Upstream name is mandatory.</span>
     <span class="help-block" ng-if="form.Upstream.$dirty && form.Upstream.$error.pattern">Upstream name cannot contain underscores or special characters. It should start with the environment name.</span>
   </div>
   <div class="form-group">
     <label class="col-md-1 control-label text-left">Environment:</label>
-    <div class="col-md-2" ng-if="PageMode != 'Copy'">
-      <label class="control-label text-left nonbold">{{LBUpstream.Value.EnvironmentName}}</label>
+    <div class="col-md-2" ng-if="!vm.view.showEnvironmentField">
+      <label class="control-label text-left nonbold">{{vm.upstream.Value.EnvironmentName}}</label>
     </div>
-    <div class="col-md-2" ng-if="PageMode == 'Copy'">
+    <div class="col-md-2" ng-if="vm.view.showEnvironmentField">
       <select class="form-control"
       name="EnvironmentName"
       required=""
-      ng-model="LBUpstream.Value.EnvironmentName"
-      ng-disabled="!canUser('edit')">
-      <option ng-repeat="env in EnvironmentsList" ng-selected="{{env == LBUpstream.Value.EnvironmentName}}" value="{{env}}">{{env}}</option>
+      ng-model="vm.upstream.Value.EnvironmentName"
+      ng-disabled="vm.view.configFieldsDisabled">
+      <option ng-repeat="env in vm.view.environments" ng-selected="{{env == vm.upstream.Value.EnvironmentName}}" value="{{env}}">{{env}}</option>
     </select>
   </div>
 </div>
@@ -47,12 +43,12 @@
     <select class="form-control"
     name="Service"
     required=""
-    ng-model="LBUpstream.Value.ServiceName"
-    ng-disabled="!canUser('edit')">
-    <option ng-repeat="service in ServicesList track by $index" ng-selected="{{service == LBUpstream.Value.ServiceName}}" value="{{service}}">{{service}}</option>
+    ng-model="vm.upstream.Value.ServiceName"
+    ng-disabled="vm.view.configFieldsDisabled">
+    <option ng-repeat="service in vm.view.services track by $index" ng-selected="{{service == vm.upstream.Value.ServiceName}}" value="{{service}}">{{service}}</option>
   </select>
 </div>
-<a class="help-link" href="/#/config/services/{{SelectedService.ServiceName}}/?Range={{SelectedService.OwningCluster}}" target="_blank">Go to service definition</a>
+<a ng-if="vm.view.showServiceLink()" class="help-link" href="{{vm.view.serviceLink()}}" target="_blank">Go to service definition</a>
 <span class="help-block" ng-if="form.Service.$error.required">Service Name is mandatory.</span>
 </div>
 <div class="form-group" ng-class="{'has-error': form.ZoneSize.$invalid}">
@@ -63,8 +59,8 @@
     class="form-control"
     maxlength="10"
     required=""
-    ng-model="LBUpstream.Value.ZoneSize"
-    ng-readonly="!canUser('edit')" />
+    ng-model="vm.upstream.Value.ZoneSize"
+    ng-readonly="vm.view.configFieldsDisabled" />
   </div>
   <span class="help-block" ng-if="form.ZoneSize.$dirty && form.ZoneSize.$error.required">Zone Size is mandatory.</span>
 </div>
@@ -75,8 +71,8 @@
     name="LoadBalancingMethod"
     class="form-control"
     maxlength="100"
-    ng-model="LBUpstream.Value.LoadBalancingMethod"
-    ng-readonly="!canUser('edit')" />
+    ng-model="vm.upstream.Value.LoadBalancingMethod"
+    ng-readonly="vm.view.configFieldsDisabled" />
   </div>
 </div>
 <div class="form-group" ng-class="{'has-error': form.PersistenceMethod.$invalid}">
@@ -86,8 +82,8 @@
       name="PersistenceMethod"
       class="form-control"
       maxlength="100"
-      ng-model="LBUpstream.Value.PersistenceMethod"
-      ng-readonly="!canUser('edit')" />
+      ng-model="vm.upstream.Value.PersistenceMethod"
+      ng-readonly="vm.view.configFieldsDisabled" />
   </div>
 </div>
 <div class="form-group" ng-class="{'has-error': form.UpStreamKeepalives.$invalid}">
@@ -99,8 +95,8 @@
       step="1"
       name="UpStreamKeepalives"
       class="form-control"
-      ng-model="LBUpstream.Value.UpStreamKeepalives"
-      ng-readonly="!canUser('edit')" />
+      ng-model="vm.upstream.Value.UpStreamKeepalives"
+      ng-readonly="vm.view.configFieldsDisabled" />
   </div>
   <span class="help-block" ng-if="form.UpStreamKeepalives.$dirty && form.UpStreamKeepalives.$invalid">Keep alives must be an integer between 1 and 500.</span>
 </div>
@@ -112,8 +108,8 @@
       name="SlowStart"
       pattern="[0-9]{1,2}[s,m]"
       class="form-control"
-      ng-model="LBUpstream.Value.SlowStart"
-      ng-readonly="!canUser('edit')" />
+      ng-model="vm.upstream.Value.SlowStart"
+      ng-readonly="vm.view.configFieldsDisabled" />
   </div>
   <span class="help-block" ng-if="form.SlowStart.$dirty && form.SlowStart.$invalid">Slow start must be an integer between 1 and 99 followed by an 's' or 'm'.</span>
 </div>
@@ -131,14 +127,14 @@
           <th>MaxFails</th>
           <th>Weight <span class="glyphicon glyphicon-asterisk mandatory"></span></th>
           <th>Configured State</th>
-          <th ng-if="canUser('edit')" class="command-header"></th>
+          <th ng-if="vm.view.configFieldsEnabled" class="command-header"></th>
         </tr>
       </thead>
       <tbody>
-        <tr ng-repeat="host in LBUpstream.Value.Hosts">
+        <tr ng-repeat="host in vm.upstream.Value.Hosts">
           <td>
-            <span ng-if="!canUser('edit')">{{host.DnsName}}</span>
-            <div ng-if="canUser('edit')" ng-class="{'has-error': !host.DnsName}">
+            <span ng-if="vm.view.configFieldsDisabled">{{host.DnsName}}</span>
+            <div ng-if="vm.view.configFieldsEnabled" ng-class="{'has-error': !host.DnsName}">
               <input type="text"
                 name="DnsName"
                 class="form-control"
@@ -148,8 +144,8 @@
             </div>
           </td>
           <td>
-            <span ng-if="!canUser('edit')">{{host.Port}}</span>
-            <div ng-if="canUser('edit')" ng-class="{'has-error': !host.Port}">
+            <span ng-if="vm.view.configFieldsDisabled">{{host.Port}}</span>
+            <div ng-if="vm.view.configFieldsEnabled" ng-class="{'has-error': !host.Port}">
               <input type="number"
                 min="1"
                 max="41000"
@@ -161,8 +157,8 @@
             </div>
           </td>
           <td>
-            <span ng-if="!canUser('edit')">{{host.FailTimeout}}</span>
-            <div ng-if="canUser('edit')">
+            <span ng-if="vm.view.configFieldsDisabled">{{host.FailTimeout}}</span>
+            <div ng-if="vm.view.configFieldsEnabled">
               <input type="text"
                 name="FailTimeout"
                 class="form-control"
@@ -171,8 +167,8 @@
             </div>
           </td>
           <td>
-            <span ng-if="!canUser('edit')">{{host.MaxFails}}</span>
-            <div ng-if="canUser('edit')">
+            <span ng-if="vm.view.configFieldsDisabled">{{host.MaxFails}}</span>
+            <div ng-if="vm.view.configFieldsEnabled">
               <input type="number"
                 min="0"
                 max="100"
@@ -183,8 +179,8 @@
             </div>
           </td>
           <td>
-            <span ng-if="!canUser('edit')">{{host.Weight}}</span>
-            <div ng-if="canUser('edit')" ng-class="{'has-error': !host.Weight}">
+            <span ng-if="vm.view.configFieldsDisabled">{{host.Weight}}</span>
+            <div ng-if="vm.view.configFieldsEnabled" ng-class="{'has-error': !host.Weight}">
               <input type="number"
                 min="1"
                 max="100"
@@ -196,11 +192,11 @@
             </div>
           </td>
           <td>
-            <span ng-if="!canUser('edit')">
-              <span ng-if="host.State=='up'" class="status-up"><span class="glyphicon glyphicon-triangle-top"></span> Up</span>
-              <span ng-if="host.State=='down'" class="status-down"><span class="glyphicon glyphicon-triangle-bottom"></span> Down</span>
+            <span ng-if="vm.view.configFieldsDisabled">
+              <span ng-if="host.State === 'up'" class="status-up"><span class="glyphicon glyphicon-triangle-top"></span> Up</span>
+              <span ng-if="host.State === 'down'" class="status-down"><span class="glyphicon glyphicon-triangle-bottom"></span> Down</span>
             </span>
-            <div ng-if="canUser('edit')">
+            <div ng-if="vm.view.configFieldsEnabled">
               <div class="onoffswitch">
                 <input type="checkbox" name="onoffswitch" class="onoffswitch-checkbox" id="hostState{{$index}}" checked ng-model="host.State" ng-true-value="'up'" ng-false-value="'down'">
                 <label class="onoffswitch-label" for="hostState{{$index}}">
@@ -210,36 +206,36 @@
               </div>
             </div>
           </td>
-          <td ng-if="canUser('edit')" class="command command-delete"><span class="glyphicon glyphicon-remove" ng-click="DeleteHost(host)" title="Remove Host"></span></td>
+          <td ng-if="vm.view.configFieldsEnabled" class="command command-delete"><span class="glyphicon glyphicon-remove" ng-click="vm.deleteHost(host)" title="Remove Host"></span></td>
         </tr>
-        <tr ng-if="LBUpstream.Value.Hosts.length > 0">
+        <tr ng-if="vm.upstream.Value.Hosts.length > 0">
           <td colspan="7" style="height: 5px;"></td>
         </tr>
-        <tr ng-if="LBUpstream.Value.Hosts.length > 0">
+        <tr ng-if="vm.upstream.Value.Hosts.length > 0">
           <td colspan="7" style="background-color: RGB(170,170,170); height: 3px; padding: 0px;"></td>
         </tr>
-        <tr ng-if="canUser('edit') && (AddingHost==false && LBUpstream.Value.Hosts.length > 0)">
-          <td colspan="7" style="text-align: center"><strong><a href="" ng-click="ShowAddHost()">Click to Add Another Host</a></strong></td>
+        <tr ng-if="vm.view.showCreateHostLink()">
+          <td colspan="7" style="text-align: center"><strong><a href="" ng-click="vm.view.createNewHost()">Click to Add Another Host</a></strong></td>
         </tr>
-        <tr ng-if="canUser('edit') && (AddingHost==true || LBUpstream.Value.Hosts.length == 0)">
+        <tr ng-if="vm.view.newHost">
           <td>
-            <div ng-class="{'has-error': !NewHost.DnsName}">
+            <div ng-class="{'has-error': !vm.view.newHost.DnsName}">
               <input type="text"
                 name="DnsName"
                 class="form-control"
                 maxlength="63"
-                ng-model="NewHost.DnsName" />
+                ng-model="vm.view.newHost.DnsName" />
             </div>
           </td>
           <td>
-            <div ng-class="{'has-error': !NewHost.Port}">
+            <div ng-class="{'has-error': !vm.view.newHost.Port}">
               <input type="number"
                 min="1"
                 max="41000"
                 step="1"
                 name="Port"
                 class="form-control"
-                ng-model="NewHost.Port" />
+                ng-model="vm.view.newHost.Port" />
             </div>
           </td>
           <td>
@@ -248,7 +244,7 @@
                 name="FailTimeout"
                 class="form-control"
                 maxlength="4"
-                ng-model="NewHost.FailTimeout" />
+                ng-model="vm.view.newHost.FailTimeout" />
             </div>
           </td>
           <td>
@@ -259,22 +255,22 @@
                 step="1"
                 name="MaxFails"
                 class="form-control"
-                ng-model="NewHost.MaxFails" />
+                ng-model="vm.view.newHost.MaxFails" />
             </div>
           </td>
           <td>
-            <div ng-if="canUser('edit')" ng-class="{'has-error': !NewHost.Weight}">
+            <div ng-if="vm.view.configFieldsEnabled" ng-class="{'has-error': !vm.view.newHost.Weight}">
               <input type="number"
                 min="1"
                 max="100"
                 step="1"
                 name="Weight"
                 class="form-control"
-                ng-model="NewHost.Weight" />
+                ng-model="vm.view.newHost.Weight" />
             </div>
           </td>
           <td>
-            <div ng-if="canUser('edit')">
+            <div ng-if="vm.view.configFieldsEnabled">
               <div class="onoffswitch">
                 <input type="checkbox" name="onoffswitch" class="onoffswitch-checkbox" id="NewHost" checked ng-model="NewHost.State" ng-true-value="'up'" ng-false-value="'down'">
                 <label class="onoffswitch-label" for="NewHost">
@@ -284,24 +280,24 @@
               </div>
             </div>
           </td>
-          <td class="command command-add"><span class="glyphicon glyphicon-plus" ng-click="AddHost()" title="Add New Host"></span></td>
+          <td class="command command-add"><span class="glyphicon glyphicon-plus" ng-click="vm.addHost()" title="Add New Host"></span></td>
         </tr>
       </tbody>
     </table>
   </div>
 </div>
-<div class="form-group has-error" ng-if="PageError != ''">
+<div class="form-group has-error" ng-if="vm.view.validationError">
   <label class="col-md-1">&nbsp;</label>
   <div class="col-md-7">
-    <span class="help-block">{{PageError}}.</span>
+    <span class="help-block">{{vm.view.validationError}}.</span>
   </div>
 </div>
 <div class="form-group">
   <label class="col-md-1">&nbsp;</label>
   <div class="col-md-5">
-    <button type="button" class="btn btn-default" ng-click="Cancel()">Cancel</button>
-    <button type="button" class="btn btn-default" ng-if="canUser('edit')" ng-disabled="LBUpstream.Value.Hosts.length == 0" ng-click="Toggle()">Toggle Active Hosts</button>
-    <button type="button" class="btn btn-default" ng-if="canUser('edit')" ng-disabled="!form.$valid" ng-click="Save()">Save</button>
+    <button type="button" class="btn btn-default" ng-click="vm.backToSummary()">Cancel</button>
+    <button type="button" class="btn btn-default" ng-if="vm.view.configFieldsEnabled" ng-disabled="vm.view.toggleActiveHostsButtonIsDisabled()" ng-click="vm.view.toggleActiveHosts()">Toggle Active Hosts</button>
+    <button type="button" class="btn btn-default" ng-if="vm.view.configFieldsEnabled" ng-disabled="!form.$valid" ng-click="vm.save()">Save</button>
   </div>
 </div>
 

--- a/client/app/configuration/lbupstreams/upstreamViewModel.js
+++ b/client/app/configuration/lbupstreams/upstreamViewModel.js
@@ -1,0 +1,122 @@
+/* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
+
+'use strict';
+
+angular.module('EnvironmentManager.configuration').factory('UpstreamViewModel', function () {
+  var defaultHostTemplate = { DnsName: '', Port: null, FailTimeout: '30s', MaxFails: null, State: 'down', Weight: 1 };
+
+  function UpstreamViewModel(params) {
+    var self = this;
+
+    var isNewMode = params.mode === 'New';
+    var isCopyMode = params.mode === 'Copy';
+    var isEditMode = params.mode === 'Edit';
+    var allServices = [];
+    var upstream;
+
+    self.title = 'Loading...';
+    self.showForm = false;
+    self.showNameField = !isEditMode;
+
+    self.configFieldsEnabled = false;
+    self.configFieldsDisabled = true;
+
+    self.showEnvironmentEditorField = isCopyMode;
+    self.showEnvironmentReadOnlyField = !isCopyMode;
+
+    if (isNewMode) {
+      self.newHost = _.clone(defaultHostTemplate);
+    }
+
+    self.init = function (resources) {
+      loadEnvironments(resources.environments);
+      loadServices(resources.services);
+      loadUpstream(resources.upstream);
+
+      if (isNewMode) self.title = 'New Upstream';
+      if (isCopyMode) self.title = 'Copy Upstream: ' + upstream.Value.UpstreamName;
+      if (isEditMode) self.title = 'Edit Upstream: ' + upstream.Value.UpstreamName;
+
+      var upstreamResourceName = '/config/upstreams/' + (isNewMode ? '*' : upstream.Value.UpstreamName);
+      var hasPermissionsToEdit = params.user.hasPermission({
+        access: 'PUT',
+        resource: upstreamResourceName
+      });
+
+      self.configFieldsEnabled = hasPermissionsToEdit;
+      self.configFieldsDisabled = !self.configFieldsEnabled;
+
+      self.showForm = true;
+    };
+
+    self.errorOnInit = function (error) {
+      self.showError = true;
+      self.errorMessage = error;
+    };
+
+    self.showCreateHostLink = function () {
+      return !self.newHost && self.configFieldsEnabled;
+    };
+
+    self.createNewHost = function () {
+      if (!self.newHost) self.newHost = _.clone(defaultHostTemplate);
+    };
+
+    self.clearNewHostEditor = function () {
+      delete self.newHost;
+    };
+
+    self.newHostIsValid = function () {
+      return !!(self.newHost.DnsName && self.newHost.Port && self.newHost.Weight);
+    };
+
+    self.showServiceLink = function () {
+      if (!upstream) return false;
+      return !!getServiceByName(upstream.Value.ServiceName);
+    };
+
+    self.serviceLink = function () {
+      if (!upstream) return null;
+
+      var service = getServiceByName(upstream.Value.ServiceName);
+      if (!service) return null;
+
+      return '/#/config/services/' + service.ServiceName + '/?Range=' + service.OwningCluster;
+    };
+
+    self.toggleActiveHostsButtonIsDisabled = function () {
+      return upstream.Value.Hosts.length === 0;
+    };
+
+    self.toggleActiveHosts = function () {
+      upstream.Value.Hosts.forEach(function (host) {
+        host.State = host.State === 'up' ? 'down' : 'up';
+      });
+    };
+
+    self.showValidationError = function (msg) {
+      self.validationError = msg;
+    };
+
+    function getServiceByName(serviceName) {
+      return _.find(allServices, function (s) {
+        return s.ServiceName === serviceName;
+      });
+    }
+
+    function loadEnvironments(environments) {
+      self.environments = _.map(environments, 'EnvironmentName').sort();
+    }
+
+    function loadServices(services) {
+      allServices = services;
+      self.services = _.map(services, 'ServiceName').sort();
+    }
+
+    function loadUpstream(upstreamData) {
+      upstream = upstreamData;
+    }
+  }
+
+  return UpstreamViewModel;
+});

--- a/client/app/configuration/lbupstreams/upstreamViewModel.spec.js
+++ b/client/app/configuration/lbupstreams/upstreamViewModel.spec.js
@@ -1,0 +1,316 @@
+/* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
+
+'use strict';
+
+describe('UpstreamViewModel', function () {
+  var UpstreamViewModel;
+  var defaultHost = { DnsName: '', Port: null, FailTimeout: '30s', MaxFails: null, State: 'down', Weight: 1 };
+
+  beforeEach(module('EnvironmentManager.configuration'));
+  beforeEach(inject(function (_UpstreamViewModel_) {
+    UpstreamViewModel = _UpstreamViewModel_;
+  }));
+
+  it('Should not show the form before the view is initialised', function () {
+    var vm = createUpstreamViewModel();
+    expect(vm.showForm).toBe(false);
+  });
+
+  it('Should show a loading indicator before the view is initialised', function () {
+    var vm = createUpstreamViewModel();
+    expect(vm.title).toBe('Loading...');
+  });
+
+  it('Should show the form once the view is initialised', function () {
+    var vm = createAndInitUpstreamViewModel();
+    expect(vm.showForm).toBe(true);
+  });
+
+  it('Should show title "Edit Upstream: ..." when editing an upstream', function () {
+    var vm = createUpstreamViewModel({ mode: 'Edit' });
+    init(vm, { upstream: createSimpleTestUpstream() });
+    expect(vm.title).toBe('Edit Upstream: TestUpstream');
+  });
+
+  it('Should show title "Copy Upstream: ..." when editing an upstream', function () {
+    var vm = createUpstreamViewModel({ mode: 'Copy' });
+    init(vm, { upstream: createSimpleTestUpstream() });
+    expect(vm.title).toBe('Copy Upstream: TestUpstream');
+  });
+
+  it('Should show the name field when copying an upstream', function () {
+    var vm = createUpstreamViewModel({ mode: 'Copy' });
+    expect(vm.showNameField).toBe(true);
+  });
+
+  it('Should show the name field when creating a new upstream', function () {
+    var vm = createUpstreamViewModel({ mode: 'New' });
+    expect(vm.showNameField).toBe(true);
+  });
+
+  it('Should not show the name field when editing a new upstream', function () {
+    var vm = createUpstreamViewModel({ mode: 'Edit' });
+    expect(vm.showNameField).toBe(false);
+  });
+
+  it('Should allow the environment to be edited when copying an upstream', function () {
+    var vm = createUpstreamViewModel({ mode: 'Copy' });
+    expect(vm.showEnvironmentEditorField).toBe(true);
+    expect(vm.showEnvironmentReadOnlyField).toBe(false);
+  });
+
+  it('Should not allow the environment to be edited when creating a new upstream', function () {
+    var vm = createUpstreamViewModel({ mode: 'New' });
+    expect(vm.showEnvironmentEditorField).toBe(false);
+    expect(vm.showEnvironmentReadOnlyField).toBe(true);
+  });
+
+  it('Should not allow the environment to be edited when editing an upstream', function () {
+    var vm = createUpstreamViewModel({ mode: 'Edit' });
+    expect(vm.showEnvironmentEditorField).toBe(false);
+    expect(vm.showEnvironmentReadOnlyField).toBe(true);
+  });
+
+  it('Should allow config fields to be edited when creating a new upstream if the user has permission', function () {
+    var vm = createAndInitUpstreamViewModel();
+    expect(vm.configFieldsDisabled).toBe(false);
+    expect(vm.configFieldsEnabled).toBe(true);
+  });
+
+  it('Should enable config fields when creating a new upstream', function () {
+    var vm = createAndInitUpstreamViewModel();
+    expect(vm.configFieldsDisabled).toBe(false);
+    expect(vm.configFieldsEnabled).toBe(true);
+  });
+
+  it('Should disable config fields when the user does not have permissions to edit upstreams', function () {
+    var testUpstream = createSimpleTestUpstream();
+    var testUser = createUserWhoCantEdit(testUpstream.Value.UpstreamName);
+    var vm = createUpstreamViewModel({ mode: 'Edit', user: testUser });
+    init(vm, { upstream: testUpstream });
+    expect(vm.configFieldsDisabled).toBe(true);
+    expect(vm.configFieldsEnabled).toBe(false);
+  });
+
+  it('Should disable config fields when the user does not have permissions to create upstreams', function () {
+    var testUser = createUserWhoCantCreate();
+    var vm = createUpstreamViewModel({ mode: 'New', user: testUser });
+    expect(vm.configFieldsDisabled).toBe(true);
+    expect(vm.configFieldsEnabled).toBe(false);
+  });
+
+  it('Should enable config fields when the user has permissions to edit upstreams', function () {
+    var testUser = createAdminUser();
+    var vm = createUpstreamViewModel({ mode: 'Edit', user: testUser });
+    init(vm, { upstream: createSimpleTestUpstream() });
+    expect(vm.configFieldsDisabled).toBe(false);
+    expect(vm.configFieldsEnabled).toBe(true);
+  });
+
+  it('Should sort service names drop down', function () {
+    var vm = createUpstreamViewModel();
+    init(vm, { services: [{ ServiceName: 's2' }, { ServiceName: 's1' }] });
+    expect(vm.services).toEqual(['s1', 's2']);
+  });
+
+  it('Should sort environment names drop down', function () {
+    var vm = createUpstreamViewModel();
+    init(vm, { environments: [{ EnvironmentName: 'e2' }, { EnvironmentName: 'e1' }] });
+    expect(vm.environments).toEqual(['e1', 'e2']);
+  });
+
+  it('Should not show the service link if no service is selected', function () {
+    var vm = createUpstreamViewModel();
+    expect(vm.showServiceLink()).toBe(false);
+    expect(vm.serviceLink()).toEqual(null);
+  });
+
+  it('Should show the correct service link when a service is selected', function () {
+    var vm = createUpstreamViewModel();
+    var testUpstream = createSimpleTestUpstream();
+    init(vm, { upstream: testUpstream });
+    testUpstream.Value.ServiceName = 's2';
+    expect(vm.showServiceLink()).toBe(true);
+    expect(vm.serviceLink()).toEqual('/#/config/services/s2/?Range=c2');
+  });
+
+  it('Should show new host line when creating a new Upstream', function () {
+    var vm = createUpstreamViewModel({ mode: 'New' });
+    expect(vm.newHost).toEqual(defaultHost);
+  });
+
+  it('Should show new host line when the new host button is clicked', function () {
+    var vm = createUpstreamViewModel({ mode: 'Edit' });
+    vm.createNewHost();
+    expect(vm.newHost).toEqual(defaultHost);
+  });
+
+  it('Should not show new host line when editing an Upstream', function () {
+    var vm = createUpstreamViewModel({ mode: 'Edit' });
+    expect(vm.newHost).not.toBeDefined();
+  });
+
+  it('Should not show new host line when copying an Upstream', function () {
+    var vm = createUpstreamViewModel({ mode: 'Copy' });
+    expect(vm.newHost).not.toBeDefined();
+  });
+
+  it('Should not clear the current new host values when the new host button is clicked', function () {
+    var vm = createAndInitUpstreamViewModel();
+    vm.newHost.DnsName = 'test';
+    vm.createNewHost();
+    expect(vm.newHost).not.toEqual(defaultHost);
+  });
+
+  it('Should hide the new host editor once a new host has been added', function () {
+    var vm = createUpstreamViewModel();
+    vm.newHost.DnsName = 'test';
+    vm.clearNewHostEditor();
+    expect(vm.newHost).not.toBeDefined();
+  });
+
+  it('Should report that the new host is valid if no all host fields have been entered', function () {
+    var vm = createUpstreamViewModel();
+    _.assign(vm.newHost, { DnsName: 'test', Port: 8080 });
+    expect(vm.newHostIsValid()).toBe(true);
+  });
+
+  it('Should report that the new host is not valid if no Consul Service Name has been entered', function () {
+    var vm = createUpstreamViewModel();
+    _.assign(vm.newHost, { Port: 8080 });
+    expect(vm.newHostIsValid()).toBe(false);
+  });
+
+  it('Should report that the new host is not valid if no Port has been entered', function () {
+    var vm = createUpstreamViewModel();
+    _.assign(vm.newHost, { DnsName: 'test' });
+    expect(vm.newHostIsValid()).toBe(false);
+  });
+
+  it('Should report that the new host is not valid if no Weight has been entered', function () {
+    var vm = createUpstreamViewModel();
+    delete vm.newHost.Weight;
+    expect(vm.newHostIsValid()).toBe(false);
+  });
+
+  it('Should show new host link when editing an upstream', function () {
+    var vm = createUpstreamViewModel({ mode: 'Edit' });
+    init(vm);
+    expect(vm.showCreateHostLink()).toBe(true);
+  });
+
+  it('Should not show new host link when already creating one', function () {
+    var vm = createUpstreamViewModel({ mode: 'Edit' });
+    init(vm);
+    vm.createNewHost();
+    expect(vm.showCreateHostLink()).toBe(false);
+  });
+
+  it('Should not show new host link when user has no edit permissions', function () {
+    var testUpstream = createSimpleTestUpstream();
+    var testUser = createUserWhoCantEdit();
+    var vm = createUpstreamViewModel({ mode: 'Edit', user: testUser });
+    init(vm, { upstream: testUpstream });
+    expect(vm.showCreateHostLink()).toBe(false);
+  });
+
+  it('Should show an error instead of the form if an error occurred collecting data for initialisation', function () {
+    var vm = createUpstreamViewModel();
+    vm.errorOnInit('Something bad');
+    expect(vm.showError).toBe(true);
+    expect(vm.errorMessage).toBe('Something bad');
+    expect(vm.showForm).toBe(false);
+  });
+
+  it('Should show a validation error when needed', function () {
+    var vm = createUpstreamViewModel();
+    vm.showValidationError('Something not right');
+    expect(vm.validationError).toBe('Something not right');
+  });
+
+  it('Should disable the "toggle active hosts" button if the number of hosts is zero', function () {
+    var vm = createAndInitUpstreamViewModel();
+    expect(vm.toggleActiveHostsButtonIsDisabled()).toBe(true);
+  });
+
+  it('Should not disable the "toggle active hosts" button if the number of hosts is greater than zero', function () {
+    var vm = createUpstreamViewModel();
+    var testUpstream = createSimpleTestUpstream();
+    init(vm, { upstream: testUpstream });
+
+    testUpstream.Value.Hosts.push({ DnsName: 'blah', State: 'up' });
+
+    expect(vm.toggleActiveHostsButtonIsDisabled()).toBe(false);
+  });
+
+  it('Should toggle hosts when the "toggle active hosts" button is pressed', function () {
+    var vm = createUpstreamViewModel();
+    var testUpstream = createSimpleTestUpstream();
+    init(vm, { upstream: testUpstream });
+
+    testUpstream.Value.Hosts.push({ State: 'up' });
+    testUpstream.Value.Hosts.push({ State: 'down' });
+
+    expect(testUpstream.Value.Hosts[0].State).toBe('up');
+    expect(testUpstream.Value.Hosts[1].State).toBe('down');
+
+    vm.toggleActiveHosts();
+
+    expect(testUpstream.Value.Hosts[0].State).toBe('down');
+    expect(testUpstream.Value.Hosts[1].State).toBe('up');
+  });
+
+  function createAndInitUpstreamViewModel() {
+    var vm = createUpstreamViewModel();
+    init(vm);
+    return vm;
+  }
+
+  function createUpstreamViewModel(params) {
+    var defaultParams = { mode: 'New', user: createAdminUser() };
+    return new UpstreamViewModel(_.assign(defaultParams, params));
+  }
+
+  function init(view, resources) {
+    var defaults = {
+      environments: [{ EnvironmentName: 'e2' }, { EnvironmentName: 'e1' }],
+      services: [{ ServiceName: 's2', OwningCluster: 'c2' }, { ServiceName: 's1', OwningCluster: 'c1' }],
+      upstream: { Value: { EnvironmentName: 'e1', Hosts: [] } }
+    };
+    view.init(_.assign(defaults, resources));
+  }
+
+  function createAdminUser() {
+    return { hasPermission: function () { return true; } };
+  }
+
+  function createSimpleTestUpstream() {
+    return { Value: { UpstreamName: 'TestUpstream', ServiceName: 's1', Hosts: [] } };
+  }
+
+  function createUserWhoCantEdit(upstreamName) {
+    return {
+      hasPermission: function (permission) {
+        if (!upstreamName) return false;
+
+        if (!(permission.access === 'PUT' && permission.resource === '/config/upstreams/' + upstreamName)) {
+          throw new Error('Incorrect Permission Check');
+        }
+
+        return false;
+      }
+    };
+  }
+
+  function createUserWhoCantCreate() {
+    return {
+      hasPermission: function (permission) {
+        if (!(permission.access === 'POST' && permission.resource === '/config/upstreams/*')) {
+          throw new Error('Incorrect Permission Check');
+        }
+
+        return false;
+      }
+    };
+  }
+});

--- a/client/index.html
+++ b/client/index.html
@@ -99,6 +99,7 @@
   <script src="app/configuration/load-balancers/LBUpstreamController.js"></script>
   <script src="app/configuration/load-balancers/LBController.js"></script>
   <script src="app/configuration/load-balancers/LBCloneController.js"></script>
+  <script src="app/configuration/lbupstreams/upstreamViewModel.js"></script>
   <script src="app/configuration/import/ImportController.js"></script>
   <script src="app/configuration/export/ExportController.js"></script>
   <script src="app/configuration/environment-types/EnvironmentTypesController.js"></script>

--- a/client/package.json
+++ b/client/package.json
@@ -26,6 +26,7 @@
     "eslint-config-airbnb-base": "^10.0.1",
     "eslint-plugin-angular": "^1.4.1",
     "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jasmine": "^2.2.0",
     "gulp": "^3.9.1",
     "gulp-angular-filesort": "^1.1.1",
     "gulp-angular-templatecache": "^2.0.0",


### PR DESCRIPTION
This is a pure refactoring of the config upstream screen. The feature hasn't changed at all. The idea was to move view-specific logic out of the controller and put it under test to make future changes easier such as the toggling changes. I haven't finished these toggling changes yet but there's no reason this refactoring can't be merged on its own.