### PR TITLE
Remove cross-account operations from audit Lambda Function

### DIFF
--- a/setup/cloudformation/lambda/InfraEnvironmentManagerAudit/package.json
+++ b/setup/cloudformation/lambda/InfraEnvironmentManagerAudit/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "dependencies": {},
   "scripts": {
     "build-aws-resource": "pack-zip",


### PR DESCRIPTION
All DynamoDB tables are owned by the same account in which this Lambda Function runs, so there is no longer a need for cross-account writes.

https://jira.thetrainline.com/browse/PD-301