### PR TITLE
Use data access modules to read and write load balancer config

### DIFF
--- a/server/modules/authorizers/upstreams.js
+++ b/server/modules/authorizers/upstreams.js
@@ -4,20 +4,12 @@
 
 let co = require('co');
 let configEnvironments = require('modules/data-access/configEnvironments');
+let loadBalancerUpstreams = require('modules/data-access/loadBalancerUpstreams');
 let Environment = require('models/Environment');
 let logger = require('modules/logger');
 
-function getUpstream(accountName, upstreamName) {
-  let sender = require('modules/sender');
-
-  let query = {
-    name: 'GetDynamoResource',
-    key: upstreamName,
-    resource: 'config/lbupstream',
-    accountName
-  };
-
-  return sender.sendQuery({ query });
+function getUpstream(upstreamName) {
+  return loadBalancerUpstreams.get({ Key: upstreamName });
 }
 
 function getEnvironment(name) {
@@ -36,10 +28,10 @@ function getEnvironmentPermissionsPromise(upstreamName, environmentName, account
     return getModifyPermissionsForEnvironment(environmentName);
   }
 
-  return getUpstream(accountName, upstreamName)
+  return getUpstream(upstreamName)
     .then((upstream) => {
       if (upstream) {
-        let envName = upstream.Value.EnvironmentName;
+        let envName = upstream.Environment;
         return getModifyPermissionsForEnvironment(envName);
       }
 

--- a/server/queryHandlers/slices/GetSlicesByService.js
+++ b/server/queryHandlers/slices/GetSlicesByService.js
@@ -4,19 +4,12 @@
 
 let assert = require('assert');
 let getSlices = require('modules/queryHandlersUtil/getSlices');
-let getAccountByEnvironment = require('commands/aws/GetAccountByEnvironment');
-
-const FILTER = getSlices.FILTER;
-const QUERYING = getSlices.QUERYING;
+let loadBalancerUpstreams = require('modules/data-access/loadBalancerUpstreams');
 
 module.exports = function GetSlicesByService(query) {
   assert.equal(typeof query.environmentName, 'string');
   assert.equal(typeof query.serviceName, 'string');
 
-  return getAccountByEnvironment({ environment: query.environmentName }).then((account) => {
-    query.accountName = account;
-    return getSlices.handleQuery(query,
-      QUERYING.upstream.byServiceName(query),
-      FILTER.upstream.byServiceName(query));
-  });
+  return loadBalancerUpstreams.inEnvironmentWithService(query.environmentName, query.serviceName)
+    .then(upstreams => getSlices.handleQuery(query, upstreams));
 };


### PR DESCRIPTION
This change replaces reads and writes of the load balancer upstream table and the load balancer settings table that currently use the `sender` with the `loadBalancerSettings` and `loadBalancerUpstreams` data access modules.

These changes reduce DynamoDB read capacity usage by replacing scan operations with query operations.

Pre _v1_ API endpoints should be unaffected by this change.