### PR TITLE
Write load balancer settings to a single DynamoDB table

### DIFF
--- a/server/api/api-utils/lbSettingsController.js
+++ b/server/api/api-utils/lbSettingsController.js
@@ -1,0 +1,182 @@
+/* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
+
+'use strict';
+
+let { flow } = require('lodash/fp');
+let { convertToNewModel, convertToOldModel } = require('modules/data-access/lbSettingsAdapter');
+let loadBalancerSettings = require('modules/data-access/loadBalancerSettings');
+let { getMetadataForDynamoAudit } = require('api/api-utils/requestMetadata');
+let param = require('api/api-utils/requestParam');
+let { versionOf } = require('modules/data-access/dynamoVersion');
+let { removeAuditMetadata } = require('modules/data-access/dynamoAudit');
+let { hasValue, when } = require('modules/functional');
+let { ifNotFound, notFoundMessage } = require('api/api-utils/ifNotFound');
+
+const sns = require('modules/sns/EnvironmentManagerEvents');
+
+function convertToApiModel(persistedModel) {
+  let apiModel = removeAuditMetadata(persistedModel);
+  let Version = versionOf(persistedModel);
+  return Object.assign(apiModel, { Version });
+}
+
+// let notify = sns.publish.bind(sns);
+let notify = console.log.bind(console);
+
+/**
+ * GET /config/lb-settings
+ */
+function getLBSettingsConfig(req, res, next) {
+  const environmentName = param('environment', req);
+  const frontend = param('frontend', req);
+  const loadBalancerGroup = param('loadBalancerGroup', req);
+
+  function filterExpression(expressions) {
+    let { length } = expressions;
+    if (length === 0) {
+      return {};
+    } else if (length === 1) {
+      let [FilterExpression] = expressions;
+      return { FilterExpression };
+    } else {
+      let FilterExpression = ['and', ...expressions];
+      return { FilterExpression };
+    }
+  }
+
+  let filterExpressions = [
+    (frontend !== undefined)
+      ? ['=', ['at', 'Value', 'FrontEnd'], ['val', frontend !== false]]
+      : undefined,
+    (loadBalancerGroup !== undefined && environmentName !== undefined)
+      ? ['=', ['at', 'LoadBalancerGroup'], ['val', loadBalancerGroup]]
+      : undefined
+  ];
+
+  let expressions = Object.assign(
+    (environmentName !== undefined)
+      ? { KeyConditionExpression: ['=', ['at', 'EnvironmentName'], ['val', environmentName]] }
+      : {},
+    (loadBalancerGroup !== undefined && environmentName === undefined)
+      ? {
+        IndexName: 'LoadBalancerGroup-index',
+        KeyConditionExpression: ['=', ['at', 'LoadBalancerGroup'], ['val', loadBalancerGroup]]
+      }
+      : {},
+    filterExpression(filterExpressions.filter(x => x !== undefined))
+  );
+
+  console.log(expressions);
+
+  let getData = expressions.KeyConditionExpression
+    ? () => loadBalancerSettings.query(expressions)
+    : () => loadBalancerSettings.scan(expressions);
+
+  return getData()
+    .then(data => res.json(data))
+    .catch(next);
+}
+
+/**
+ * GET /config/lb-settings/{environment}/{vHostName}
+ */
+function getLBSettingConfigByName(req, res, next) {
+  const key = {
+    EnvironmentName: param('environment', req),
+    VHostName: param('vHostName', req)
+  };
+  return loadBalancerSettings.get(key)
+    .then(when(hasValue, flow(convertToOldModel, convertToApiModel)))
+    .then(ifNotFound(notFoundMessage('lb-setting')))
+    .then(send => send(res))
+    .catch(next);
+}
+
+/**
+ * POST /config/lb-settings
+ */
+function postLBSettingsConfig(req, res, next) {
+  return Promise.resolve()
+    .then(() => {
+      const body = param('body', req);
+      let metadata = getMetadataForDynamoAudit(req);
+      let key = {
+        EnvironmentName: body.EnvironmentName,
+        VHostName: body.VHostName
+      };
+      return convertToNewModel(Object.assign(key, body))
+        .then((record) => {
+          delete record.Version;
+          return { record, metadata };
+        });
+    })
+    .then(loadBalancerSettings.create)
+    .then(() => res.status(201).end())
+    .then(notify({
+      message: 'Post /config/lb-settings',
+      topic: sns.TOPICS.CONFIGURATION_CHANGE,
+      attributes: {
+        Action: sns.ACTIONS.POST,
+        ID: ''
+      }
+    }))
+    .catch(next);
+}
+
+/**
+ * PUT /config/lb-settings/{environment}/{vHostName}
+ */
+function putLBSettingConfigByName(req, res, next) {
+  const key = {
+    EnvironmentName: param('environment', req),
+    VHostName: param('vHostName', req)
+  };
+  const Value = param('body', req);
+  const expectedVersion = param('expected-version', req);
+  let metadata = getMetadataForDynamoAudit(req);
+
+  return convertToNewModel(Object.assign(key, { Value }))
+    .then(record => loadBalancerSettings.put({ record, metadata }, expectedVersion))
+    .then(() => res.status(200).end())
+    .then(notify({
+      message: 'Put /config/lb-settings',
+      topic: sns.TOPICS.CONFIGURATION_CHANGE,
+      attributes: {
+        Action: sns.ACTIONS.POST,
+        ID: ''
+      }
+    }))
+    .catch(next);
+}
+
+/**
+ * DELETE /config/lb-settings/{environment}/{vHostName}
+ */
+function deleteLBSettingConfigByName(req, res, next) {
+  const key = {
+    EnvironmentName: param('environment', req),
+    VHostName: param('vHostName', req)
+  };
+  const expectedVersion = param('expected-version', req);
+  let metadata = getMetadataForDynamoAudit(req);
+
+  return loadBalancerSettings.delete({ key, metadata }, expectedVersion)
+    .then(() => res.status(200).end())
+    .then(notify({
+      message: `Delete /config/lb-settings/${key}`,
+      topic: sns.TOPICS.CONFIGURATION_CHANGE,
+      attributes: {
+        Action: sns.ACTIONS.DELETE,
+        ID: ''
+      }
+    }))
+    .catch(next);
+}
+
+module.exports = {
+  getLBSettingsConfig,
+  getLBSettingConfigByName,
+  postLBSettingsConfig,
+  putLBSettingConfigByName,
+  deleteLBSettingConfigByName
+};

