### PR TITLE
Feature/read new lbconfig

### DIFF
--- a/client/app/common/models/UpstreamConfig.js
+++ b/client/app/common/models/UpstreamConfig.js
@@ -26,6 +26,12 @@ angular.module('EnvironmentManager.common').factory('UpstreamConfig',
       });
     };
 
+    UpstreamConfig.getForEnvironment = function (environment) {
+      return $http.get(baseUrl + '?environment=' + environment).then(function (response) {
+        return response.data;
+      });
+    };
+
     UpstreamConfig.deleteByKey = function (key, account) {
       return $http.delete(baseUrl + '/' + encodeURIComponent(key), { params: { account: account } });
     };

--- a/client/app/configuration/lbupstreams/lbupstreams.html
+++ b/client/app/configuration/lbupstreams/lbupstreams.html
@@ -10,7 +10,7 @@
     <label class="control-label text-left">Environment:</label>
   </div>
   <div class="form-group">
-    <select class="form-control" ng-model="vm.selectedEnvironment" ng-change="vm.updateFilter()">
+    <select class="form-control" ng-model="vm.selectedEnvironment" ng-change="vm.updateEnvironment()">
       <option ng-repeat="env in vm.environmentsList" ng-selected="{{env == vm.selectedEnvironment}}" value="{{env}}">{{env}}</option>
     </select>
   </div>

