### PR TITLE
When there are no logs available to EM, make it a little more obvious…

### DIFF
--- a/client/app/environments/dialogs/asg/asgSingleInstance.html
+++ b/client/app/environments/dialogs/asg/asgSingleInstance.html
@@ -25,7 +25,12 @@
             </td>
             <td><health-checks list="service.HealthChecks" ></health-checks></td>
             <!-- <td>{{ service.DeploymentCause }}</td> -->
-            <td><a ng-if="vm.showLogLink(service)" ng-href="{{ service.LogLink }}" target="_blank">View Log</a></td>
+            <td>
+              <a ng-if="vm.showLogLink(service)" ng-href="{{ service.LogLink }}" target="_blank">View Log</a>
+              <span ng-if="!vm.showLogLink(service)">
+                <span class="glyphicon glyphicon-question-sign" title="An error has occurred prior to logs becoming available."></span>
+              </span>
+            </td>
           </tr>
         </tbody>
       </table>

--- a/client/app/environments/dialogs/asg/asgSingleInstance.js
+++ b/client/app/environments/dialogs/asg/asgSingleInstance.js
@@ -15,7 +15,7 @@ angular.module('EnvironmentManager.environments').component('asgSingleInstance',
     vm.dataLoading = false;
     vm.instance = vm.resolve.instance;
     vm.showLogLink = function (service) {
-      return !_.includes(['Missing', 'Ignored'], service.DiffWithTargetState);
+      return !_.includes(['Ignored'], service.DiffWithTargetState);
     };
   }
 });


### PR DESCRIPTION
… to the user

- Rather than have no link, provide a glyph and tool tip to explain "why" there is no log to view. 