### PR TITLE
Default keepalive to 32 for all new upstreams

### DIFF
--- a/client/app/configuration/lbupstreams/lbupstream.html
+++ b/client/app/configuration/lbupstreams/lbupstream.html
@@ -95,6 +95,7 @@
       step="1"
       name="UpStreamKeepalives"
       class="form-control"
+      disabled
       ng-model="vm.upstream.Value.UpStreamKeepalives"
       ng-readonly="vm.view.configFieldsDisabled" />
   </div>

--- a/client/app/configuration/lbupstreams/upstreamViewModel.js
+++ b/client/app/configuration/lbupstreams/upstreamViewModel.js
@@ -5,6 +5,7 @@
 angular.module('EnvironmentManager.configuration').factory('UpstreamViewModel', function () {
   var defaultHostTemplate = { DnsName: '', Port: null, FailTimeout: '30s', MaxFails: null, State: 'down', Weight: 1 };
 
+
   function UpstreamViewModel(params) {
     var self = this;
 
@@ -46,6 +47,9 @@ angular.module('EnvironmentManager.configuration').factory('UpstreamViewModel', 
       self.configFieldsEnabled = hasPermissionsToEdit;
       self.configFieldsDisabled = !self.configFieldsEnabled;
 
+      if (isNewMode) {
+        upstream.Value.UpStreamKeepalives = 32; // All new upstreams should have a keep alive value of 32
+      }
       self.showForm = true;
     };
 


### PR DESCRIPTION
Upstreams are often being created with empty or invalid keep alive values. This fixes that.