### PR TITLE
Write upstream configuration to a single DynamoDB table

### DIFF
--- a/server/api/controllers/audit/auditController.js
+++ b/server/api/controllers/audit/auditController.js
@@ -3,6 +3,7 @@
 'use strict';
 
 let notImplemented = require('api/api-utils/notImplemented');
+let { getTableName } = require('modules/awsResourceNameProvider');
 
 /* eslint-disable import/no-extraneous-dependencies */
 let auditLogReader = require('modules/auditLogReader');
@@ -37,7 +38,11 @@ function createAuditLogQuery(since, until, exclusiveStartKey, perPage, filter) {
 function createFilter(query) {
   logger.debug('Audit History: Creating filter.');
   let exprs = {
-    'Entity.Type': val => ['=', ['attr', 'Entity', 'Type'], ['val', val]],
+    'Entity.Type': val => (val === 'ConfigLBUpstream'
+      ? ['or',
+        ['=', ['attr', 'Entity', 'Type'], ['val', getTableName('ConfigLBUpstream')]],
+        ['=', ['attr', 'Entity', 'Type'], ['val', getTableName('InfraConfigLBUpstream')]]]
+      : ['=', ['attr', 'Entity', 'Type'], ['val', getTableName(val)]]),
     'ChangeType': val => ['=', ['attr', 'ChangeType'], ['val', val]],
     'Entity.Key': val => ['=', ['attr', 'Entity', 'Key'], ['val', val]]
   };

--- a/server/commands/resources/DeleteDynamoResource.js
+++ b/server/commands/resources/DeleteDynamoResource.js
@@ -16,6 +16,10 @@ function* handler(command) {
 
   if (command.key) params.key = command.key;
   if (command.range) params.range = command.range;
+  params.metadata = {
+    TransactionID: command.commandId,
+    User: command.username
+  };
 
   // Mark item as deleted in order to trace the right audit
   // Run this step only if auditing is enabled

--- a/server/modules/awsDynamo/dynamodbExpression.js
+++ b/server/modules/awsDynamo/dynamodbExpression.js
@@ -30,7 +30,10 @@ function expressionScope() {
 
 function compileOne(scope, expr) {
   let compile = compileOne.bind(null, scope);
-  let infix = ([fn, ...args]) => `(${args.map(compile).join(` ${fn} `)})`;
+  let infix = ([fn, ...args]) => {
+    let compiled = args.map(compile).join(` ${fn} `);
+    return args.length === 1 ? compiled : `(${compiled})`;
+  };
   let prefix = ([fn, ...args]) => `${fn}(${args.map(compile).join(', ')})`;
   let attr = ([, ...exprs]) => exprs.map(name => scope.nameExpressionAttributeName(name)).join('.');
   let val = ([, ...exprs]) => exprs.map(value => scope.nameExpressionAttributeValue(value)).join(', ');

--- a/server/modules/data-access/dynamoSoftDelete.js
+++ b/server/modules/data-access/dynamoSoftDelete.js
@@ -2,10 +2,33 @@
 
 'use strict';
 
-function deleteMarkerFor(key) {
-  return Object.assign({}, key, { __Deleted: true });
+let { updateAuditMetadata } = require('modules/data-access/dynamoAudit');
+let { compareAndSetVersionOnUpdate, setVersionOnUpdate } = require('modules/data-access/dynamoVersion');
+let { flow } = require('lodash/fp');
+
+function softDelete({ key, metadata, expectedVersion }) {
+  let updateExpression = ['update', ['set', ['at', '__Deleted'], ['val', true]]];
+  let updateWithDeleteMarker = expectedVersion
+    ? flow(
+      updateAuditMetadata,
+      UpdateExpression => ({
+        key,
+        expressions: { UpdateExpression },
+        expectedVersion
+      }),
+      compareAndSetVersionOnUpdate
+    )
+    : flow(
+      updateAuditMetadata,
+      UpdateExpression => ({
+        key,
+        expressions: { UpdateExpression }
+      }),
+      setVersionOnUpdate
+    );
+  return updateWithDeleteMarker({ key, metadata, updateExpression });
 }
 
 module.exports = {
-  deleteMarkerFor
+  softDelete
 };

--- a/server/modules/data-access/lbUpstreamAdapter.js
+++ b/server/modules/data-access/lbUpstreamAdapter.js
@@ -1,0 +1,71 @@
+/* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
+
+'use strict';
+
+let environments = require('modules/data-access/configEnvironments');
+let environmentTypes = require('modules/data-access/configEnvironmentTypes');
+
+function getEnvironmentType(environmentName) {
+  let rejectIfNotFound = msg => obj => (obj !== null ? Promise.resolve(obj) : Promise.reject(new Error(msg)));
+  return environments.get({ EnvironmentName: environmentName })
+    .then(rejectIfNotFound(`Environment not found: ${environmentName}`))
+    .then(({ Value: { EnvironmentType } }) => environmentTypes.get({ EnvironmentType })
+      .then(rejectIfNotFound(`Environment Type not found: ${EnvironmentType}`)));
+}
+
+function convertToOldModel(model) {
+  return {
+    Audit: model.Audit,
+    key: model.Key,
+    Value: {
+      EnvironmentName: model.Environment,
+      Hosts: model.Hosts,
+      LoadBalancingMethod: model.LoadBalancingMethod,
+      PersistenceMethod: model.PersistenceMethod,
+      SchemaVersion: model.SchemaVersion,
+      ServiceName: model.Service,
+      SlowStart: model.SlowStart,
+      UpStreamKeepalives: model.UpStreamKeepalives,
+      UpstreamName: model.Upstream,
+      ZoneSize: model.ZoneSize
+    }
+  };
+}
+
+function convertToNewModel(model) {
+  console.log(JSON.stringify(model, null, 2));
+  return Promise.resolve()
+    .then(() => {
+      if (model.__Deleted) { // eslint-disable-line no-underscore-dangle
+        return {
+          __Deleted: true,
+          Audit: model.Audit,
+          Key: model.key
+        };
+      } else {
+        let environmentName = model.Value.EnvironmentName;
+        return getEnvironmentType(environmentName)
+          .then(environmentType => ({
+            AccountId: environmentType.Value.AWSAccountNumber,
+            Audit: model.Audit,
+            Environment: environmentName,
+            Hosts: model.Value.Hosts,
+            Key: model.key,
+            LoadBalancerGroup: environmentType.Value.AWSAccountNumber,
+            LoadBalancingMethod: model.Value.LoadBalancingMethod,
+            PersistenceMethod: model.Value.PersistenceMethod,
+            SchemaVersion: model.Value.SchemaVersion,
+            Service: model.Value.ServiceName,
+            SlowStart: model.Value.SlowStart,
+            Upstream: model.Value.UpstreamName,
+            UpStreamKeepalives: model.Value.UpStreamKeepalives,
+            ZoneSize: model.Value.ZoneSize
+          }));
+      }
+    });
+}
+
+module.exports = {
+  convertToOldModel,
+  convertToNewModel
+};

--- a/server/modules/resourceFactories/lbUpstreamResourceFactory.js
+++ b/server/modules/resourceFactories/lbUpstreamResourceFactory.js
@@ -2,16 +2,28 @@
 
 'use strict';
 
-/* eslint no-underscore-dangle: 0 */
-/**
- * TODO: This module uses _underscoredNames in many places
- * Disabling eslint of this until it can be properly refactored
- */
+const UPSTREAMS_TABLE = 'InfraConfigLBUpstream';
 
+let Promise = require('bluebird');
 let utils = require('modules/utilities');
 let amazonClientFactory = require('modules/amazon-client/childAccountClient');
+let dynamoTable = require('modules/data-access/dynamoTable');
+let { convertToNewModel } = require('modules/data-access/lbUpstreamAdapter');
+let { mkArn } = require('modules/data-access/dynamoTableArn');
+let { makeWritable } = require('modules/data-access/dynamoItemFilter');
+let { getTableName: physicalTableName } = require('modules/awsResourceNameProvider');
+let { softDelete } = require('modules/data-access/dynamoSoftDelete');
+let dynamoVersion = require('modules/data-access/dynamoVersion');
 let DynamoTableResource = require('./DynamoTableResource');
 let _ = require('lodash');
+let {
+  assign,
+  flow,
+  mapKeys,
+  omitBy,
+  pickBy,
+  replace
+} = require('lodash/fp');
 
 
 function fromNativeDynamoItem(item) {
@@ -25,17 +37,6 @@ function fromNativeDynamoItem(item) {
   return itemClone;
 }
 
-function toNativeDynamoItem(item) {
-  if (!item.Value) return item;
-
-  let itemClone = _.clone(item);
-
-  itemClone.value = JSON.stringify(itemClone.Value);
-  delete itemClone.Value;
-
-  return itemClone;
-}
-
 function LBUpstreamTableResource(config, client) {
   this.client = client;
 
@@ -44,7 +45,7 @@ function LBUpstreamTableResource(config, client) {
   this.getKeyName = $base.getKeyName.bind($base);
   this.getRangeName = $base.getRangeName.bind($base);
   this.isAuditingEnabled = $base.isAuditingEnabled.bind($base);
-  this._buildPrimaryKey = $base._buildPrimaryKey.bind($base);
+  this._buildPrimaryKey = $base._buildPrimaryKey.bind($base); // eslint-disable-line no-underscore-dangle
 
   this.get = function (params) {
     return $base.get(params).then(item => fromNativeDynamoItem(item));
@@ -55,16 +56,54 @@ function LBUpstreamTableResource(config, client) {
   };
 
   this.put = function (params) {
-    params.item = toNativeDynamoItem(params.item);
-    return $base.put(params);
+    function convertAuditPathsToNestedProperties(record) {
+      let isAuditProperty = (v, k) => k.startsWith('Audit.');
+      let Audit = flow(
+        pickBy(isAuditProperty),
+        mapKeys(replace('Audit.', '')))(record);
+
+      return flow(
+        omitBy(isAuditProperty),
+        assign({ Audit })
+      )(record);
+    }
+
+    let { item, expectedVersion } = params;
+    if (item.__Deleted) { // eslint-disable-line no-underscore-dangle
+      return Promise.resolve();
+    }
+    let tableArnP = mkArn({ tableName: physicalTableName(UPSTREAMS_TABLE) });
+    let recordP = convertToNewModel(convertAuditPathsToNestedProperties(item));
+    return Promise.join(tableArnP, recordP, (t, r) => flow(
+      makeWritable,
+      record => ({ record, expectedVersion }),
+      dynamoVersion.compareAndSetVersionOnPut('Key'),
+      dynamoTable.replace.bind(null, t)
+    )(r));
   };
 
   this.post = function (params) {
-    params.item = toNativeDynamoItem(params.item);
-    return $base.post(params);
+    // convert to new schema before writing. must include account
+    let { item } = params;
+    let tableArnP = mkArn({ tableName: physicalTableName(UPSTREAMS_TABLE) });
+    let recordP = convertToNewModel(item);
+    return Promise.join(tableArnP, recordP, (t, r) => flow(
+      makeWritable,
+      record => ({ record }),
+      dynamoVersion.compareAndSetVersionOnCreate('Key'),
+      dynamoTable.create.bind(null, t)
+    )(r));
   };
 
-  this.delete = $base.delete.bind($base);
+  this.delete = function (params) {
+    let { expectedVersion, key: keyValue, metadata } = params;
+    let key = { Key: keyValue };
+    let tableArnP = mkArn({ tableName: physicalTableName(UPSTREAMS_TABLE) });
+    return tableArnP.then((tableArn) => {
+      return dynamoTable.update(tableArn, softDelete({ key, metadata, expectedVersion }))
+        .then(() => dynamoTable.delete(tableArn, { key }));
+    });
+  };
 }
 
 
@@ -76,16 +115,16 @@ module.exports = {
     resourceDescriptor.name.toLowerCase() === 'config/lbupstream',
 
   create: (resourceDescriptor, parameters) =>
-  amazonClientFactory.createDynamoClient(parameters.accountName).then((client) => {
-    let config = {
-      resourceName: resourceDescriptor.name,
-      table: resourceDescriptor.tableName,
-      key: resourceDescriptor.keyName,
-      range: resourceDescriptor.rangeName,
-      auditingEnabled: resourceDescriptor.enableAuditing,
-      dateField: resourceDescriptor.dateField
-    };
+    amazonClientFactory.createDynamoClient(parameters.accountName).then((client) => {
+      let config = {
+        resourceName: resourceDescriptor.name,
+        table: resourceDescriptor.tableName,
+        key: resourceDescriptor.keyName,
+        range: resourceDescriptor.rangeName,
+        auditingEnabled: resourceDescriptor.enableAuditing,
+        dateField: resourceDescriptor.dateField
+      };
 
-    return new LBUpstreamTableResource(config, client);
-  })
+      return new LBUpstreamTableResource(config, client);
+    })
 };

--- a/server/test/modules/awsDynamo/dynamodbExpressionTest.js
+++ b/server/test/modules/awsDynamo/dynamodbExpressionTest.js
@@ -159,6 +159,15 @@ describe('dynamodb expression', function () {
           '#a.#b, #c.#d');
       });
     });
+    context('when I compile an and expression with a single subexpression', function () {
+      let input = ['and', ['=',
+        ['at', 'a', 'b'],
+        ['val', 'x']]];
+      let result = sut.compile(input);
+      it('the expression does not have duplicate parentheses.', function () {
+        result.Expression.should.eql('(#a.#b = :val0)');
+      });
+    });
   });
 });
 

--- a/setup/cloudformation/EnvironmentManagerUpstreams.template.yaml
+++ b/setup/cloudformation/EnvironmentManagerUpstreams.template.yaml
@@ -1,0 +1,137 @@
+AWSTemplateFormatVersion: "2010-09-09"
+# A template for a stack that contains an ElastiCache Redis Cluster.
+Description: Environment Manager Resources
+Parameters:
+  pExecutionRole:
+    Description: role to execute the Lambda function
+    Type: String
+  pCrossAccountRole:
+    Description: role to assume for cross-account writes
+    Type: String
+  pDestinationTable:
+    Description: destination table for cross-account writes
+    Type: String
+  pAlertSNSTopic:
+    Description: SNS Topic ARN for lambda alerts.
+    Type: String
+  pAuditLambdaFunction:
+    Description: the lambda function that audits upstream changes
+    Type: String
+  pResourcePrefix:
+    Description: optional resource name prefix
+    Type: String
+    Default: ""
+Resources:
+  tableInfraConfigLBUpstream:
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: Environment
+          AttributeType: S
+        - AttributeName: Key
+          AttributeType: S
+        - AttributeName: LoadBalancerGroup
+          AttributeType: S
+        - AttributeName: Service
+          AttributeType: S
+        - AttributeName: Upstream
+          AttributeType: S
+      GlobalSecondaryIndexes:
+        - IndexName: Environment-Service-index
+          KeySchema:
+            - AttributeName: Environment
+              KeyType: HASH
+            - AttributeName: Service
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: 10
+            WriteCapacityUnits: 2
+        - IndexName: Environment-Upstream-index
+          KeySchema:
+            - AttributeName: Environment
+              KeyType: HASH
+            - AttributeName: Upstream
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: 10
+            WriteCapacityUnits: 2
+        - IndexName: LoadBalancerGroup-index
+          KeySchema:
+            - AttributeName: LoadBalancerGroup
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: 10
+            WriteCapacityUnits: 2
+      KeySchema:
+        - AttributeName: Key
+          KeyType: HASH
+      ProvisionedThroughput:
+        ReadCapacityUnits: 10
+        WriteCapacityUnits: 2
+      StreamSpecification:
+        StreamViewType: NEW_AND_OLD_IMAGES
+      TableName: !Sub ${pResourcePrefix}InfraConfigLBUpstream
+  lambdaInfraEnvironmentManagerUpstreamRouter:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code: ./lambda/InfraEnvironmentManagerUpstreamRouter/infra-environment-manager-upstream-router.zip
+      Description: This function routes upstream configuration records to the correct DynamoDB table in each child account.
+      Environment:
+        Variables:
+          DESTINATION_TABLE: !Ref pDestinationTable
+          ROLE_NAME: !Ref pCrossAccountRole
+      FunctionName: !Sub ${pResourcePrefix}InfraEnvironmentManagerUpstreamRouter
+      Handler: index.handler
+      MemorySize: 128
+      Role: !Ref pExecutionRole
+      Runtime: nodejs6.10
+      Timeout: 10
+  alertInfraEnvironmentManagerUpstreamRouter:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref pAlertSNSTopic
+      AlarmDescription: Error propagating upstream change to the destination account
+      AlarmName: !Sub ${pResourcePrefix}alertInfraEnvironmentManagerUpstreamRouter
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref lambdaInfraEnvironmentManagerUpstreamRouter
+      Period: 60
+      Statistic: Sum
+      Threshold: 0
+  triggerInfraEnvironmentManagerUpstreamRouter:
+    Type: "AWS::Lambda::EventSourceMapping"
+    Properties:
+      BatchSize: 5
+      Enabled: true
+      EventSourceArn: !GetAtt tableInfraConfigLBUpstream.StreamArn
+      FunctionName: !Ref lambdaInfraEnvironmentManagerUpstreamRouter
+      StartingPosition: LATEST
+  triggerAuditInfraConfigLBSettings:
+    Type: "AWS::Lambda::EventSourceMapping"
+    Properties:
+      BatchSize: 5
+      Enabled: true
+      EventSourceArn: !GetAtt tableInfraConfigLBUpstream.StreamArn
+      FunctionName: !Ref pAuditLambdaFunction
+      StartingPosition: LATEST
+Outputs:
+  lambdaInfraEnvironmentManagerUpstreamRouter:
+    Description: The upstream router Lambda function
+    Value:
+      !GetAtt lambdaInfraEnvironmentManagerUpstreamRouter.Arn
+  tableInfraConfigLBUpstream:
+    Description: The upstream configuration table
+    Value:
+      !Ref tableInfraConfigLBUpstream

--- a/setup/cloudformation/lambda/InfraEnvironmentManagerUpstreamRouter/index.js
+++ b/setup/cloudformation/lambda/InfraEnvironmentManagerUpstreamRouter/index.js
@@ -1,0 +1,307 @@
+'use strict';
+
+let AWS = require('aws-sdk');
+
+let { formatItem, parseItem } = (function dynamoDbConverter() {
+
+  let mapObj = (f, o) => Object.keys(o).reduce((acc, k) => { acc[k] = f(o[k]); return acc; }, {});
+
+  function withErrorHandler(fn) {
+    let errorFlag = false;
+    let error = (msg, val) => { errorFlag = true; return [[`Error: ${msg}`, val], null]; };
+    return obj => {
+      let result = fn(error, obj)
+      if (errorFlag) {
+        throw new Error(`Conversion error: ${JSON.stringify(result, null, 2)}`);
+      } else {
+        return result;
+      }
+    };
+  }
+
+  function parsePrimitive(error, obj) {
+    let keys = Object.keys(obj);
+    let recur = parsePrimitive.bind(null, error);
+    if (keys.length === 1) {
+      let [key] = keys;
+      let val = obj[key];
+      switch (key) {
+        case 'B':
+        case 'BB':
+          return error(`Unsupported type discriminator: ${key}`)
+        case 'BOOL': return typeof (val) === 'boolean' ? val : error('Expected a boolean', val);
+        case 'L': return Array.isArray(val) ? val.map(recur) : error('Expected an array', val);
+        case 'M': return typeof (val) === 'object' && val !== null ? mapObj(recur, val) : error('Expected an object', val);
+        case 'N': return typeof (val) === 'number' || typeof (val) === 'string' ? Number(val) : error('Expected a number or string', val);
+        case 'NULL': return null;
+        case 'S': return typeof (val) === 'string' ? val : error('Expected a string', val);
+        case 'SS': return Array.isArray(val) ? new Set(val.map(x => recur({ S: x }))) : error('Expected an array', val);
+        case 'NN': return Array.isArray(val) ? new Set(val.map(x => recur({ N: x }))) : error('Expected an array', val);
+        default: return error(`Invalid type discriminator: ${key}`);
+      }
+    } else {
+      return error('Expected an object with one property', obj);
+    }
+  }
+
+  function formatPrimitive(error, obj) {
+    let recur = formatPrimitive.bind(null, error);
+    let type = typeof obj
+    switch (type) {
+      case 'boolean':
+        return { BOOL: obj };
+      case 'function':
+        return error('Unsupported value', obj);
+      case 'number':
+        return { N: obj };
+      case 'string':
+        return { S: obj };
+      case 'object':
+        if (obj === null) {
+          return { NULL: true };
+        } else if (obj instanceof Array) {
+          return { L: obj.map(recur) }
+        } else if (obj instanceof Set) {
+          let items = Array.from(obj);
+          let itemType = (([x, ...xs]) => xs.reduce((a, y) => { let t = typeof y; return a === t ? a : 'undefined' }, typeof x))(items);
+          if (itemType === 'number') {
+            return { NN: items };
+          } else if (itemType === 'string') {
+            return { SS: items };
+          } else {
+            return { L: items.map(recur) };
+          }
+        } else {
+          return { M: mapObj(recur, obj) };
+        }
+      case 'symbol':
+        return error('Unsupported value', obj);
+      case 'undefined':
+        return error('Unsupported value', obj);
+    }
+  }
+
+  return {
+    formatItem(obj) {
+      if (typeof obj !== 'object' || obj === null) {
+        throw new Error('Expected an object')
+      }
+      let result = withErrorHandler(formatPrimitive)(obj);
+      return result.M;
+    },
+
+    parseItem(obj) {
+      let result = withErrorHandler(parsePrimitive)({ M: obj });
+      return result;
+    }
+  }
+})();
+
+function show(x) {
+  return JSON.stringify(x);
+}
+
+function reduceSeq(fn, [x, ...xs], acc) {
+  return x === undefined
+    ? Promise.resolve(acc)
+    : Promise.resolve(acc)
+      .then(a => Promise.resolve(fn(a, x)))
+      .then(a => reduceSeq(fn, xs, a));
+}
+
+function mapSeq(fn, array) {
+  return reduceSeq((acc, nxt) => Promise.resolve(fn(nxt)).then(x => [...acc, x]), array, []);
+}
+
+function memoize(fn) {
+  let memo = new Map();
+  return (...args) => {
+    let key = JSON.stringify(args);
+    if (!memo.has(key)) {
+      let result = fn(...args);
+      memo.set(key, result);
+    }
+    return memo.get(key);
+  };
+}
+
+let fromPairs = (acc, [k, v]) => { acc[k] = v; return acc; };
+let toPairs = obj => Object.keys(obj).map(k => [k, obj[k]]);
+
+function convertToOldModel(item) {
+  let value = toPairs(parseItem(item))
+    .filter(([k, v]) => [
+      'Environment',
+      'Hosts',
+      'LoadBalancingMethod',
+      'PersistenceMethod',
+      'SchemaVersion',
+      'Service',
+      'SlowStart',
+      'Upstream',
+      'UpStreamKeepalives',
+      'ZoneSize'
+    ].some(x => x === k) && v !== undefined)
+    .map(([k, v]) => [{
+      Environment: 'EnvironmentName',
+      Service: 'ServiceName',
+      Upstream: 'UpstreamName'
+    }[k] || k, v])
+    .reduce(fromPairs, {});
+
+  let deleteMarker = item.__Deleted ? { __Deleted: item.__Deleted } : {}
+
+  return Object.assign({
+    Audit: item.Audit,
+    key: item.Key,
+    value: {
+      S: JSON.stringify(value)
+    },
+    version: item.Audit.M.Version,
+    readonly: { BOOL: true }
+  }, deleteMarker);
+}
+
+function convertToNewModel(item, accountForEnvironment) {
+  let parsedValue = JSON.parse(item.value.S)
+  let accountId = accountForEnvironment(parsedValue.EnvironmentName)
+  return Object.assign(
+    {
+      AccountId: { S: accountId },
+      LoadBalancerGroup: { S: accountId }
+    },
+    toPairs(item)
+      .filter(([k, v]) => [
+        '__Deleted',
+        'Audit',
+        'key',
+      ].some(x => x === k && v !== undefined))
+      .map(([k, v]) => [{
+        key: 'Key',
+      }[k] || k, v])
+      .reduce(fromPairs, {}),
+    formatItem(
+      toPairs(parsedValue)
+        .filter(([k, v]) => [
+          'EnvironmentName',
+          'Hosts',
+          'LoadBalancingMethod',
+          'PersistenceMethod',
+          'SchemaVersion',
+          'ServiceName',
+          'SlowStart',
+          'UpstreamName',
+          'UpStreamKeepalives',
+          'ZoneSize'
+        ].some(x => x === k) && v !== undefined)
+        .map(([k, v]) => [{
+          EnvironmentName: 'Environment',
+          ServiceName: 'Service',
+          UpstreamName: 'Upstream'
+        }[k] || k, v])
+        .reduce(fromPairs, {})
+    ));
+}
+
+function parseFunctionArn(functionArn) {
+  let match = /^arn:aws:lambda:([^:]+):([^:]+):function:(.*)/.exec(functionArn);
+  if (match !== null && match.length > 1) {
+    return {
+      region: match[1],
+      accountId: match[2],
+      functionName: match[3]
+    };
+  }
+  throw new Error('Could not determine AWS account from context object.');
+}
+
+exports.convertToNewModel = convertToNewModel;
+exports.convertToOldModel = convertToOldModel;
+exports.formatItem = formatItem;
+exports.parseItem = parseItem;
+exports.handler = (event, context, callback) => {
+
+  const DESTINATION_TABLE = process.env.DESTINATION_TABLE;
+  const ROLE_NAME = process.env.ROLE_NAME;
+
+  const {
+        accountId: myAccountId,
+    functionName
+    } = parseFunctionArn(context.invokedFunctionArn);
+
+  let getCredentialsForAccount = memoize((accountId) => {
+    if (accountId === myAccountId) {
+      return Promise.resolve({});
+    }
+    let sts = new AWS.STS();
+    let params = {
+      RoleArn: `arn:aws:iam::${accountId}:role/${ROLE_NAME}`,
+      RoleSessionName: functionName,
+      DurationSeconds: 900
+    };
+    return sts.assumeRole(params).promise().then(({ Credentials: { AccessKeyId, SecretAccessKey, SessionToken } }) =>
+      ({
+        credentials: new AWS.Credentials({
+          accessKeyId: AccessKeyId,
+          secretAccessKey: SecretAccessKey,
+          sessionToken: SessionToken
+        })
+      }));
+  });
+
+  function deleteRecord(record) {
+    console.log(`DELETE ${show(record.dynamodb.Keys)}`);
+    return Promise.resolve()
+      .then(() => getCredentialsForAccount(record.dynamodb.OldImage.AccountId.S))
+      .then(credentials => new AWS.DynamoDB(credentials))
+      .then(dynamo => {
+        let params = {
+          Key: {
+            key: record.dynamodb.Keys.Key
+          },
+          TableName: DESTINATION_TABLE
+        }
+        return dynamo.deleteItem(params).promise()
+      })
+      .catch(error => { console.error(`Error deleting record: ${record}`); return Promise.reject(error); });
+  }
+
+  function putRecord(record) {
+    console.log(`PUT ${show(record.dynamodb.Keys)}`);
+    return Promise.resolve()
+      .then(() => getCredentialsForAccount(record.dynamodb.NewImage.AccountId.S))
+      .then(credentials => new AWS.DynamoDB(credentials))
+      .then(dynamo => dynamo.putItem({
+        Item: convertToOldModel(record.dynamodb.NewImage),
+        TableName: DESTINATION_TABLE,
+        ConditionExpression: '#Audit.#Version < :version or attribute_not_exists(#key)',
+        ExpressionAttributeNames: {
+          '#Audit': 'Audit',
+          '#key': 'key',
+          '#Version': 'Version'
+        },
+        ExpressionAttributeValues: {
+          ':version': record.dynamodb.NewImage.Audit.M.Version
+        }
+      }).promise().catch(error => (error.code === 'ConditionalCheckFailedException' ? Promise.resolve() : Promise.reject(error))))
+      .catch(error => { console.error(`Error putting record: ${record}`); return Promise.reject(error); });
+  }
+
+  function processRecord(record) {
+    let { eventName } = record;
+    switch (eventName) {
+      case 'INSERT':
+      case 'MODIFY':
+        return putRecord(record).then(() => ({ PUT: record.dynamodb.Keys }));
+      case 'REMOVE':
+        return deleteRecord(record).then(() => ({ DELETE: record.dynamodb.Keys }));
+      default:
+        return Promise.reject(`Unsupported eventName: ${eventName}`);
+    }
+  }
+
+  Promise.resolve()
+    .then(mapSeq(processRecord, event.Records))
+    .then(data => callback(null, data))
+    .catch(error => callback(error));
+};

--- a/setup/cloudformation/lambda/InfraEnvironmentManagerUpstreamRouter/index.spec.js
+++ b/setup/cloudformation/lambda/InfraEnvironmentManagerUpstreamRouter/index.spec.js
@@ -1,0 +1,95 @@
+/* eslint-env mocha */
+
+'use strict'
+
+const proxyquire = require('proxyquire').noCallThru();
+require('should');
+const { describe, it } = require('mocha');
+const { check, gen } = require('mocha-testcheck');
+
+let fromPairs = (acc, [k, v]) => { acc[k] = v; return acc; };
+let toPairs = obj => Object.keys(obj).map(k => [k, obj[k]]);
+
+describe('InfraEnvironmentManagerUpstreamRouter', function () {
+
+  describe('convertToOldModel', function () {
+    let { convertToNewModel, convertToOldModel, formatItem } = proxyquire('./index', { 'aws-sdk': {} });
+
+    let scenarios = [
+      ['Environment', 'EnvironmentName'],
+      ['Service', 'ServiceName'],
+      ['Upstream', 'UpstreamName'],
+    ];
+    scenarios.forEach(([oldName, newName]) =>
+      it(`it renames ${oldName} to ${newName}`, function () {
+        let result = convertToOldModel(formatItem({
+          Audit: { Version: 0 },
+          Environment: 'e',
+          Service: 's',
+          Upstream: 'u'
+        }));
+        result.should.match({ value: /"EnvironmentName":/ });
+        result.should.match({ value: /"ServiceName":/ });
+        result.should.match({ value: /"UpstreamName":/ });
+      }));
+
+    context('when converting to old format and back to new format', function () {
+      let maybe = g => gen.oneOf([gen.undefined, gen.null, g]);
+      let genInput = gen.object({
+            AccountId: 'myaccount',
+            Audit: gen.object({ Version: gen.posInt }),
+            Environment: maybe(gen.string),
+            Hosts: gen.array(gen.object(gen.JSONPrimitive)),
+            Key: gen.string.notEmpty(),
+            LoadBalancerGroup: 'myaccount',
+            LoadBalancingMethod: maybe(gen.string),
+            PersistenceMethod: maybe(gen.string),
+            SchemaVersion: maybe(gen.int),
+            Service: maybe(gen.string),
+            SlowStart: maybe(gen.string),
+            Upstream: gen.string.notEmpty(),
+            UpStreamKeepalives: maybe(gen.int),
+            ZoneSize: maybe(gen.string)
+      })
+      it('it returns the input object', check({ maxSize: 3 }, genInput, function (x) {
+        let removeUndefined = xs => toPairs(xs).filter(([,v]) => v !== undefined).reduce(fromPairs, {});
+        let input = formatItem(removeUndefined(x));
+        convertToNewModel(convertToOldModel(input), () => 'myaccount').should.eql(input);
+      }));
+    });
+  });
+
+  describe('dynamoDbConverter', function () {
+    let { formatItem, parseItem } = proxyquire('./index', { 'aws-sdk': {} });
+
+    context('when converting to DynamoDB JSON and back to original JSON', function () {
+      it('it returns the input object', check({ maxSize: 3 }, gen.JSON, function (x) {
+        parseItem(formatItem(x)).should.eql(x);
+      }));
+    });
+
+    context('when converting a Set of numbers to DynamoDB JSON', function () {
+      it('it returns a DynamoDB NN', check(gen.uniqueArray(gen.number).notEmpty(), function (x) {
+        formatItem({ X: new Set(x) }).should.match({ X: { NN: [] } });
+      }));
+    });
+
+    context('when converting a Set of strings to DynamoDB JSON', function () {
+      it('it returns a DynamoDB SS', check({ maxSize: 5 }, gen.uniqueArray(gen.string).notEmpty(), function (x) {
+        formatItem({ X: new Set(x) }).should.match({ X: { SS: [] } });
+      }));
+    });
+
+    context('when converting an empty Set DynamoDB JSON', function () {
+      it('it returns a DynamoDB L', function () {
+        formatItem({ X: new Set([]) }).should.match({ X: { L: [] } });
+      });
+    });
+
+    context('when converting a Set of items of distinct types to DynamoDB JSON', function () {
+      it('it returns a DynamoDB L', check(gen.uniqueArray(gen.JSONPrimitive, x => typeof (x), { minSize: 2 }), function (x) {
+        formatItem({ X: new Set(x) }).should.match({ X: { L: [] } });
+      }));
+    });
+  });
+});

--- a/setup/cloudformation/lambda/InfraEnvironmentManagerUpstreamRouter/package.json
+++ b/setup/cloudformation/lambda/InfraEnvironmentManagerUpstreamRouter/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "infra-environment-manager-upstream-router",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "author": "",
+  "license": "ISC",
+  "dependencies": {},
+  "scripts": {
+    "build-aws-resource": "pack-zip",
+    "lint": "eslint",
+    "test": "mocha **/*.spec.js"
+  },
+  "eslintConfig": {
+    "env": {
+      "es6": true,
+      "node": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+      "ecmaVersion": 6
+    },
+    "rules": {
+      "no-console": 0
+    }
+  },
+  "devDependencies": {
+    "eslint": "^3.4.0",
+    "mocha": "^3.3.0",
+    "mocha-testcheck": "^1.0.0-rc.0",
+    "pack-zip": "^0.2.2",
+    "proxyquire": "^1.7.11",
+    "should": "^11.2.1"
+  }
+}


### PR DESCRIPTION
Environment Manager currently writes each upstream configuration record to a DynamoDB table named _ConfigLBUpstream_ one of the child accounts. The account to which the record is written is derived from the environment to which the upstream is linked.

This pull request modifies Environment Manager to **write** all upstream configuration records to a single DynamoDB table _InfraConfigLBUpstream_. The DynamoDB stream from this table is processed by a Lambda function that writes each record to the _ConfigLBUpstream_ table in the appropriate child account. Environment Manager still **reads** upstream configuration records from the existing _ConfigLBUpstream_ tables.

- Each record replicated from the _InfraConfigLBUpstream_ table to one of the _ConfigLBUpstream_ tables is tagged with the attribute { readonly: true }. This will be used to exclude these records when migrating data from the _ConfigLBUpstream_ tables to the _InfraConfigLBUpstream_ table.

- Environment Manager will be updated to read from the _InfraConfigLBUpstream_  table when all of the upstream configuration records are migrated from the _ConfigLBUpstream_ tables to the _InfraConfigLBUpstream_ table. The _InfraConfigLBUpstream_ table is indexed to allow Environment Manager to execute the queries it currently executes against the _ConfigLBUpstream_ tables against _InfraConfigLBUpstream_.

https://jira.thetrainline.com/browse/PD-242