### PR TITLE
Multi-value query support for load balancer upstreams and settings

### DIFF
--- a/client/app/common/models/UpstreamConfig.js
+++ b/client/app/common/models/UpstreamConfig.js
@@ -27,7 +27,7 @@ angular.module('EnvironmentManager.common').factory('UpstreamConfig',
     };
 
     UpstreamConfig.getForEnvironment = function (environment) {
-      return $http.get(baseUrl + '?environment=' + environment).then(function (response) {
+      return $http.get(baseUrl + '?qa=environment&qv=' + environment).then(function (response) {
         return response.data;
       });
     };

--- a/client/app/configuration/load-balancers/LBsController.js
+++ b/client/app/configuration/load-balancers/LBsController.js
@@ -62,7 +62,8 @@ angular.module('EnvironmentManager.configuration').controller('LBsController',
         var params = {
           account: accountName,
           query: {
-            environment: $scope.SelectedEnvironment
+            qa: 'environment',
+            qv: $scope.SelectedEnvironment
           }
         };
 

--- a/server/api/swagger.yaml
+++ b/server/api/swagger.yaml
@@ -1800,10 +1800,20 @@ paths:
           in: query
           required: false
           type: boolean
-        - name: loadBalancerGroup
+        - name: qa
+          description: query attribute
+          in: query
+          type: string
+          enum:
+            - environment
+            - load-balancer-group
+        - name: qv
+          description: query value list
           in: query
           required: false
-          type: string
+          type: array
+          items:
+            type: string
       responses:
         200:
           description: The list of load balancer settings
@@ -2073,30 +2083,20 @@ paths:
       tags:
         - Upstream
       parameters:
-        - name: environment
-          in: query
-          type: string
-        - name: loadBalancerGroup
-          in: query
-          type: string
-        - name: exclusiveStartKey
-          in: query
-          type: string
-        - name: per_page
-          in: query
-          type: integer
-        - name: sort
+        - name: qa
+          description: query attribute
           in: query
           type: string
           enum:
-            - asc
-            - ASC
-            - ascending
-            - ASCENDING
-            - desc
-            - DESC
-            - descending
-            - DESCENDING
+            - environment
+            - load-balancer-group
+        - name: qv
+          description: query value list
+          in: query
+          required: false
+          type: array
+          items:
+            type: string
       responses:
         200:
           description: The list of upstream configs


### PR DESCRIPTION
This PR adds support for querying `/config/upstreams` and `/config/lb-settings` such that the environment or load balancer group is in a set of values.

Example:
Get those upstreams where the environment attribute of the upstream is in { uat, test, prod }
`GET /config/upstreams?qa=environment&qv=uat,test,prod`