### PR TITLE
Fix unhandled promise rejection when environment not found

### DIFF
--- a/server/api/controllers/asgs/asgController.js
+++ b/server/api/controllers/asgs/asgController.js
@@ -50,8 +50,8 @@ function getAsgByName(req, res, next) {
 
   return co(function* () {
     let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
-    return getASG({ accountName, autoScalingGroupName }).then(data => res.json(data)).catch(next);
-  });
+    return getASG({ accountName, autoScalingGroupName }).then(data => res.json(data));
+  }).catch(next);
 }
 
 
@@ -77,8 +77,8 @@ function getAsgIps(req, res, next) {
   const exposeAudit = 'version-only';
   return co(function* () {
     let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
-    getDynamo({ accountName, key, resource, exposeAudit }).then(data => res.json(data)).catch(next);
-  });
+    getDynamo({ accountName, key, resource, exposeAudit }).then(data => res.json(data));
+  }).catch(next);
 }
 
 /**
@@ -90,8 +90,8 @@ function getAsgLaunchConfig(req, res, next) {
 
   return co(function* () {
     let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
-    GetLaunchConfiguration({ accountName, autoScalingGroupName }).then(data => res.json(data)).catch(next);
-  });
+    GetLaunchConfiguration({ accountName, autoScalingGroupName }).then(data => res.json(data));
+  }).catch(next);
 }
 
 /**
@@ -103,8 +103,8 @@ function getScalingSchedule(req, res, next) {
 
   return co(function* () {
     let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
-    GetAutoScalingGroupScheduledActions({ accountName, autoScalingGroupName }).then(data => res.json(data)).catch(next);
-  });
+    GetAutoScalingGroupScheduledActions({ accountName, autoScalingGroupName }).then(data => res.json(data));
+  }).catch(next);
 }
 
 /**
@@ -135,8 +135,8 @@ function deleteAsg(req, res, next) {
         res.json({
           Ok: status
         });
-      }).catch(next);
-  });
+      });
+  }).catch(next);
 }
 
 /**
@@ -180,8 +180,8 @@ function putAsgSize(req, res, next) {
       autoScalingGroupDesiredSize,
       autoScalingGroupMaxSize
     })
-      .then(data => res.json(data)).catch(next);
-  });
+      .then(data => res.json(data));
+  }).catch(next);
 }
 
 /**
@@ -194,8 +194,8 @@ function putAsgLaunchConfig(req, res, next) {
 
   return co(function* () {
     let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
-    SetLaunchConfiguration({ accountName, autoScalingGroupName, data }).then(res.json.bind(res)).catch(next);
-  });
+    SetLaunchConfiguration({ accountName, autoScalingGroupName, data }).then(res.json.bind(res));
+  }).catch(next);
 }
 
 module.exports = {

--- a/server/test/test-api/controllers/asgs/asgControllerTests.js
+++ b/server/test/test-api/controllers/asgs/asgControllerTests.js
@@ -1,0 +1,75 @@
+'use strict';
+
+let { mapValues } = require('lodash/fp');
+let proxyquire = require('proxyquire').noCallThru();
+require('should');
+let sinon = require('sinon');
+
+function mkreq(params) {
+  return {
+    swagger: {
+      params: mapValues(x => ({ value: x }))(params)
+    }
+  };
+}
+
+function assertItCallsErrorCallbackWhenEnvironmentNotFound(req, handlerFunctionName) {
+  context('when the environment search returns a rejected promise', function () {
+    let environment = {
+      getAccountNameForEnvironment: sinon.spy(() => Promise.reject(new Error('BOOM!')))
+    };
+    let sut = proxyquire('api/controllers/asgs/asgController', {
+      'models/Environment': environment
+    });
+    it('it calls the Express error callback', function () {
+      let res = null;
+      let next = sinon.spy(error => error);
+      return sut[handlerFunctionName](req, res, next)
+        .catch(() => undefined)
+        .then(() => sinon.assert.called(next));
+    });
+  });
+}
+
+describe('asgController', function () {
+  let req = mkreq({ account: 'my-account', body: {}, environment: 'my-env', name: 'my-name' });
+  describe('getAsgByName', function () {
+    assertItCallsErrorCallbackWhenEnvironmentNotFound(req, 'getAsgByName');
+  });
+
+  describe('getAsgs', function () {
+    assertItCallsErrorCallbackWhenEnvironmentNotFound(req, 'getAsgs');
+  });
+
+  describe('getAsgIps', function () {
+    assertItCallsErrorCallbackWhenEnvironmentNotFound(req, 'getAsgIps');
+  });
+
+  describe('getAsgLaunchConfig', function () {
+    assertItCallsErrorCallbackWhenEnvironmentNotFound(req, 'getAsgLaunchConfig');
+  });
+
+  describe('getScalingSchedule', function () {
+    assertItCallsErrorCallbackWhenEnvironmentNotFound(req, 'getScalingSchedule');
+  });
+
+  describe('deleteAsg', function () {
+    assertItCallsErrorCallbackWhenEnvironmentNotFound(req, 'deleteAsg');
+  });
+
+  describe('putScalingSchedule', function () {
+    assertItCallsErrorCallbackWhenEnvironmentNotFound(req, 'putScalingSchedule');
+  });
+
+  describe('putScalingSchedule', function () {
+    assertItCallsErrorCallbackWhenEnvironmentNotFound(req, 'putScalingSchedule');
+  });
+
+  describe('putAsgSize', function () {
+    assertItCallsErrorCallbackWhenEnvironmentNotFound(req, 'putAsgSize');
+  });
+
+  describe('putAsgLaunchConfig', function () {
+    assertItCallsErrorCallbackWhenEnvironmentNotFound(req, 'putAsgLaunchConfig');
+  });
+});


### PR DESCRIPTION
Some controller functions were not correctly handling the rejected promises returned when the environment specified in the request was not found. HTTP responses were never sent as a consequence.

This pull request fixes this behaviour for the following routes:

* GET /asgs/{name}
* GET /asgs/{name}/ips
* GET /asgs/{name}/launch-config
* GET /asgs/{name}/scaling-schedule
* PUT /asgs/{name}
* DELETE /asgs/{name}
* PUT /asgs/{name}/size
* PUT /asgs/{name}/launch-config

https://jira.thetrainline.com/browse/PD-266