### PR TITLE
Log client IP not HTTP proxy IP

### DIFF
--- a/server/modules/MainServer.js
+++ b/server/modules/MainServer.js
@@ -36,6 +36,11 @@ function createExpressApp() {
   /* eslint-enable */
 
   let app = express();
+  /* enable the 'trust proxy' setting so that we resolve
+   * the client IP address when app is behind HTTP Proxy
+   * http://expressjs.com/en/guide/behind-proxies.html
+   * */
+  app.enable('trust proxy');
 
   let loggerMiddleware = loggingMiddleware.loggerMiddleware(logger);
   let errorLoggerMiddleware = loggingMiddleware.errorLoggerMiddleware(logger);

--- a/server/modules/express-middleware/loggingMiddleware.js
+++ b/server/modules/express-middleware/loggingMiddleware.js
@@ -94,6 +94,7 @@ let errorLoggerMiddleware = logger => (err, req, res, next) => {
       req: {
         id: fp.get('id')(req),
         method: fp.get('method')(req),
+        ip: fp.get('ip')(req),
         originalUrl: fp.get('originalUrl')(req),
         params: swaggerParams(req)
       },


### PR DESCRIPTION
When running behind an HTTP proxy, the application was logging the IP address of the HTTP proxy as the IP address of the client. This change corrects the problem.

http://expressjs.com/en/guide/behind-proxies.html
https://jira.thetrainline.com/browse/PD-271