### PR TITLE
Write port numbers to Consul KV store as numbers

### DIFF
--- a/server/test/queryHandlers/GetServicePortTest.js
+++ b/server/test/queryHandlers/GetServicePortTest.js
@@ -9,7 +9,8 @@ let assert = require('assert');
 describe('GetServicePortConfig', function() {
   let sut;
   let Service;
-  const DEFAULT = { green:0, blue:0 };
+  const DEFAULT_PORT = 0;
+  const DEFAULT = { green:DEFAULT_PORT, blue:DEFAULT_PORT };
 
   function setup(service) {
     Service = {
@@ -52,7 +53,7 @@ describe('GetServicePortConfig', function() {
 
   it('sets default blue port when only green port is known', () => {
     const GREEN = 7825;
-    const EXPECTED = { blue:0, green:GREEN };
+    const EXPECTED = { blue:DEFAULT_PORT, green:GREEN };
     setup(mockService(undefined, GREEN));
     return sut('serviceName').then(result => {
       return assert.deepEqual(result, EXPECTED);
@@ -61,7 +62,7 @@ describe('GetServicePortConfig', function() {
 
   it('sets default green port when only blue port is known', () => {
     const BLUE = 1105;
-    const EXPECTED = { blue:BLUE, green:0 };
+    const EXPECTED = { blue:BLUE, green:DEFAULT_PORT };
     setup(mockService(BLUE, undefined));
     return sut('serviceName').then(result => {
       return assert.deepEqual(result, EXPECTED);
@@ -72,6 +73,24 @@ describe('GetServicePortConfig', function() {
     setup(undefined);
     return sut('serviceName').then(result => {
       return assert.deepEqual(result, DEFAULT);
+    });
+  });
+
+  it('converts the port number to an integer if possible', () => {
+    const BLUE = '9134';
+    const EXPECTED = { blue: 9134, green: DEFAULT_PORT };
+    setup(mockService(BLUE, undefined));
+    return sut('serviceName').then(result => {
+      return assert.deepEqual(result, EXPECTED);
+    });
+  });
+
+  it('assigns the default port number if the port number cannot be converted to an integer', () => {
+    const BLUE = '913.4';
+    const EXPECTED = { blue: DEFAULT_PORT, green: DEFAULT_PORT };
+    setup(mockService(BLUE, undefined));
+    return sut('serviceName').then(result => {
+      return assert.deepEqual(result, EXPECTED);
     });
   });
 });


### PR DESCRIPTION
Writing port numbers to the Consul KV store as strings causes service registration to fail because the Consul HTTP API only accepts values of type _number_ for port numbers.

If a service specifies it's port numbers as strings and they can be parsed as integers this change will ensure they are written to the Consul KV store as numbers.

https://jira.thetrainline.com/projects/PLATFORM/queues/issue/PLATFORM-5150