### PR TITLE
Fix for issue 277

### DIFF
--- a/server/modules/provisioning/launchConfiguration/securityGroupsProvider.js
+++ b/server/modules/provisioning/launchConfiguration/securityGroupsProvider.js
@@ -41,24 +41,15 @@ module.exports = {
 };
 
 function getAndVerifyAllExpectedSecurityGroups(securityGroups, vpcId, securityGroupNamesAndReasonsMapping, logger) {
-  let atLeastOneFound = false;
   for (let securityGroupName in securityGroupNamesAndReasonsMapping) {
     if ({}.hasOwnProperty.call(securityGroupNamesAndReasonsMapping, securityGroupName)) {
       let found = _.find(securityGroups, sg => sg.getName() === securityGroupName);
       if (found === undefined) {
-        logger.warn(`Security group "${securityGroupName}" not found in "${vpcId}" VPC. ${
+        throw new Error(`Security group "${securityGroupName}" not found in "${vpcId}" VPC. ${
           securityGroupNamesAndReasonsMapping[securityGroupName]}`
         );
-      } else {
-        atLeastOneFound = true;
       }
     }
-  }
-
-  if (atLeastOneFound === false) {
-    let errorMessage = 'You need at least 1 SecurityGroup to start an ASG';
-    logger.error(errorMessage);
-    throw new Error(errorMessage);
   }
 
   return securityGroups;

--- a/server/test/modules/provisioning/launchConfiguration/SecurityGroupsProviderTest.js
+++ b/server/test/modules/provisioning/launchConfiguration/SecurityGroupsProviderTest.js
@@ -223,7 +223,7 @@ describe('SecurityGroupsProvider:', () => {
             () => should.ok(false, 'Promise should fail'),
             error =>
             error.name.should.be.equal('Error') &&
-            error.toString().should.be.containEql('You need at least 1 SecurityGroup to start an ASG')
+            error.toString().should.be.containEql('Error: Security group "sgRoleTangoWeb" not found in "vpc-id" VPC. It is assigned by default given server role and cluster. It can be overwritten by specifying one or more security groups in the server role configuration.')
           );
 
         });


### PR DESCRIPTION
When a new Launch Configuration is being created from a deployment map with an invalid security group, we used to log a warning and continue. This only ever causes problems so this change makes the deployment fail and alert the user to the problem.