--- a/server/api/api-utils/lbSettingsControllerCrossAccount.js
+++ b/server/api/api-utils/lbSettingsControllerCrossAccount.js
@@ -1,0 +1,103 @@
+/* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
+
+'use strict';
+
+const RESOURCE = 'config/lbsettings';
+const PARTITION_KEY = 'EnvironmentName';
+const SORT_KEY = 'VHostName';
+
+let co = require('co');
+let dynamoHelper = new (require('api/api-utils/DynamoHelper'))(RESOURCE);
+let Environment = require('models/Environment');
+const sns = require('modules/sns/EnvironmentManagerEvents');
+
+/**
+ * GET /config/lb-settings
+ */
+function getLBSettingsConfig(req, res, next) {
+  const environmentName = req.swagger.params.environment.value;
+  const frontend = req.swagger.params.frontend.value;
+  let filter = {};
+  if (environmentName !== undefined) {
+    filter.EnvironmentName = environmentName;
+  }
+  if (frontend !== undefined) {
+    filter['Value.FrontEnd'] = frontend;
+  }
+  return dynamoHelper.getAllCrossAccount(filter).then(data => res.json(data)).catch(next);
+}
+
+/**
+ * GET /config/lb-settings/{environment}/{vHostName}
+ */
+function getLBSettingConfigByName(req, res, next) {
+  const key = req.swagger.params.environment.value;
+  const range = req.swagger.params.vHostName.value;
+  co(function* () {
+    let accountName = yield Environment.getAccountNameForEnvironment(key);
+    return dynamoHelper.getBySortKey(key, range, { accountName });
+  }).then(data => res.json(data)).catch(next);
+}
+
+/**
+ * POST /config/lb-settings
+ */
+function postLBSettingsConfig(req, res, next) {
+  const body = req.swagger.params.body.value;
+  const environmentName = body[PARTITION_KEY];
+  const vHostName = body[SORT_KEY];
+  const user = req.user;
+
+  co(function* () {
+    let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
+    return dynamoHelper.createWithSortKey(environmentName, vHostName, { Value: body.Value }, user, { accountName });
+  })
+    .then(() => res.status(201).end())
+    .then(sns.publish({
+      message: 'Post /config/lb-settings',
+      topic: sns.TOPICS.CONFIGURATION_CHANGE,
+      attributes: {
+        Action: sns.ACTIONS.POST,
+        ID: ''
+      }
+    }))
+    .catch(next);
+}
+
+/**
+ * PUT /config/lb-settings/{environment}/{vHostName}
+ */
+function putLBSettingConfigByName(req, res, next) {
+  const body = req.swagger.params.body.value;
+  const environmentName = req.swagger.params.environment.value;
+  const vHostName = req.swagger.params.vHostName.value;
+  const expectedVersion = req.swagger.params['expected-version'].value;
+  const user = req.user;
+
+  co(function* () {
+    let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
+    return dynamoHelper.updateWithSortKey(environmentName, vHostName, { Value: body }, expectedVersion, user, { accountName });
+  }).then(() => res.status(200).end()).catch(next);
+}
+
+/**
+ * DELETE /config/lb-settings/{environment}/{vHostName}
+ */
+function deleteLBSettingConfigByName(req, res, next) {
+  const environmentName = req.swagger.params.environment.value;
+  const vHostName = req.swagger.params.vHostName.value;
+  const user = req.user;
+
+  co(function* () {
+    let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
+    return dynamoHelper.deleteWithSortKey(environmentName, vHostName, user, { accountName });
+  }).then(() => res.status(200).end()).catch(next);
+}
+
+module.exports = {
+  getLBSettingsConfig,
+  getLBSettingConfigByName,
+  postLBSettingsConfig,
+  putLBSettingConfigByName,
+  deleteLBSettingConfigByName
+};

