### PR TITLE
Direct users from upstream editor to toggle

### DIFF
--- a/client/app/configuration/lbupstreams/lbupstream.html
+++ b/client/app/configuration/lbupstreams/lbupstream.html
@@ -118,7 +118,13 @@
 <div class="form-group" style="margin-bottom: 0px;">
   <label class="col-md-1 control-label text-left">Hosts:</label>
   <div class="col-md-8">
-
+  <div style="text-align:center;" ng-if="vm.view.showToggleLink()">
+    <span  class="warning">
+      Changes made on this page require elevated permissions!
+      <p>
+      Just want to <strong>toggle</strong>? You can <strong><a ng-href="{{vm.view.toggleLink()}}" target="">toggle here</a></strong>.
+    </span>
+  </div>
     <table id="UpstreamHosts" class="table table-responsive">
       <thead>
         <tr>
@@ -297,7 +303,6 @@
   <label class="col-md-1">&nbsp;</label>
   <div class="col-md-5">
     <button type="button" class="btn btn-default" ng-click="vm.backToSummary()">Cancel</button>
-    <button type="button" class="btn btn-default" ng-if="vm.view.configFieldsEnabled" ng-disabled="vm.view.toggleActiveHostsButtonIsDisabled()" ng-click="vm.view.toggleActiveHosts()">Toggle Active Hosts</button>
     <button type="button" class="btn btn-default" ng-if="vm.view.configFieldsEnabled" ng-disabled="!form.$valid" ng-click="vm.save()">Save</button>
   </div>
 </div>

--- a/client/app/configuration/lbupstreams/upstreamViewModel.js
+++ b/client/app/configuration/lbupstreams/upstreamViewModel.js
@@ -89,14 +89,14 @@ angular.module('EnvironmentManager.configuration').factory('UpstreamViewModel', 
       return '/#/config/services/' + service.ServiceName + '/?Range=' + service.OwningCluster;
     };
 
-    self.toggleActiveHostsButtonIsDisabled = function () {
-      return upstream.Value.Hosts.length === 0;
+    self.showToggleLink = function () {
+      if (!upstream) return false;
+      return !!(isEditMode && upstream.Value.EnvironmentName && upstream.Value.ServiceName);
     };
 
-    self.toggleActiveHosts = function () {
-      upstream.Value.Hosts.forEach(function (host) {
-        host.State = host.State === 'up' ? 'down' : 'up';
-      });
+    self.toggleLink = function () {
+      if (!upstream) return null;
+      return '/#/operations/upstreams?environment=' + upstream.Value.EnvironmentName + '&state=All&service=' + upstream.Value.ServiceName;
     };
 
     self.showValidationError = function (msg) {

--- a/client/app/configuration/lbupstreams/upstreamViewModel.spec.js
+++ b/client/app/configuration/lbupstreams/upstreamViewModel.spec.js
@@ -134,6 +134,34 @@ describe('UpstreamViewModel', function () {
     expect(vm.serviceLink()).toEqual('/#/config/services/s2/?Range=c2');
   });
 
+  it('Should hide the toggle link when copying an upstream', function () {
+    var vm = createUpstreamViewModel({ mode: 'Copy' });
+    expect(vm.showToggleLink()).toBe(false);
+  });
+
+  it('Should hide the toggle link when creating an upstream', function () {
+    var vm = createUpstreamViewModel({ mode: 'New' });
+    expect(vm.showToggleLink()).toBe(false);
+  });
+
+  it('Should show the toggle link when editing an upstream that has an environment and service', function () {
+    var vm = createUpstreamViewModel({ mode: 'Edit' });
+    var testUpstream = createSimpleTestUpstream();
+    init(vm, { upstream: testUpstream });
+    testUpstream.Value.EnvironmentName = 'e01';
+    testUpstream.Value.ServiceName = 'mysvc';
+    expect(vm.showToggleLink()).toBe(true);
+  });
+
+  it('Should show the correct toggle link when a service is selected', function () {
+    var vm = createUpstreamViewModel();
+    var testUpstream = createSimpleTestUpstream();
+    init(vm, { upstream: testUpstream });
+    testUpstream.Value.EnvironmentName = 'e01';
+    testUpstream.Value.ServiceName = 'mysvc';
+    expect(vm.toggleLink()).toEqual('/#/operations/upstreams?environment=e01&state=All&service=mysvc');
+  });
+
   it('Should show new host line when creating a new Upstream', function () {
     var vm = createUpstreamViewModel({ mode: 'New' });
     expect(vm.newHost).toEqual(defaultHost);
@@ -226,38 +254,6 @@ describe('UpstreamViewModel', function () {
     var vm = createUpstreamViewModel();
     vm.showValidationError('Something not right');
     expect(vm.validationError).toBe('Something not right');
-  });
-
-  it('Should disable the "toggle active hosts" button if the number of hosts is zero', function () {
-    var vm = createAndInitUpstreamViewModel();
-    expect(vm.toggleActiveHostsButtonIsDisabled()).toBe(true);
-  });
-
-  it('Should not disable the "toggle active hosts" button if the number of hosts is greater than zero', function () {
-    var vm = createUpstreamViewModel();
-    var testUpstream = createSimpleTestUpstream();
-    init(vm, { upstream: testUpstream });
-
-    testUpstream.Value.Hosts.push({ DnsName: 'blah', State: 'up' });
-
-    expect(vm.toggleActiveHostsButtonIsDisabled()).toBe(false);
-  });
-
-  it('Should toggle hosts when the "toggle active hosts" button is pressed', function () {
-    var vm = createUpstreamViewModel();
-    var testUpstream = createSimpleTestUpstream();
-    init(vm, { upstream: testUpstream });
-
-    testUpstream.Value.Hosts.push({ State: 'up' });
-    testUpstream.Value.Hosts.push({ State: 'down' });
-
-    expect(testUpstream.Value.Hosts[0].State).toBe('up');
-    expect(testUpstream.Value.Hosts[1].State).toBe('down');
-
-    vm.toggleActiveHosts();
-
-    expect(testUpstream.Value.Hosts[0].State).toBe('down');
-    expect(testUpstream.Value.Hosts[1].State).toBe('up');
   });
 
   function createAndInitUpstreamViewModel() {


### PR DESCRIPTION
A warning is displayed when a user opens an upstream in the upstream configuration editor, suggesting that if they only want to toggle slices they can use the upstream operations page instead.

There is no longer a _Toggle Active Hosts_ button on the upstream configuration editor, which makes it less tempting to try and do so.

https://jira.thetrainline.com/browse/PD-208

![image](https://cloud.githubusercontent.com/assets/3935360/26362282/61ab6e90-3fd5-11e7-9c8e-8dab7b29461b.png)

