### PR TITLE
Toggle without scanning the upstreams DynamoDB table

### DIFF
--- a/server/commands/slices/ToggleSlicesByUpstream.js
+++ b/server/commands/slices/ToggleSlicesByUpstream.js
@@ -3,11 +3,12 @@
 'use strict';
 
 let assert = require('assert');
-let toggleSlices = require('../utils/toggleSlices');
-let UpstreamProvider = toggleSlices.UpstreamProvider;
-let ToggleUpstreamByNameVerifier = toggleSlices.ToggleUpstreamByNameVerifier;
-let UpstreamToggler = toggleSlices.UpstreamToggler;
-let orchestrate = toggleSlices.orchestrate;
+let {
+  orchestrate,
+  ToggleUpstreamByNameVerifier,
+  UpstreamProvider,
+  UpstreamToggler
+ } = require('../utils/toggleSlices');
 let sender = require('modules/sender');
 let Environment = require('models/Environment');
 
@@ -19,9 +20,9 @@ module.exports = function ToggleSlicesByUpstream(command) {
     command.accountName = account;
 
     let resourceName = `Upstream named "${command.upstreamName}" in "${command.environmentName}" environment`;
-    let provider = new UpstreamProvider(sender, command, resourceName);
-    let verifier = new ToggleUpstreamByNameVerifier(resourceName);
-    let toggler = new UpstreamToggler(sender, command);
+    let provider = UpstreamProvider(sender, command, resourceName);
+    let verifier = ToggleUpstreamByNameVerifier(resourceName);
+    let toggler = UpstreamToggler(sender, command);
 
     return orchestrate(provider, verifier, toggler);
   });

--- a/server/modules/awsDynamo/dynamodbExpression.js
+++ b/server/modules/awsDynamo/dynamodbExpression.js
@@ -2,7 +2,6 @@
 
 function expressionScope() {
   let valName = i => `:val${i}`;
-  let qname = name => `#${name}`;
   let expressionAttributeValues = {};
   let expressionAttributeNames = {};
   let i = 0;
@@ -14,10 +13,15 @@ function expressionScope() {
     return t;
   }
 
-  function nameExpressionAttributeName(name) {
-    let t = qname(name);
-    expressionAttributeNames[t] = name;
-    return t;
+  function nameExpressionAttributeName(result, name) {
+    if (typeof name === 'number') {
+      let elt = `[${name}]`;
+      return result === null ? elt : `${result}${elt}`;
+    } else {
+      let elt = `#${name}`;
+      expressionAttributeNames[elt] = name;
+      return result === null ? elt : `${result}.${elt}`;
+    }
   }
 
   return {
@@ -35,7 +39,7 @@ function compileOne(scope, expr) {
     return args.length === 1 ? compiled : `(${compiled})`;
   };
   let prefix = ([fn, ...args]) => `${fn}(${args.map(compile).join(', ')})`;
-  let attr = ([, ...exprs]) => exprs.map(name => scope.nameExpressionAttributeName(name)).join('.');
+  let attr = ([, ...exprs]) => exprs.reduce(scope.nameExpressionAttributeName, null);
   let val = ([, ...exprs]) => exprs.map(value => scope.nameExpressionAttributeValue(value)).join(', ');
   let list = ([, sep, ...items]) => `${items.map(compile).join(sep)}`;
   let update = ([, ...args]) => {

--- a/server/test/modules/awsDynamo/dynamodbExpressionTest.js
+++ b/server/test/modules/awsDynamo/dynamodbExpressionTest.js
@@ -168,6 +168,19 @@ describe('dynamodb expression', function () {
         result.Expression.should.eql('(#a.#b = :val0)');
       });
     });
+    context('when I compile an attribute expression with an index number', function () {
+      let input = ['at', 'array', 0, 'itemprop'];
+      let result = sut.compile(input);
+      it('the expression contains an index number in square brackets', function () {
+        result.Expression.should.eql('#array[0].#itemprop');
+      });
+      it('the index is not treated as an expression attribute name', function () {
+        result.ExpressionAttributeNames.should.eql({
+          '#array': 'array',
+          '#itemprop': 'itemprop'
+        });
+      });
+    });
   });
 });
 


### PR DESCRIPTION
### List indices are now supported in DynamoDB attribute paths
See commit b0bf30e
```
['at', 'MyList', 4, 'ItemAttribute']
```
is compiled to
```
#MyList[4].#ItemAttribute
```

### Toggling an upstream no longer scans all upstreams
See commit 6587a88

Toggling an upstream now uses a query operation over a global secondary index to read the set of upstreams to toggle, followed by one update operation per upstream that sets the state of each slice, the version and the audit metadata.

Each update is conditional on the slice state not having changed since the upstream was read.