--- a/server/api/controllers/audit/auditController.js
+++ b/server/api/controllers/audit/auditController.js
@@ -38,10 +38,10 @@ function createAuditLogQuery(since, until, exclusiveStartKey, perPage, filter) {
 function createFilter(query) {
   logger.debug('Audit History: Creating filter.');
   let exprs = {
-    'Entity.Type': val => (val === 'ConfigLBUpstream'
+    'Entity.Type': val => (val === 'ConfigLBUpstream' || val === 'ConfigLBSettings'
       ? ['or',
-        ['=', ['attr', 'Entity', 'Type'], ['val', getTableName('ConfigLBUpstream')]],
-        ['=', ['attr', 'Entity', 'Type'], ['val', getTableName('InfraConfigLBUpstream')]]]
+        ['=', ['attr', 'Entity', 'Type'], ['val', getTableName(val)]],
+        ['=', ['attr', 'Entity', 'Type'], ['val', getTableName(`Infra${val}`)]]]
       : ['=', ['attr', 'Entity', 'Type'], ['val', getTableName(val)]]),
     'ChangeType': val => ['=', ['attr', 'ChangeType'], ['val', val]],
     'Entity.Key': val => ['=', ['attr', 'Entity', 'Key'], ['val', val]]

--- a/server/api/controllers/config/lb-settings/lbSettingsController.js
+++ b/server/api/controllers/config/lb-settings/lbSettingsController.js
@@ -2,97 +2,16 @@
 
 'use strict';
 
-const RESOURCE = 'config/lbsettings';
-const PARTITION_KEY = 'EnvironmentName';
-const SORT_KEY = 'VHostName';
+let {
+  getLBSettingsConfig,
+  getLBSettingConfigByName
+} = require('api/api-utils/lbSettingsControllerCrossAccount');
 
-let co = require('co');
-let dynamoHelper = new (require('api/api-utils/DynamoHelper'))(RESOURCE);
-let Environment = require('models/Environment');
-const sns = require('modules/sns/EnvironmentManagerEvents');
-
-/**
- * GET /config/lb-settings
- */
-function getLBSettingsConfig(req, res, next) {
-  const environmentName = req.swagger.params.environment.value;
-  const frontend = req.swagger.params.frontend.value;
-  let filter = {};
-  if (environmentName !== undefined) {
-    filter.EnvironmentName = environmentName;
-  }
-  if (frontend !== undefined) {
-    filter['Value.FrontEnd'] = frontend;
-  }
-  return dynamoHelper.getAllCrossAccount(filter).then(data => res.json(data)).catch(next);
-}
-
-/**
- * GET /config/lb-settings/{environment}/{vHostName}
- */
-function getLBSettingConfigByName(req, res, next) {
-  const key = req.swagger.params.environment.value;
-  const range = req.swagger.params.vHostName.value;
-  co(function* () {
-    let accountName = yield Environment.getAccountNameForEnvironment(key);
-    return dynamoHelper.getBySortKey(key, range, { accountName });
-  }).then(data => res.json(data)).catch(next);
-}
-
-/**
- * POST /config/lb-settings
- */
-function postLBSettingsConfig(req, res, next) {
-  const body = req.swagger.params.body.value;
-  const environmentName = body[PARTITION_KEY];
-  const vHostName = body[SORT_KEY];
-  const user = req.user;
-
-  co(function* () {
-    let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
-    return dynamoHelper.createWithSortKey(environmentName, vHostName, { Value: body.Value }, user, { accountName });
-  })
-    .then(() => res.status(201).end())
-    .then(sns.publish({
-      message: 'Post /config/lb-settings',
-      topic: sns.TOPICS.CONFIGURATION_CHANGE,
-      attributes: {
-        Action: sns.ACTIONS.POST,
-        ID: ''
-      }
-    }))
-    .catch(next);
-}
-
-/**
- * PUT /config/lb-settings/{environment}/{vHostName}
- */
-function putLBSettingConfigByName(req, res, next) {
-  const body = req.swagger.params.body.value;
-  const environmentName = req.swagger.params.environment.value;
-  const vHostName = req.swagger.params.vHostName.value;
-  const expectedVersion = req.swagger.params['expected-version'].value;
-  const user = req.user;
-
-  co(function* () {
-    let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
-    return dynamoHelper.updateWithSortKey(environmentName, vHostName, { Value: body }, expectedVersion, user, { accountName });
-  }).then(() => res.status(200).end()).catch(next);
-}
-
-/**
- * DELETE /config/lb-settings/{environment}/{vHostName}
- */
-function deleteLBSettingConfigByName(req, res, next) {
-  const environmentName = req.swagger.params.environment.value;
-  const vHostName = req.swagger.params.vHostName.value;
-  const user = req.user;
-
-  co(function* () {
-    let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
-    return dynamoHelper.deleteWithSortKey(environmentName, vHostName, user, { accountName });
-  }).then(() => res.status(200).end()).catch(next);
-}
+let {
+  deleteLBSettingConfigByName,
+  postLBSettingsConfig,
+  putLBSettingConfigByName
+} = require('api/api-utils/lbSettingsController');
 
 module.exports = {
   getLBSettingsConfig,

--- a/server/api/swagger.yaml
+++ b/server/api/swagger.yaml
@@ -1799,6 +1799,10 @@ paths:
         - name: frontend
           in: query
           required: false
+          type: boolean
+        - name: loadBalancerGroup
+          in: query
+          required: false
           type: string
       responses:
         200:

--- a/server/modules/data-access/lbSettingsAdapter.js
+++ b/server/modules/data-access/lbSettingsAdapter.js
@@ -1,0 +1,33 @@
+/* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
+
+'use strict';
+
+let { assign, omit } = require('lodash/fp');
+let environments = require('modules/data-access/configEnvironments');
+let environmentTypes = require('modules/data-access/configEnvironmentTypes');
+
+function getEnvironmentType(environmentName) {
+  let rejectIfNotFound = msg => obj => (obj !== null ? Promise.resolve(obj) : Promise.reject(new Error(msg)));
+  return environments.get({ EnvironmentName: environmentName })
+    .then(rejectIfNotFound(`Environment not found: ${environmentName}`))
+    .then(({ Value: { EnvironmentType } }) => environmentTypes.get({ EnvironmentType })
+      .then(rejectIfNotFound(`Environment Type not found: ${EnvironmentType}`)));
+}
+
+function convertToOldModel(model) {
+  return omit(['AccountId', 'LoadBalancerGroup'])(model);
+}
+
+function convertToNewModel(model) {
+  return Promise.resolve(model)
+  .then(({ EnvironmentName }) => getEnvironmentType(EnvironmentName))
+  .then(environmentType => assign({
+    AccountId: environmentType.Value.AWSAccountNumber,
+    LoadBalancerGroup: environmentType.EnvironmentType
+  })(model));
+}
+
+module.exports = {
+  convertToOldModel,
+  convertToNewModel
+};

--- a/server/modules/data-access/loadBalancerSettings.js
+++ b/server/modules/data-access/loadBalancerSettings.js
@@ -1,0 +1,11 @@
+/* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
+
+'use strict';
+
+const LOGICAL_TABLE_NAME = 'InfraConfigLBSettings';
+const TTL = 600; // seconds
+
+let { getTableName: physicalTableName } = require('modules/awsResourceNameProvider');
+let cachedSingleAccountDynamoTable = require('modules/data-access/cachedSingleAccountDynamoTable');
+
+module.exports = cachedSingleAccountDynamoTable(physicalTableName(LOGICAL_TABLE_NAME), { ttl: TTL });

--- a/setup/cloudformation/EnvironmentManagerLbSettings.template.yaml
+++ b/setup/cloudformation/EnvironmentManagerLbSettings.template.yaml
@@ -1,0 +1,113 @@
+AWSTemplateFormatVersion: "2010-09-09"
+# A template for a stack that contains an ElastiCache Redis Cluster.
+Description: Environment Manager Resources
+Parameters:
+  pExecutionRole:
+    Description: role to execute the Lambda function
+    Type: String
+  pCrossAccountRole:
+    Description: role to assume for cross-account writes
+    Type: String
+  pDestinationTable:
+    Description: destination table for cross-account writes
+    Type: String
+  pAlertSNSTopic:
+    Description: SNS Topic ARN for lambda alerts.
+    Type: String
+  pAuditLambdaFunction:
+    Description: the lambda function that audits upstream changes
+    Type: String
+  pResourcePrefix:
+    Description: optional resource name prefix
+    Type: String
+    Default: ""
+Resources:
+  tableInfraConfigLbSettings:
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: EnvironmentName
+          AttributeType: S
+        - AttributeName: LoadBalancerGroup
+          AttributeType: S
+        - AttributeName: VHostName
+          AttributeType: S
+      GlobalSecondaryIndexes:
+        - IndexName: LoadBalancerGroup-index
+          KeySchema:
+            - AttributeName: LoadBalancerGroup
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: 10
+            WriteCapacityUnits: 2
+      KeySchema:
+        - AttributeName: EnvironmentName
+          KeyType: HASH
+        - AttributeName: VHostName
+          KeyType: RANGE
+      ProvisionedThroughput:
+        ReadCapacityUnits: 10
+        WriteCapacityUnits: 2
+      StreamSpecification:
+        StreamViewType: NEW_AND_OLD_IMAGES
+      TableName: !Sub ${pResourcePrefix}InfraConfigLBSettings
+  lambdaInfraEnvironmentManagerLbSettingsRouter:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code: ./lambda/InfraEnvironmentManagerLbSettingsRouter/infra-environment-manager-lb-settings-router.zip
+      Description: This function routes load balancer settings records to the correct DynamoDB table in each child account.
+      Environment:
+        Variables:
+          DESTINATION_TABLE: !Ref pDestinationTable
+          ROLE_NAME: !Ref pCrossAccountRole
+      FunctionName: !Sub ${pResourcePrefix}InfraEnvironmentManagerLbSettingsRouter
+      Handler: index.handler
+      MemorySize: 128
+      Role: !Ref pExecutionRole
+      Runtime: nodejs6.10
+      Timeout: 10
+  alertInfraEnvironmentManagerLbSettingsRouter:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref pAlertSNSTopic
+      AlarmDescription: Error propagating load balancer settings change to the destination account
+      AlarmName: !Sub ${pResourcePrefix}alertInfraEnvironmentManagerLbSettingsRouter
+      ComparisonOperator: GreaterThanThreshold
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref lambdaInfraEnvironmentManagerLbSettingsRouter
+      Period: 60
+      Statistic: Sum
+      Threshold: 0
+  triggerInfraEnvironmentManagerLbSettingsRouter:
+    Type: "AWS::Lambda::EventSourceMapping"
+    Properties:
+      BatchSize: 5
+      Enabled: true
+      EventSourceArn: !GetAtt tableInfraConfigLbSettings.StreamArn
+      FunctionName: !Ref lambdaInfraEnvironmentManagerLbSettingsRouter
+      StartingPosition: LATEST
+  triggerAuditInfraConfigLbSettings:
+    Type: "AWS::Lambda::EventSourceMapping"
+    Properties:
+      BatchSize: 5
+      Enabled: true
+      EventSourceArn: !GetAtt tableInfraConfigLbSettings.StreamArn
+      FunctionName: !Ref pAuditLambdaFunction
+      StartingPosition: LATEST
+Outputs:
+  lambdaInfraEnvironmentManagerLbSettingsRouter:
+    Description: The load balancer settings router Lambda function
+    Value:
+      !GetAtt lambdaInfraEnvironmentManagerLbSettingsRouter.Arn
+  tableInfraConfigLbSettings:
+    Description: The load balancer settings table
+    Value:
+      !Ref tableInfraConfigLbSettings

--- a/setup/cloudformation/lambda/InfraEnvironmentManagerLbSettingsRouter/index.js
+++ b/setup/cloudformation/lambda/InfraEnvironmentManagerLbSettingsRouter/index.js
@@ -1,0 +1,135 @@
+'use strict';
+
+let AWS = require('aws-sdk');
+
+function show(x) {
+  return JSON.stringify(x);
+}
+
+function reduceSeq(fn, [x, ...xs], acc) {
+  return x === undefined
+    ? Promise.resolve(acc)
+    : Promise.resolve(acc)
+      .then(a => Promise.resolve(fn(a, x)))
+      .then(a => reduceSeq(fn, xs, a));
+}
+
+function mapSeq(fn, array) {
+  return reduceSeq((acc, nxt) => Promise.resolve(fn(nxt)).then(x => [...acc, x]), array, []);
+}
+
+function memoize(fn) {
+  let memo = new Map();
+  return (...args) => {
+    let key = JSON.stringify(args);
+    if (!memo.has(key)) {
+      let result = fn(...args);
+      memo.set(key, result);
+    }
+    return memo.get(key);
+  };
+}
+
+function convertToOldModel(item) {
+  return Object.assign({ readonly: { BOOL: true } }, item);
+}
+
+function parseFunctionArn(functionArn) {
+  let match = /^arn:aws:lambda:([^:]+):([^:]+):function:(.*)/.exec(functionArn);
+  if (match !== null && match.length > 1) {
+    return {
+      region: match[1],
+      accountId: match[2],
+      functionName: match[3]
+    };
+  }
+  throw new Error('Could not determine AWS account from context object.');
+}
+
+exports.convertToOldModel = convertToOldModel;
+exports.handler = (event, context, callback) => {
+
+  const DESTINATION_TABLE = process.env.DESTINATION_TABLE;
+  const ROLE_NAME = process.env.ROLE_NAME;
+
+  const {
+        accountId: myAccountId,
+        functionName
+    } = parseFunctionArn(context.invokedFunctionArn);
+
+  let getCredentialsForAccount = memoize((accountId) => {
+    if (accountId === myAccountId) {
+      return Promise.resolve({});
+    }
+    let sts = new AWS.STS();
+    let params = {
+      RoleArn: `arn:aws:iam::${accountId}:role/${ROLE_NAME}`,
+      RoleSessionName: functionName,
+      DurationSeconds: 900
+    };
+    return sts.assumeRole(params).promise().then(({ Credentials: { AccessKeyId, SecretAccessKey, SessionToken } }) =>
+      ({
+        credentials: new AWS.Credentials({
+          accessKeyId: AccessKeyId,
+          secretAccessKey: SecretAccessKey,
+          sessionToken: SessionToken
+        })
+      }));
+  });
+
+  function deleteRecord(record) {
+    console.log(`DELETE ${show(record.dynamodb.Keys)}`);
+    return Promise.resolve()
+      .then(() => getCredentialsForAccount(record.dynamodb.OldImage.AccountId.S))
+      .then(credentials => new AWS.DynamoDB(credentials))
+      .then(dynamo => {
+        let params = {
+          Key: {
+            key: record.dynamodb.Keys.Key
+          },
+          TableName: DESTINATION_TABLE
+        }
+        return dynamo.deleteItem(params).promise()
+      })
+      .catch(error => { console.error(`Error deleting record: ${record}`); return Promise.reject(error); });
+  }
+
+  function putRecord(record) {
+    console.log(`PUT ${show(record.dynamodb.Keys)}`);
+    return Promise.resolve()
+      .then(() => getCredentialsForAccount(record.dynamodb.NewImage.AccountId.S))
+      .then(credentials => new AWS.DynamoDB(credentials))
+      .then(dynamo => dynamo.putItem({
+        Item: convertToOldModel(record.dynamodb.NewImage),
+        TableName: DESTINATION_TABLE,
+        ConditionExpression: '#Audit.#Version < :version or attribute_not_exists(#hashKey)',
+        ExpressionAttributeNames: {
+          '#Audit': 'Audit',
+          '#hashKey': 'EnvironmentName',
+          '#Version': 'Version'
+        },
+        ExpressionAttributeValues: {
+          ':version': record.dynamodb.NewImage.Audit.M.Version
+        }
+      }).promise().catch(error => (error.code === 'ConditionalCheckFailedException' ? Promise.resolve() : Promise.reject(error))))
+      .catch(error => { console.error(`Error putting record: ${record}`); return Promise.reject(error); });
+  }
+
+  function processRecord(record) {
+    let { eventName } = record;
+    switch (eventName) {
+      case 'INSERT':
+      case 'MODIFY':
+        return putRecord(record).then(() => ({ PUT: record.dynamodb.Keys }));
+      case 'REMOVE':
+        return deleteRecord(record).then(() => ({ DELETE: record.dynamodb.Keys }));
+      default:
+        return Promise.reject(`Unsupported eventName: ${eventName}`);
+    }
+  }
+
+  Promise.resolve()
+    .then(mapSeq(processRecord, event.Records))
+    .then(data => callback(null, data))
+    .catch(error => callback(error));
+};

--- a/setup/cloudformation/lambda/InfraEnvironmentManagerLbSettingsRouter/package.json
+++ b/setup/cloudformation/lambda/InfraEnvironmentManagerLbSettingsRouter/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "infra-environment-manager-lb-settings-router",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "author": "",
+  "license": "ISC",
+  "dependencies": {},
+  "scripts": {
+    "build-aws-resource": "pack-zip",
+    "lint": "eslint",
+    "test": "mocha **/*.spec.js"
+  },
+  "eslintConfig": {
+    "env": {
+      "es6": true,
+      "node": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+      "ecmaVersion": 6
+    },
+    "rules": {
+      "no-console": 0
+    }
+  },
+  "devDependencies": {
+    "eslint": "^3.4.0",
+    "mocha": "^3.3.0",
+    "mocha-testcheck": "^1.0.0-rc.0",
+    "pack-zip": "^0.2.2",
+    "proxyquire": "^1.7.11",
+    "should": "^11.2.1"
+  }
+}


### PR DESCRIPTION
Environment Manager currently writes each load balancer settings record to a DynamoDB table named _ConfigLBSettings_ one of the child accounts. The account to which the record is written is derived from the environment to which the load balancer settings record is linked.

This pull request modifies Environment Manager to **write** all load balancer settings records to a single DynamoDB table _InfraConfigLBSettings_. The DynamoDB stream from this table is processed by a Lambda function that writes each record to the _ConfigLBSettings_ table in the appropriate child account. Environment Manager still **reads** load balancer settings records from the existing _ConfigLBSettings_ tables.

- Each record replicated from the _InfraConfigLBSettings_ table to one of the _ConfigLBSettings_ tables is tagged with the attribute { readonly: true }. This will be used to exclude these records when migrating data from the _ConfigLBSettings_ tables to the _InfraConfigLBSettings_ table.

- Environment Manager will be updated to read from the _InfraConfigLBSettings_  table when all of the load balancer settings records are migrated from the _ConfigLBSettings_ tables to the _InfraConfigLBSettings_ table. The _InfraConfigLBSettings_ table is indexed to allow Environment Manager to execute the queries it currently executes against the _ConfigLBSettings_ tables against _InfraConfigLBSettings_.

https://jira.thetrainline.com/browse/PD-242