--- a/client/app/configuration/load-balancers/LBUpstreamsController.js
+++ b/client/app/configuration/load-balancers/LBUpstreamsController.js
@@ -44,7 +44,7 @@ angular.module('EnvironmentManager.configuration').controller('LBUpstreamsContro
 
     vm.refresh = function () {
       vm.dataLoading = true;
-      UpstreamConfig.getAll().then(function (data) {
+      UpstreamConfig.getForEnvironment(vm.selectedEnvironment).then(function (data) {
         vm.fullData = data;
       }).finally(function () {
         vm.updateFilter();
@@ -53,7 +53,7 @@ angular.module('EnvironmentManager.configuration').controller('LBUpstreamsContro
     };
 
     vm.updateFilter = function () {
-      $location.search('up_environment', vm.selectedEnvironment);
+      console.log('updateFilter')
       $location.search('serviceFilter', vm.selectedService);
       vm.data = vm.fullData.filter(function (upstream) {
         var match = true;
@@ -67,6 +67,14 @@ angular.module('EnvironmentManager.configuration').controller('LBUpstreamsContro
         return match;
       });
     };
+
+    vm.updateEnvironment = function () {
+      console.log('updateEnvironment')
+      $location.search('up_environment', vm.selectedEnvironment);
+      UpstreamConfig.getForEnvironment(vm.selectedEnvironment).then(function (data) {
+        vm.fullData = data;
+      }).then(vm.updateFilter);
+    }
 
     vm.newItem = function () {
       $location.search('mode', 'New');

--- a/client/app/configuration/load-balancers/LBUpstreamsController.js
+++ b/client/app/configuration/load-balancers/LBUpstreamsController.js
@@ -53,7 +53,6 @@ angular.module('EnvironmentManager.configuration').controller('LBUpstreamsContro
     };
 
     vm.updateFilter = function () {
-      console.log('updateFilter')
       $location.search('serviceFilter', vm.selectedService);
       vm.data = vm.fullData.filter(function (upstream) {
         var match = true;
@@ -69,7 +68,6 @@ angular.module('EnvironmentManager.configuration').controller('LBUpstreamsContro
     };
 
     vm.updateEnvironment = function () {
-      console.log('updateEnvironment')
       $location.search('up_environment', vm.selectedEnvironment);
       UpstreamConfig.getForEnvironment(vm.selectedEnvironment).then(function (data) {
         vm.fullData = data;

--- a/client/app/configuration/load-balancers/LBUpstreamsController.js
+++ b/client/app/configuration/load-balancers/LBUpstreamsController.js
@@ -43,6 +43,7 @@ angular.module('EnvironmentManager.configuration').controller('LBUpstreamsContro
     };
 
     vm.refresh = function () {
+      $location.search('up_environment', vm.selectedEnvironment);
       vm.dataLoading = true;
       UpstreamConfig.getForEnvironment(vm.selectedEnvironment).then(function (data) {
         vm.fullData = data;
@@ -68,10 +69,7 @@ angular.module('EnvironmentManager.configuration').controller('LBUpstreamsContro
     };
 
     vm.updateEnvironment = function () {
-      $location.search('up_environment', vm.selectedEnvironment);
-      UpstreamConfig.getForEnvironment(vm.selectedEnvironment).then(function (data) {
-        vm.fullData = data;
-      }).then(vm.updateFilter);
+      vm.refresh();
     }
 
     vm.newItem = function () {

--- a/client/app/operations/upstream/OpsUpstreamController.js
+++ b/client/app/operations/upstream/OpsUpstreamController.js
@@ -5,7 +5,7 @@
 'use strict';
 
 angular.module('EnvironmentManager.operations').controller('OpsUpstreamController',
-  function ($routeParams, $location, $uibModal, $q, $http, resources, QuerySync, cachedResources, accountMappingService, modal) {
+  function ($routeParams, $location, $uibModal, $q, $http, resources, QuerySync, cachedResources, accountMappingService, modal, UpstreamConfig) {
     var vm = this;
     var querySync;
     var SHOW_ALL_OPTION = 'Any';
@@ -64,8 +64,7 @@ angular.module('EnvironmentManager.operations').controller('OpsUpstreamControlle
 
     vm.refresh = function () {
       vm.dataLoading = true;
-      var params = { account: 'all' };
-      resources.config.lbUpstream.all(params).then(function (data) {
+      UpstreamConfig.getForEnvironment(vm.selectedEnvironment).then(function (data) {
         vm.fullUpstreamData = restructureUpstreams(data);
         return updateLBStatus().then(function () {
           vm.updateFilter();

--- a/server/api/controllers/config/upstreams/upstreamsConfigController.js
+++ b/server/api/controllers/config/upstreams/upstreamsConfigController.js
@@ -3,24 +3,115 @@
 'use strict';
 
 const RESOURCE = 'config/lbupstream';
+let { flow, pickBy } = require('lodash/fp');
+let base64 = require('modules/base64');
+let { versionOf } = require('modules/data-access/dynamoVersion');
+let { removeAuditMetadata } = require('modules/data-access/dynamoAudit');
+let { convertToOldModel } = require('modules/data-access/lbUpstreamAdapter');
+let loadBalancerUpstreams = require('modules/data-access/loadBalancerUpstreams');
+let { getMetadataForDynamoAudit } = require('api/api-utils/requestMetadata');
 let dynamoHelper = new (require('api/api-utils/DynamoHelper'))(RESOURCE);
-let Environment = require('models/Environment');
+let param = require('api/api-utils/requestParam');
+let { getAccountNameForEnvironment } = require('models/Environment');
+let weblink = require('modules/weblink');
 let co = require('co');
+let querystring = require('querystring');
+
+function convertToApiModel(persistedModel) {
+  let apiModel = removeAuditMetadata(persistedModel);
+  let Version = versionOf(persistedModel);
+  return Object.assign(apiModel, { Version });
+}
 
 /**
  * GET /config/upstreams
  */
 function getUpstreamsConfig(req, res, next) {
-  return dynamoHelper.getAllCrossAccount().then(data => res.json(data)).catch(next);
+  const environment = param('environment', req);
+  const exclusiveStartKey = param('exclusiveStartKey', req);
+  const loadBalancerGroup = param('loadBalancerGroup', req);
+  const limit = param('per_page', req);
+  const sort = param('sort', req);
+
+  let opts = {
+    ExclusiveStartKey: exclusiveStartKey ? base64.decode(exclusiveStartKey) : null,
+    Limit: limit,
+    ScanIndexForward: sort ? !sort.toUpperCase().startsWith('DESC') : true
+  };
+
+  function nextUrl(lastEvaluatedKey) {
+    if (lastEvaluatedKey) {
+      return flow(
+        pickBy(value => value),
+        querystring.stringify,
+        q => [req.path, q].filter(x => x !== '').join('?')
+      )({
+        environment,
+        exclusiveStartKey: base64.encode(lastEvaluatedKey),
+        per_page: limit,
+        sort: opts.ScanIndexForward ? 'asc' : 'desc'
+      });
+    } else {
+      return null;
+    }
+  }
+
+  function previousUrl([head]) {
+    let keyOf = ({ Environment, Key }) => ({ Environment, Key });
+    if (head && exclusiveStartKey) {
+      return flow(
+        pickBy(value => value),
+        querystring.stringify,
+        q => [req.path, q].filter(x => x !== '').join('?')
+      )({
+        environment,
+        exclusiveStartKey: base64.encode(keyOf(head)),
+        per_page: limit,
+        sort: opts.ScanIndexForward ? 'desc' : 'asc'
+      });
+    } else {
+      return null;
+    }
+  }
+
+  let dbOperation = () => {
+    if (environment) {
+      return loadBalancerUpstreams.inEnvironment(environment, opts);
+    } else if (loadBalancerGroup) {
+      return loadBalancerUpstreams.inLoadBalancerGroup(loadBalancerGroup);
+    } else {
+      return loadBalancerUpstreams.scan();
+    }
+  };
+
+  return dbOperation()
+    .then(({ LastEvaluatedKey, Items }) => ({
+      Items,
+      Links: {
+        next: nextUrl(LastEvaluatedKey),
+        previous: previousUrl(Items)
+      }
+    }))
+    .then((data) => {
+      let linkHeader = flow(
+        pickBy(x => x),
+        weblink.link
+      )(data.Links);
+      res.header('Link', linkHeader);
+      res.json(data.Items.map(flow(convertToOldModel, convertToApiModel)));
+    })
+    .catch(next);
 }
 
 /**
  * GET /config/upstreams/{name}
  */
 function getUpstreamConfigByName(req, res, next) {
-  let key = req.swagger.params.name.value;
-  let accountName = req.swagger.params.account.value;
-  return dynamoHelper.getByKey(key, { accountName }).then(data => res.json(data)).catch(next);
+  let Key = param('name', req);
+  return loadBalancerUpstreams.get({ Key })
+    .then(flow(convertToOldModel, convertToApiModel))
+    .then(data => res.json(data))
+    .catch(next);
 }
 
 /**
@@ -33,7 +124,7 @@ function postUpstreamsConfig(req, res, next) {
   let environmentName = body.Value.EnvironmentName;
 
   co(function* () {
-    let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
+    let accountName = yield getAccountNameForEnvironment(environmentName);
     return dynamoHelper.create(key, { Value: body.Value }, user, { accountName });
   }).then(data => res.json(data)).catch(next);
 }
@@ -49,7 +140,7 @@ function putUpstreamConfigByName(req, res, next) {
   let environmentName = body.EnvironmentName;
 
   co(function* () {
-    let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
+    let accountName = yield getAccountNameForEnvironment(environmentName);
     return dynamoHelper.update(key, { Value: body }, expectedVersion, user, { accountName });
   }).then(data => res.json(data)).catch(next);
 }
@@ -58,10 +149,13 @@ function putUpstreamConfigByName(req, res, next) {
  * DELETE /config/upstreams/{name}
  */
 function deleteUpstreamConfigByName(req, res, next) {
-  let key = req.swagger.params.name.value;
-  let user = req.user;
-  let accountName = req.swagger.params.account.value;
-  return dynamoHelper.delete(key, user, { accountName }).then(data => res.json(data)).catch(next);
+  let Key = param('name', req);
+  let key = { Key };
+  const expectedVersion = param('expected-version', req);
+  let metadata = getMetadataForDynamoAudit(req);
+
+  return loadBalancerUpstreams.delete({ key, metadata }, expectedVersion)
+    .then(() => res.status(200).end());
 }
 
 module.exports = {

--- a/server/api/swagger.yaml
+++ b/server/api/swagger.yaml
@@ -2068,6 +2068,31 @@ paths:
       summary: Get all upstream configurations.
       tags:
         - Upstream
+      parameters:
+        - name: environment
+          in: query
+          type: string
+        - name: loadBalancerGroup
+          in: query
+          type: string
+        - name: exclusiveStartKey
+          in: query
+          type: string
+        - name: per_page
+          in: query
+          type: integer
+        - name: sort
+          in: query
+          type: string
+          enum:
+            - asc
+            - ASC
+            - ascending
+            - ASCENDING
+            - desc
+            - DESC
+            - descending
+            - DESCENDING
       responses:
         200:
           description: The list of upstream configs
@@ -2122,10 +2147,6 @@ paths:
           in: path
           type: string
           required: true
-        - name: account
-          in: query
-          type: string
-          required: true
       responses:
         200:
           description: The upstream config
@@ -2140,10 +2161,6 @@ paths:
       parameters:
         - name: name
           in: path
-          type: string
-          required: true
-        - name: account
-          in: query
           type: string
           required: true
       responses:

--- a/server/modules/amazon-client/pages.js
+++ b/server/modules/amazon-client/pages.js
@@ -22,10 +22,13 @@ function reduce(callback, initialValue, awsRequest) {
     awsRequest.eachPage((error, data) => {
       if (error) {
         reject(error);
+        return false;
       } else if (data === null) {
         resolve(accumulator);
+        return false;
       } else {
         accumulator = callback(accumulator, data);
+        return true;
       }
     });
   });

--- a/server/modules/data-access/cachedSingleAccountDynamoTable.js
+++ b/server/modules/data-access/cachedSingleAccountDynamoTable.js
@@ -2,12 +2,12 @@
 
 'use strict';
 
-let singleAccountdynamoTable = require('modules/data-access/singleAccountdynamoTable');
+let singleAccountDynamoTable = require('modules/data-access/singleAccountDynamoTable');
 let dynamoTableCache = require('modules/data-access/dynamoTableCache');
 
 function factory(physicalTableName, { ttl }) {
   let cachedTable = dynamoTableCache(physicalTableName, { ttl });
-  return singleAccountdynamoTable(physicalTableName, cachedTable);
+  return singleAccountDynamoTable(physicalTableName, cachedTable);
 }
 
 module.exports = factory;

--- a/server/modules/data-access/dynamoTableCache.js
+++ b/server/modules/data-access/dynamoTableCache.js
@@ -30,6 +30,10 @@ function dynamoTableCache(logicalTableName, { ttl }) {
     return dynamoTable.get(tableArn, key);
   }
 
+  function query(tableArn, expressions) {
+    return dynamoTable.query(tableArn, expressions);
+  }
+
   function replace(tableArn, replaceSpec) {
     return dynamoTable.replace(tableArn, replaceSpec)
       .then(_ => cache.del(tableArn).catch(logError('Could not invalidate cache', tableArn)));
@@ -55,6 +59,7 @@ function dynamoTableCache(logicalTableName, { ttl }) {
     create,
     delete: $delete,
     get,
+    query,
     replace,
     scan,
     update

--- a/server/modules/data-access/lbUpstreamAdapter.js
+++ b/server/modules/data-access/lbUpstreamAdapter.js
@@ -33,7 +33,6 @@ function convertToOldModel(model) {
 }
 
 function convertToNewModel(model) {
-  console.log(JSON.stringify(model, null, 2));
   return Promise.resolve()
     .then(() => {
       if (model.__Deleted) { // eslint-disable-line no-underscore-dangle
@@ -51,7 +50,7 @@ function convertToNewModel(model) {
             Environment: environmentName,
             Hosts: model.Value.Hosts,
             Key: model.key,
-            LoadBalancerGroup: environmentType.Value.AWSAccountNumber,
+            LoadBalancerGroup: environmentType.EnvironmentType,
             LoadBalancingMethod: model.Value.LoadBalancingMethod,
             PersistenceMethod: model.Value.PersistenceMethod,
             SchemaVersion: model.Value.SchemaVersion,

--- a/server/modules/data-access/loadBalancerUpstreams.js
+++ b/server/modules/data-access/loadBalancerUpstreams.js
@@ -1,0 +1,93 @@
+/* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
+
+'use strict';
+
+const LOGICAL_TABLE_NAME = 'InfraConfigLBUpstream';
+
+let {
+  getTableName: physicalTableName
+} = require('modules/awsResourceNameProvider');
+let pages = require('modules/amazon-client/pages');
+let { compile } = require('modules/awsDynamo/dynamodbExpression');
+let { DocumentClient: documentClient } = require('modules/data-access/dynamoClientFactory');
+let dynamoTable = require('modules/data-access/dynamoTable');
+let singleAccountDynamoTable = require('modules/data-access/singleAccountDynamoTable');
+
+const TABLE_NAME = physicalTableName(LOGICAL_TABLE_NAME);
+
+let table = singleAccountDynamoTable(TABLE_NAME, dynamoTable);
+
+// Paged implementation
+// function inEnvironment(environment, { ExclusiveStartKey, Limit, ScanIndexForward } = {}) {
+//   return documentClient()
+//     .then((dynamo) => {
+//       let KeyConditionExpression = ['=',
+//         ['at', 'Environment'],
+//         ['val', environment]];
+//       let params = Object.assign(
+//         {
+//           IndexName: 'Environment-Key-index',
+//           TableName: TABLE_NAME
+//         },
+//         (ExclusiveStartKey ? { ExclusiveStartKey } : {}),
+//         (Limit ? { Limit } : {}),
+//         (ScanIndexForward !== null && ScanIndexForward !== undefined ? { ScanIndexForward } : {}),
+//         compile({ KeyConditionExpression }));
+//       return dynamo.query(params).promise()
+//         .then(({ LastEvaluatedKey, Items }) => ({ LastEvaluatedKey, Items }));
+//     });
+// }
+
+function inEnvironment(environment) {
+  return documentClient()
+    .then((dynamo) => {
+      let KeyConditionExpression = ['=',
+        ['at', 'Environment'],
+        ['val', environment]];
+      let params = Object.assign(
+        {
+          IndexName: 'Environment-Key-index',
+          TableName: TABLE_NAME
+        },
+        compile({ KeyConditionExpression }));
+      return pages.flatten(rsp => rsp.Items, dynamo.query(params)).then(x => ({ Items: x }));
+    });
+}
+
+function inLoadBalancerGroup(loadBalancerGroup) {
+  return documentClient()
+    .then((dynamo) => {
+      let KeyConditionExpression = ['=',
+        ['at', 'LoadBalancerGroup'],
+        ['val', loadBalancerGroup]];
+      let params = Object.assign(
+        {
+          IndexName: 'LoadBalancerGroup-index',
+          TableName: TABLE_NAME
+        },
+        compile({ KeyConditionExpression }));
+      return pages.flatten(rsp => rsp.Items, dynamo.query(params)).then(x => ({ Items: x }));
+    });
+}
+
+function scan(environment) {
+  return documentClient()
+    .then((dynamo) => {
+      let params = {
+        IndexName: 'Environment-Key-index',
+        TableName: TABLE_NAME
+      };
+      return pages.flatten(rsp => rsp.Items, dynamo.scan(params)).then(x => ({ Items: x }));
+    });
+}
+
+module.exports = {
+  create: table.create,
+  delete: table.delete,
+  get: table.get,
+  inEnvironment,
+  inLoadBalancerGroup,
+  replace: table.replace,
+  scan,
+  update: table.update
+};

--- a/server/modules/data-access/singleAccountDynamoTable.js
+++ b/server/modules/data-access/singleAccountDynamoTable.js
@@ -1,0 +1,92 @@
+/* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
+
+'use strict';
+
+let mkArn = require('modules/data-access/dynamoTableArn').mkArn;
+let { attachAuditMetadata, updateAuditMetadata } = require('modules/data-access/dynamoAudit');
+let describeDynamoTable = require('modules/data-access/describeDynamoTable');
+let hashKeyAttributeName = require('modules/data-access/dynamoTableDescription').hashKeyAttributeName;
+let tableArn = require('modules/data-access/dynamoTableDescription').tableArn;
+let { makeWritable } = require('modules/data-access/dynamoItemFilter');
+let dynamoVersion = require('modules/data-access/dynamoVersion');
+let { softDelete } = require('modules/data-access/dynamoSoftDelete');
+let fp = require('lodash/fp');
+
+function factory(physicalTableName, dynamoTable) {
+  let tableDescriptionPromise = () => mkArn({ tableName: physicalTableName }).then(describeDynamoTable);
+
+  function create(item) {
+    return tableDescriptionPromise().then(description =>
+      fp.flow(
+        makeWritable,
+        attachAuditMetadata,
+        record => ({ record }),
+        dynamoVersion.compareAndSetVersionOnCreate(hashKeyAttributeName(description)),
+        dynamoTable.create.bind(null, tableArn(description))
+      )(item)
+    );
+  }
+
+  function $delete(item, expectedVersion) {
+    let { key, metadata } = item;
+    return tableDescriptionPromise().then((description) => {
+      let table = tableArn(description);
+      return dynamoTable.update(table, softDelete({ key, metadata, expectedVersion }))
+        .then(_ => dynamoTable.delete(table, { key }));
+    });
+  }
+
+  function get(key) {
+    return tableDescriptionPromise()
+      .then(description => dynamoTable.get(tableArn(description), key));
+  }
+
+  function query(expression) {
+    return tableDescriptionPromise()
+      .then(description => dynamoTable.query(tableArn(description), expression));
+  }
+
+  function replace(item, expectedVersion) {
+    return tableDescriptionPromise().then(description =>
+      fp.flow(
+        makeWritable,
+        attachAuditMetadata,
+        record => ({ record, expectedVersion }),
+        dynamoVersion.compareAndSetVersionOnReplace,
+        dynamoTable.replace.bind(null, tableArn(description))
+      )(item)
+    );
+  }
+
+  function scan(expression) {
+    return tableDescriptionPromise()
+      .then(description => dynamoTable.scan(tableArn(description), expression));
+  }
+
+  function update(expression, expectedVersion) {
+    return tableDescriptionPromise().then(description =>
+      fp.flow(
+        updateAuditMetadata,
+        updateExpression => ({
+          key: expression.key,
+          expressions: { UpdateExpression: updateExpression },
+          expectedVersion
+        }),
+        dynamoVersion.compareAndSetVersionOnUpdate,
+        dynamoTable.update.bind(null, tableArn(description))
+      )(expression)
+    );
+  }
+
+  return {
+    create,
+    delete: $delete,
+    get,
+    query,
+    replace,
+    scan,
+    update
+  };
+}
+
+module.exports = factory;

--- a/setup/cloudformation/EnvironmentManagerUpstreams.template.yaml
+++ b/setup/cloudformation/EnvironmentManagerUpstreams.template.yaml
@@ -43,27 +43,18 @@ Resources:
           KeySchema:
             - AttributeName: AccountId
               KeyType: HASH
-          Projection:
-            ProjectionType: ALL
-          ProvisionedThroughput:
-            ReadCapacityUnits: 10
-            WriteCapacityUnits: 2
-        - IndexName: Environment-Service-index
-          KeySchema:
-            - AttributeName: Environment
-              KeyType: HASH
-            - AttributeName: Service
+            - AttributeName: Key
               KeyType: RANGE
           Projection:
             ProjectionType: ALL
           ProvisionedThroughput:
             ReadCapacityUnits: 10
             WriteCapacityUnits: 2
-        - IndexName: Environment-Upstream-index
+        - IndexName: Environment-Key-index
           KeySchema:
             - AttributeName: Environment
               KeyType: HASH
-            - AttributeName: Upstream
+            - AttributeName: Key
               KeyType: RANGE
           Projection:
             ProjectionType: ALL
@@ -74,6 +65,8 @@ Resources:
           KeySchema:
             - AttributeName: LoadBalancerGroup
               KeyType: HASH
+            - AttributeName: Key
+              KeyType: RANGE
           Projection:
             ProjectionType: ALL
           ProvisionedThroughput:


### PR DESCRIPTION
This pull request adds support for `environment` and `loadBalancerGroup` query parameters to the `/config/upstreams` route. These parameters are supported by query operations over table indexes, not filtered scan operations. This reduces DynamoDB read throughput.

https://jira.thetrainline.com/browse/PD-242