### PR TITLE
Query the permissions DynamoDB table instead of scanning

### DIFF
--- a/server/api/controllers/config/permissions/permissionsController.js
+++ b/server/api/controllers/config/permissions/permissionsController.js
@@ -2,41 +2,66 @@
 
 'use strict';
 
-const RESOURCE = 'config/permissions';
-let dynamoHelper = new (require('api/api-utils/DynamoHelper'))(RESOURCE);
+const KEY_NAME = 'Name';
+
+let permissions = require('modules/data-access/permissions');
+let getMetadataForDynamoAudit = require('api/api-utils/requestMetadata').getMetadataForDynamoAudit;
+let param = require('api/api-utils/requestParam');
+let versionOf = require('modules/data-access/dynamoVersion').versionOf;
+let removeAuditMetadata = require('modules/data-access/dynamoAudit').removeAuditMetadata;
 const sns = require('modules/sns/EnvironmentManagerEvents');
+let { hasValue, when } = require('modules/functional');
+let { ifNotFound, notFoundMessage } = require('api/api-utils/ifNotFound');
+
+function keyOf(value) {
+  let t = {};
+  t[KEY_NAME] = value;
+  return t;
+}
+
+function convertToApiModel(persistedModel) {
+  let apiModel = removeAuditMetadata(persistedModel);
+  let Version = versionOf(persistedModel);
+  return Object.assign(apiModel, { Version });
+}
 
 /**
  * GET /config/permissions
  */
 function getPermissionsConfig(req, res, next) {
-  return dynamoHelper.getAll().then(data => res.json(data)).catch(next);
+  return permissions.scan()
+    .then(data => data.map(convertToApiModel))
+    .then(data => res.json(data)).catch(next);
 }
 
 /**
  * GET /config/permissions/{name}
  */
 function getPermissionConfigByName(req, res, next) {
-  let key = req.swagger.params.name.value;
-  return dynamoHelper.getByKey(key).then(data => res.json(data)).catch(next);
+  const key = param('name', req);
+  return permissions.get(keyOf(key))
+    .then(when(hasValue, convertToApiModel))
+    .then(ifNotFound(notFoundMessage('cluster')))
+    .then(send => send(res))
+    .catch(next);
 }
 
 /**
  * POST /config/permissions
  */
 function postPermissionsConfig(req, res, next) {
-  let body = req.swagger.params.body.value;
-  let user = req.user;
-  let key = body.Name;
-
-  return dynamoHelper.create(key, { Permissions: body.Permissions }, user)
-    .then(data => res.json(data))
+  const body = param('body', req);
+  let metadata = getMetadataForDynamoAudit(req);
+  let record = Object.assign({}, body);
+  delete record.Version;
+  return permissions.create({ record, metadata })
+    .then(() => res.status(201).end())
     .then(sns.publish({
       message: 'Post /config/permissions',
       topic: sns.TOPICS.CONFIGURATION_CHANGE,
       attributes: {
         Action: sns.ACTIONS.POST,
-        ID: ''
+        ID: body.Name
       }
     }))
     .catch(next);
@@ -46,13 +71,16 @@ function postPermissionsConfig(req, res, next) {
  * PUT /config/permissions/{name}
  */
 function putPermissionConfigByName(req, res, next) {
-  let body = req.swagger.params.body.value;
-  let key = req.swagger.params.name.value;
-  let expectedVersion = req.swagger.params['expected-version'].value;
-  let user = req.user;
+  const key = param('name', req);
+  const expectedVersion = param('expected-version', req);
+  const body = param('body', req);
 
-  return dynamoHelper.update(key, { Permissions: body }, expectedVersion, user)
-    .then(data => res.json(data))
+  let metadata = getMetadataForDynamoAudit(req);
+  let record = Object.assign(keyOf(key), { Permissions: body });
+  delete record.Version;
+
+  return permissions.replace({ record, metadata }, expectedVersion)
+    .then(() => res.status(200).end())
     .then(sns.publish({
       message: `Put /config/permissions/${key}`,
       topic: sns.TOPICS.CONFIGURATION_CHANGE,
@@ -68,16 +96,20 @@ function putPermissionConfigByName(req, res, next) {
  * DELETE /config/permissions/{name}
  */
 function deletePermissionConfigByName(req, res, next) {
-  let key = req.swagger.params.name.value;
-  let user = req.user;
-  return dynamoHelper.delete(key, user)
-    .then(data => res.json(data))
+  const name = param('name', req);
+  const expectedVersion = param('expected-version', req);
+
+  let key = keyOf(name);
+  let metadata = getMetadataForDynamoAudit(req);
+
+  return permissions.delete({ key, metadata }, expectedVersion)
+    .then(() => res.status(200).end())
     .then(sns.publish({
       message: `Put /config/permissions/${key}`,
       topic: sns.TOPICS.CONFIGURATION_CHANGE,
       attributes: {
         Action: sns.ACTIONS.DELETE,
-        ID: key
+        ID: name
       }
     }))
     .catch(next);

--- a/server/modules/data-access/permissions.js
+++ b/server/modules/data-access/permissions.js
@@ -1,0 +1,11 @@
+/* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
+
+'use strict';
+
+const LOGICAL_TABLE_NAME = 'InfraConfigPermissions';
+const TTL = 600; // seconds
+
+let physicalTableName = require('modules/awsResourceNameProvider').getTableName;
+let cachedSingleAccountDynamoTable = require('modules/data-access/cachedSingleAccountDynamoTable');
+
+module.exports = cachedSingleAccountDynamoTable(physicalTableName(LOGICAL_TABLE_NAME), { ttl: TTL });

--- a/server/modules/userRolesProvider.js
+++ b/server/modules/userRolesProvider.js
@@ -3,8 +3,7 @@
 'use strict';
 
 let _ = require('lodash');
-let awsAccounts = require('modules/awsAccounts');
-let sender = require('modules/sender');
+let permissionsDb = require('modules/data-access/permissions');
 
 module.exports = function UserRolesProvider() {
   this.getPermissionsFor = (names) => {
@@ -55,16 +54,7 @@ module.exports = function UserRolesProvider() {
   };
 
   let getPermissions = function (name) {
-    return awsAccounts.getMasterAccountName()
-      .then((masterAccountName) => {
-        let query = {
-          accountName: masterAccountName,
-          name: 'ScanDynamoResources',
-          resource: 'config/permissions',
-          filter: { Name: name }
-        };
-
-        return sender.sendQuery({ query });
-      });
+    return permissionsDb.get({ Name: name })
+      .then(result => (result === null ? [] : [result]));
   };
 };


### PR DESCRIPTION
This change introduces a data access module for permissions and uses it to replace a filtered _scan_ operation in `server/modules/userRolesProvider.js` with a _get_ operation.

https://jira.thetrainline.com/browse/PD-303