### PR TITLE
Validate API responses during development

### DIFF
--- a/server/api/v1.js
+++ b/server/api/v1.js
@@ -13,6 +13,7 @@ const swaggerAuthorizer = require('modules/express-middleware/swaggerAuthorizerM
 const swaggerNewRelic = require('modules/express-middleware/swaggerNewRelicMiddleware');
 const defaultErrorHandler = require('api/error-handler/defaultErrorHandler');
 
+const NODE_ENV = process.env.NODE_ENV;
 const API_BASE_PATH = apiSpec.basePath;
 
 if (config.get('IS_PRODUCTION') === false) {
@@ -74,7 +75,7 @@ function setup() {
           swaggerMetadata: swaggerMetadata(),
           swaggerRouter: swaggerRouter(swaggerOptions),
           swaggerUi: swaggerUi(),
-          swaggerValidator: swaggerValidator(),
+          swaggerValidator: swaggerValidator({ validateResponse: NODE_ENV === 'development' }),
           swaggerNewRelic
         };
         resolve(Object.freeze(result));


### PR DESCRIPTION
Enable Swagger validation of API responses when the environment variable `NODE_ENV = 'development'`

https://github.com/apigee-127/swagger-tools/blob/master/docs/Middleware.md#swagger-validator
https://jira.thetrainline.com/browse/PD-270