### PR TITLE
Read upstream config from a single table

### DIFF
--- a/server/modules/resourceFactories/lbUpstreamResourceFactory.js
+++ b/server/modules/resourceFactories/lbUpstreamResourceFactory.js
@@ -54,8 +54,8 @@ function LBUpstreamTableResource(config, client) {
 
   this.all = function (params) {
     let queryParams = {
-      IndexName: 'LoadBalancerGroup-index',
-      KeyConditionExpression: ['=', ['at', 'LoadBalancerGroup'], ['val', this.accountId]],
+      IndexName: 'AccountId-index',
+      KeyConditionExpression: ['=', ['at', 'AccountId'], ['val', this.accountId]],
       Limit: 20
     };
     return mkArn({ tableName: physicalTableName(UPSTREAMS_TABLE) })

--- a/setup/cloudformation/EnvironmentManagerUpstreams.template.yaml
+++ b/setup/cloudformation/EnvironmentManagerUpstreams.template.yaml
@@ -26,6 +26,8 @@ Resources:
     Type: "AWS::DynamoDB::Table"
     Properties:
       AttributeDefinitions:
+        - AttributeName: AccountId
+          AttributeType: S
         - AttributeName: Environment
           AttributeType: S
         - AttributeName: Key
@@ -37,6 +39,15 @@ Resources:
         - AttributeName: Upstream
           AttributeType: S
       GlobalSecondaryIndexes:
+        - IndexName: AccountId-index
+          KeySchema:
+            - AttributeName: AccountId
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: 10
+            WriteCapacityUnits: 2
         - IndexName: Environment-Service-index
           KeySchema:
             - AttributeName: Environment


### PR DESCRIPTION
Environment Manager reads upstream configuration records from a DynamoDB table named _ConfigLBUpstream_ in each of the child accounts.

This pull request modifies Environment Manager to read all upstream configuration records from a single DynamoDB table _InfraConfigLBUpstream_.

https://jira.thetrainline.com/browse/PD-242