### PR TITLE
Supply port configuration to deployment service definition

### DIFF
--- a/server/commands/deployments/DeployService.js
+++ b/server/commands/deployments/DeployService.js
@@ -18,6 +18,7 @@ let s3PackageLocator = require('modules/s3PackageLocator');
 let EnvironmentHelper = require('models/Environment');
 let OpsEnvironment = require('models/OpsEnvironment');
 let ResourceLockedError = require('modules/errors/ResourceLockedError');
+let GetServicePort = require('queryHandlers/GetServicePort');
 
 module.exports = function DeployServiceCommandHandler(command) {
   return co(function* () {
@@ -78,6 +79,7 @@ function validateCommandAndCreateDeployment(command) {
     const opsEnvironment = yield OpsEnvironment.getByName(command.environmentName);
     const environmentType = yield environment.getEnvironmentType();
     command.accountName = environmentType.AWSAccountName;
+    const servicePort = yield GetServicePort(command.serviceName, command.serviceSlice);
 
     if (opsEnvironment.Value.DeploymentsLocked) {
       throw new ResourceLockedError(`The environment ${environmentName} is currently locked for deployments. Contact the environment owner.`);
@@ -96,6 +98,7 @@ function validateCommandAndCreateDeployment(command) {
       serviceName: command.serviceName,
       serviceVersion: command.serviceVersion,
       serviceSlice: command.serviceSlice || '',
+      servicePort,
       serverRole: roleName,
       serverRoleName: command.serverRoleName,
       clusterName: configuration.cluster.Name,

--- a/server/commands/deployments/DeployService.js
+++ b/server/commands/deployments/DeployService.js
@@ -18,7 +18,7 @@ let s3PackageLocator = require('modules/s3PackageLocator');
 let EnvironmentHelper = require('models/Environment');
 let OpsEnvironment = require('models/OpsEnvironment');
 let ResourceLockedError = require('modules/errors/ResourceLockedError');
-let GetServicePort = require('queryHandlers/GetServicePort');
+let GetServicePortConfig = require('queryHandlers/GetServicePortConfig');
 
 module.exports = function DeployServiceCommandHandler(command) {
   return co(function* () {
@@ -79,7 +79,7 @@ function validateCommandAndCreateDeployment(command) {
     const opsEnvironment = yield OpsEnvironment.getByName(command.environmentName);
     const environmentType = yield environment.getEnvironmentType();
     command.accountName = environmentType.AWSAccountName;
-    const servicePortConfig = yield GetServicePort(command.serviceName, command.serviceSlice);
+    const servicePortConfig = yield GetServicePortConfig(command.serviceName, command.serviceSlice);
 
     if (opsEnvironment.Value.DeploymentsLocked) {
       throw new ResourceLockedError(`The environment ${environmentName} is currently locked for deployments. Contact the environment owner.`);

--- a/server/commands/deployments/DeployService.js
+++ b/server/commands/deployments/DeployService.js
@@ -79,7 +79,7 @@ function validateCommandAndCreateDeployment(command) {
     const opsEnvironment = yield OpsEnvironment.getByName(command.environmentName);
     const environmentType = yield environment.getEnvironmentType();
     command.accountName = environmentType.AWSAccountName;
-    const servicePort = yield GetServicePort(command.serviceName, command.serviceSlice);
+    const servicePortConfig = yield GetServicePort(command.serviceName, command.serviceSlice);
 
     if (opsEnvironment.Value.DeploymentsLocked) {
       throw new ResourceLockedError(`The environment ${environmentName} is currently locked for deployments. Contact the environment owner.`);
@@ -98,7 +98,7 @@ function validateCommandAndCreateDeployment(command) {
       serviceName: command.serviceName,
       serviceVersion: command.serviceVersion,
       serviceSlice: command.serviceSlice || '',
-      servicePort,
+      servicePortConfig,
       serverRole: roleName,
       serverRoleName: command.serverRoleName,
       clusterName: configuration.cluster.Name,

--- a/server/modules/deployment/serviceDefinition.js
+++ b/server/modules/deployment/serviceDefinition.js
@@ -10,7 +10,7 @@ function getKeyValue(deployment) {
   let serviceSlice = deployment.serviceSlice;
   let clusterName = deployment.clusterName;
   let serviceId = getServiceId(environmentName, serviceName, serviceSlice);
-  let servicePort = deployment.servicePort || 0;
+  let servicePorts = deployment.servicePortConfig;
   let serviceDefinitionKeyValue = {
     key: `environments/${environmentName}/services/${serviceName}/${serviceVersion}/definition`,
     value: {
@@ -18,7 +18,7 @@ function getKeyValue(deployment) {
         Name: serviceId,
         ID: serviceId,
         Address: '',
-        Port: servicePort,
+        Ports: servicePorts,
         Tags: [
           `environment_type:${environmentTypeName}`,
           `environment:${environmentName}`,

--- a/server/modules/deployment/serviceDefinition.js
+++ b/server/modules/deployment/serviceDefinition.js
@@ -10,6 +10,7 @@ function getKeyValue(deployment) {
   let serviceSlice = deployment.serviceSlice;
   let clusterName = deployment.clusterName;
   let serviceId = getServiceId(environmentName, serviceName, serviceSlice);
+  let servicePort = deployment.servicePort || 0;
   let serviceDefinitionKeyValue = {
     key: `environments/${environmentName}/services/${serviceName}/${serviceVersion}/definition`,
     value: {
@@ -17,7 +18,7 @@ function getKeyValue(deployment) {
         Name: serviceId,
         ID: serviceId,
         Address: '',
-        Port: 0,
+        Port: servicePort,
         Tags: [
           `environment_type:${environmentTypeName}`,
           `environment:${environmentName}`,

--- a/server/queryHandlers/GetServicePort.js
+++ b/server/queryHandlers/GetServicePort.js
@@ -1,0 +1,36 @@
+'use strict';
+
+let Service = require('models/Service');
+let co = require('co');
+let _ = require('lodash');
+
+function* getServicePort(serviceName, slice) {
+  if (serviceName === undefined || serviceName === '') {
+    return 0;
+  }
+  if (slice !== undefined && (typeof slice) === 'string') {
+    slice = slice.toLowerCase().trim(); // eslint-disable-line no-param-reassign
+  }
+  if (slice === 'none') {
+    return 0;
+  }
+
+  serviceName = serviceName.trim(); // eslint-disable-line no-param-reassign
+  const service = yield Service.getByName(serviceName);
+  if (service === undefined) {
+    return 0;
+  }
+
+  const configValue = _.get(service, '[0].Value');
+  if (configValue === undefined) {
+    return 0;
+  }
+  if (slice === 'blue') {
+    return configValue.BluePort || 0;
+  } else if (slice === 'green') {
+    return configValue.GreenPort || 0;
+  }
+  return 0;
+}
+
+module.exports = co.wrap(getServicePort);

--- a/server/queryHandlers/GetServicePort.js
+++ b/server/queryHandlers/GetServicePort.js
@@ -4,33 +4,30 @@ let Service = require('models/Service');
 let co = require('co');
 let _ = require('lodash');
 
-function* getServicePort(serviceName, slice) {
+function* getServicePort(serviceName) {
+  let portConfig = { blue: 0, green: 0 };
+
   if (serviceName === undefined || serviceName === '') {
-    return 0;
-  }
-  if (slice !== undefined && (typeof slice) === 'string') {
-    slice = slice.toLowerCase().trim(); // eslint-disable-line no-param-reassign
-  }
-  if (slice === 'none') {
-    return 0;
+    return portConfig;
   }
 
   serviceName = serviceName.trim(); // eslint-disable-line no-param-reassign
   const service = yield Service.getByName(serviceName);
   if (service === undefined) {
-    return 0;
+    return portConfig;
   }
 
   const configValue = _.get(service, '[0].Value');
   if (configValue === undefined) {
-    return 0;
+    return portConfig;
   }
-  if (slice === 'blue') {
-    return configValue.BluePort || 0;
-  } else if (slice === 'green') {
-    return configValue.GreenPort || 0;
+  if (configValue.BluePort !== undefined) {
+    portConfig.blue = configValue.BluePort;
   }
-  return 0;
+  if (configValue.GreenPort !== undefined) {
+    portConfig.green = configValue.GreenPort;
+  }
+  return portConfig;
 }
 
 module.exports = co.wrap(getServicePort);

--- a/server/queryHandlers/GetServicePortConfig.js
+++ b/server/queryHandlers/GetServicePortConfig.js
@@ -4,7 +4,7 @@ let Service = require('models/Service');
 let co = require('co');
 let _ = require('lodash');
 
-function* getServicePort(serviceName) {
+function* getServicePortConfig(serviceName) {
   let portConfig = { blue: 0, green: 0 };
 
   if (serviceName === undefined || serviceName === '') {
@@ -30,4 +30,4 @@ function* getServicePort(serviceName) {
   return portConfig;
 }
 
-module.exports = co.wrap(getServicePort);
+module.exports = co.wrap(getServicePortConfig);

--- a/server/test/commandHandlers/deployment/DeployServiceTest.js
+++ b/server/test/commandHandlers/deployment/DeployServiceTest.js
@@ -92,6 +92,7 @@ describe('DeployService', function () {
       updateStatus: sinon.stub(),
       started: sinon.stub().returns(Promise.resolve({}))
     };
+    const GetServicePortConfig = x => ({ blue: 0, green: 0 });
 
     sut.__set__({ // eslint-disable-line no-underscore-dangle
       s3PackageLocator,
@@ -102,7 +103,8 @@ describe('DeployService', function () {
       DeploymentContract,
       packagePathProvider,
       sender,
-      deploymentLogger
+      deploymentLogger,
+      GetServicePortConfig
     });
   });
 

--- a/server/test/modules/deployment/serviceDefinitionTest.js
+++ b/server/test/modules/deployment/serviceDefinitionTest.js
@@ -21,6 +21,10 @@ describe('ServiceDefinitionKeyValueProvider:', () => {
       serviceName: 'MyService',
       serviceVersion: '1.2.3',
       serviceSlice: 'none',
+      servicePortConfig: {
+        blue: 1234,
+        green: 9876
+      },
       clusterName: 'Tango',
       accountName: 'Prod',
       username: 'test-user',
@@ -59,7 +63,7 @@ describe('ServiceDefinitionKeyValueProvider:', () => {
             Name: 'pr1-MyService',
             ID: 'pr1-MyService',
             Address: '',
-            Port: 0,
+            Ports: { blue: 1234, green: 9876 },
             Tags: [
               'environment_type:Prod',
               'environment:pr1',
@@ -86,6 +90,7 @@ describe('ServiceDefinitionKeyValueProvider:', () => {
       serviceName: 'MyService',
       serviceVersion: '1.2.3',
       serviceSlice: 'blue',
+      servicePortConfig: { blue: 1234, green: 9876 },
       clusterName: 'Tango',
       accountName: 'Prod',
       username: 'test-user',
@@ -104,7 +109,7 @@ describe('ServiceDefinitionKeyValueProvider:', () => {
             Name: 'pr1-MyService-blue',
             ID: 'pr1-MyService-blue',
             Address: '',
-            Port: 0,
+            Ports: { blue: 1234, green: 9876 },
             Tags: [
               'environment_type:Prod',
               'environment:pr1',
@@ -130,6 +135,7 @@ describe('ServiceDefinitionKeyValueProvider:', () => {
       serverRoleName: 'Web',
       serviceName: 'MyService',
       serviceVersion: '1.2.3',
+      servicePortConfig: { blue: 1234, green: 9876 },
       serviceSlice: 'blue',
       clusterName: 'Tango',
       accountName: 'Prod',
@@ -149,7 +155,7 @@ describe('ServiceDefinitionKeyValueProvider:', () => {
             Name: 'pr1-MyService-blue',
             ID: 'pr1-MyService-blue',
             Address: '',
-            Port: 0,
+            Ports: { blue: 1234, green: 9876 },
             Tags: [
               'environment_type:Prod',
               'environment:pr1',

--- a/server/test/queryHandlers/GetServicePortTest.js
+++ b/server/test/queryHandlers/GetServicePortTest.js
@@ -1,0 +1,100 @@
+/* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
+/* eslint-disable */
+'use strict';
+
+let sinon = require('sinon');
+let rewire = require('rewire');
+let assert = require('assert');
+
+describe('GetServicePort', function() {
+  let sut;
+  let Service;
+  
+  function setup(service) {
+    Service = {
+      getByName: sinon.stub().returns(Promise.resolve(service))
+    };
+    sut = rewire('queryHandlers/GetServicePort');
+    sut.__set__({ Service }); //eslint-disable no-underscore-dangle
+  }
+
+  function mockService(bluePort, greenPort) {
+    return [{
+      Value: {
+        BluePort: bluePort,
+        GreenPort: greenPort
+      }
+    }];
+  }
+  
+  it('returns 0 for no inputs', () => {
+    setup();
+    return sut().then(result => assert.equal(result, 0));
+  });
+  
+  it('returns 0 for empty string inputs', () => {
+    setup();
+    return sut('', '').then(result => {
+      return assert.equal(result, 0);
+    });
+  });
+  
+  it('looks up the service config by name', () => {
+    return sut('mockServiceName', 'blue').then(result => {
+      assert.ok(Service.getByName.calledOnce)
+    });
+  });
+  
+  it('correctly resolves blue ports', () => {
+    const BLUE = 9134;
+    const GREEN = 7265;
+    setup(mockService(BLUE, GREEN));
+    return sut('serviceName', 'blue').then(result => {
+      return assert.equal(result, BLUE);
+    });
+  });
+
+  it('correctly resolves green ports', () => {
+    const BLUE = 6552;
+    const GREEN = 4461;
+    setup(mockService(BLUE, GREEN));
+    return sut('serviceName', 'green').then(result => {
+      return assert.equal(result, GREEN);
+    });
+  });
+  
+  it('is case insensitive', () => {
+    const BLUE = 9134;
+    const GREEN = 7265;
+    setup(mockService(BLUE, GREEN));
+    return sut('serviceName', 'bLuE').then(result => {
+      return assert.equal(result, BLUE);
+    });
+  });
+  
+  it('ignores whitespace', () => {
+    const BLUE = 6552;
+    const GREEN = 4461;
+    setup(mockService(BLUE, GREEN));
+    return sut(' serviceName ', '  green     ').then(result => {
+      return assert.equal(result, GREEN);
+    });
+  });
+  
+  it('returns 0 if the given slice is undefined', () => {
+    const BLUE = 6552;
+    const GREEN = 4461;
+    setup(mockService(BLUE));
+    return sut('serviceName', 'green').then(result => {
+      return assert.equal(result, 0);
+    });
+  });
+  
+  it('returns 0 if the service is undefined', () => {
+    setup(undefined);
+    return sut('serviceName', 'blue').then(result => {
+      return assert.equal(result, 0);
+    });
+  });
+});
+

--- a/server/test/queryHandlers/GetServicePortTest.js
+++ b/server/test/queryHandlers/GetServicePortTest.js
@@ -6,7 +6,7 @@ let sinon = require('sinon');
 let rewire = require('rewire');
 let assert = require('assert');
 
-describe.only('GetServicePort', function() {
+describe('GetServicePortConfig', function() {
   let sut;
   let Service;
   const DEFAULT = { green:0, blue:0 };
@@ -15,7 +15,7 @@ describe.only('GetServicePort', function() {
     Service = {
       getByName: sinon.stub().returns(Promise.resolve(service))
     };
-    sut = rewire('queryHandlers/GetServicePort');
+    sut = rewire('queryHandlers/GetServicePortConfig');
     sut.__set__({ Service }); //eslint-disable no-underscore-dangle
   }
 


### PR DESCRIPTION
This update ensures that a services port configuration is written to the service definition at the point of deployment. The deployment agent relies on this information for configuration at install time