### PR TITLE
Rename user-visible instances of "cluster" to "team"

### DIFF
--- a/client/app/common/launch-config/launch-config.html
+++ b/client/app/common/launch-config/launch-config.html
@@ -119,7 +119,7 @@
     <label class="col-md-2 control-label text-left">EC2 Key Pair:</label>
     <div class="col-md-8">
       <label class="control-label text-left nonbold inline">
-        <input type="radio" ng-model="vm.target.ASG.LaunchConfig.UI_UseSpecificKey" ng-value="false" ng-disabled="!vm.canUser('edit')"> Use Owning Cluster's Key (recommended)
+        <input type="radio" ng-model="vm.target.ASG.LaunchConfig.UI_UseSpecificKey" ng-value="false" ng-disabled="!vm.canUser('edit')"> Use Owning Team's Key (recommended)
       </label>
       <br />
       <label class="control-label text-left nonbold inline">

--- a/client/app/compare/compare.html
+++ b/client/app/compare/compare.html
@@ -45,7 +45,7 @@
       </ui-select>
     </div>
     <div class="form-group" ng-if="vm.selected.comparable.key === 'versions'">
-      <label class="control-label text-left">Cluster:</label>
+      <label class="control-label text-left">Team:</label>
     </div>
     <div class="form-group" ng-if="vm.selected.comparable.key === 'versions'">
       <select class="form-control" ng-model="vm.selected.cluster" ng-change="vm.onSelectionChanged()">

--- a/client/app/configuration/clusters/cluster.html
+++ b/client/app/configuration/clusters/cluster.html
@@ -1,7 +1,7 @@
 <div class="row page-title">
     <div class="col-md-12">
-        <h2 ng-if="!EditMode">New Cluster</h2>
-        <h2 ng-if="EditMode">Edit Cluster {{Cluster.ClusterName}}</h2>
+        <h2 ng-if="!EditMode">New Team</h2>
+        <h2 ng-if="EditMode">Edit Team {{Cluster.ClusterName}}</h2>
     </div>
 </div>
 
@@ -10,7 +10,7 @@
 <form name="form" id="Cluster" class="form-horizontal" ng-show="DataFound || !EditMode">
 
     <div class="form-group" ng-if="!EditMode" ng-class="{'has-error': form.ClusterName.$invalid}">
-        <label class="col-md-1 control-label text-left nowrap">Cluster Name: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
+        <label class="col-md-1 control-label text-left nowrap">Team Name: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
         <div class="col-md-2">
             <input type="text"
                    name="ClusterName"
@@ -23,9 +23,9 @@
                    pattern="[a-zA-Z]+[a-zA-Z0-9]*"
                    ng-readonly="!!EditMode || !canUser('edit')" />
         </div>
-        <span class="help-block" ng-if="form.ClusterName.$dirty && form.ClusterName.$error.required">Cluster name is mandatory.</span>
-        <span class="help-block" ng-if="form.ClusterName.$dirty && form.ClusterName.$error.duplicated">A Cluster already exists with the same name.</span>
-        <span class="help-block" ng-if="form.ClusterName.$dirty && form.ClusterName.$error.pattern">Cluster name must be a single alphanumeric word.</span>
+        <span class="help-block" ng-if="form.ClusterName.$dirty && form.ClusterName.$error.required">Team name is mandatory.</span>
+        <span class="help-block" ng-if="form.ClusterName.$dirty && form.ClusterName.$error.duplicated">A Team already exists with the same name.</span>
+        <span class="help-block" ng-if="form.ClusterName.$dirty && form.ClusterName.$error.pattern">Team name must be a single alphanumeric word.</span>
     </div>
     <div class="form-group" ng-class="{'has-error': form.ShortName.$invalid}">
         <label class="col-md-1 control-label text-left nowrap">Short Name Code: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>

--- a/client/app/configuration/clusters/clusters.html
+++ b/client/app/configuration/clusters/clusters.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-md-12"><h2>Clusters</h2></div>
+  <div class="col-md-12"><h2>Teams</h2></div>
   <div id="RefreshData">
     <span class="glyphicon glyphicon-refresh" ng-click="Refresh()" title="Refresh data"></span>
   </div>
@@ -16,13 +16,13 @@
     <spinner></spinner>
   </div>
   <div class="col-md-12" ng-show="!dataLoading && Data.length == 0">
-    <p>No clusters found.</p>
+    <p>No teams found.</p>
   </div>
   <div class="col-md-8" ng-show="!dataLoading && Data.length > 0">
     <table class="table">
       <thead>
         <tr>
-          <th class="text-nowrap">Cluster Name</th>
+          <th class="text-nowrap">Team Name</th>
           <th class="text-nowrap">Short Name Code</th>
           <th class="text-nowrap">EC2 Key Pair</th>
           <th class="text-nowrap">Email</th>

--- a/client/app/configuration/deployment-maps/deployment-map.html
+++ b/client/app/configuration/deployment-maps/deployment-map.html
@@ -6,7 +6,7 @@
 
 <form id="SearchFilter" class="form-inline">
     <div class="form-group">
-        <label class="control-label text-left">Owning Cluster:</label>
+        <label class="control-label text-left">Owning Team:</label>
     </div>
     <div class="form-group">
         <select class="form-control" ng-model="vm.selectedOwningCluster" ng-change="vm.search()">

--- a/client/app/configuration/deployment-maps/deployment-maps-target-modal.html
+++ b/client/app/configuration/deployment-maps/deployment-maps-target-modal.html
@@ -16,13 +16,13 @@
           <span class="help-block" ng-if="form.ServerRoleName.$dirty && form.ServerRoleName.$error.pattern">Server Role name must start with a character and may only contain alphanumeric characters.</span>
         </div>
         <div class="form-group" ng-class="{'has-error': form.OwningClusters.$invalid}">
-          <label class="col-md-2 control-label text-left">Owning Cluster:</label>
+          <label class="col-md-2 control-label text-left">Owning Team:</label>
           <div class="col-md-3">
             <select class="form-control" name="OwningClusters" required="" ng-model="vm.target.OwningCluster" ng-change="vm.owningClusterUpdated()" ng-disabled="vm.pageMode == 'Edit' || !vm.canUser('edit')">
               <option ng-repeat="cluster in vm.owningClustersList" ng-selected="{{cluster.ClusterName == vm.target.OwningCluster}}" value="{{cluster.ClusterName}}">{{cluster.ClusterName}}</option>
             </select>
           </div>
-          <span class="help-block" ng-if="form.OwningClusters.$dirty && form.OwningClusters.$error.required">Owning cluster is mandatory.</span>
+          <span class="help-block" ng-if="form.OwningClusters.$dirty && form.OwningClusters.$error.required">Owning team is mandatory.</span>
         </div>
         <div class="form-group" ng-class="{'has-error': form.SecurityZone.$invalid}">
           <label class="col-md-2 control-label text-left">Security Zone:</label>

--- a/client/app/configuration/em-services/service.html
+++ b/client/app/configuration/em-services/service.html
@@ -28,7 +28,7 @@
         <span class="help-block" ng-if="form.ServiceName.$dirty && form.ServiceName.$error.pattern">Service name must contain only alphanumeric characters.</span>
     </div>
     <div class="form-group" ng-class="{'has-error': form.OwningClusters.$invalid} && form.OwningClusters.$dirty">
-        <label class="col-sm-2 control-label text-left nowrap">Owning Cluster: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
+        <label class="col-sm-2 control-label text-left nowrap">Owning Team: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
         <div class="col-sm-4">
             <select class="form-control"
                     name="OwningClusters"
@@ -38,7 +38,7 @@
                 <option ng-repeat="cluster in vm.owningClustersList" ng-selected="{{cluster == vm.service.OwningCluster}}" value="{{cluster}}">{{cluster}}</option>
             </select>
         </div>
-        <span class="help-block" ng-if="form.OwningClusters.$error.required">Owning cluster is mandatory.</span>
+        <span class="help-block" ng-if="form.OwningClusters.$error.required">Owning team is mandatory.</span>
     </div>
     <div class="form-group">
         <label class="col-sm-2 control-label text-left nowrap">Description:</label>

--- a/client/app/configuration/em-services/services.html
+++ b/client/app/configuration/em-services/services.html
@@ -7,7 +7,7 @@
 
 <form id="SearchFilter" class="form-inline">
   <div class="form-group">
-    <label class="control-label text-left">Owning Cluster:</label>
+    <label class="control-label text-left">Owning Team:</label>
   </div>
   <div class="form-group">
     <select class="form-control" ng-model="vm.selectedOwningCluster" ng-change="vm.refresh()">
@@ -41,7 +41,7 @@
       <thead>
         <tr>
           <th class="text-nowrap">Service Name</th>
-          <th class="text-nowrap">Owning Cluster</th>
+          <th class="text-nowrap">Owning Team</th>
           <th class="text-nowrap">Description</th>
           <th class="text-nowrap">Blue Port</th>
           <th class="text-nowrap">Green Port</th>

--- a/client/app/configuration/popovers/notification-settings.html
+++ b/client/app/configuration/popovers/notification-settings.html
@@ -1,3 +1,3 @@
 <div>
-  Notification settings which will be used for notification alerts of environment / service owned by this cluster.
+  Notification settings which will be used for notification alerts of environment / service owned by this team.
 </div>

--- a/client/app/environments/dialogs/env-create-environment-modal.html
+++ b/client/app/environments/dialogs/env-create-environment-modal.html
@@ -35,7 +35,7 @@
             <span class="help-block" ng-if="form.EnvironmentType.$dirty && form.EnvironmentType.$error.required">Environment Type is mandatory.</span>
         </div>
         <div class="form-group" ng-class="{'has-error': form.OwningClusters.$invalid}">
-            <label class="col-md-4 control-label text-left nowrap">Owning Cluster: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
+            <label class="col-md-4 control-label text-left nowrap">Owning Team: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
             <div class="col-md-4">
                 <select class="form-control"
                         name="OwningClusters"
@@ -44,7 +44,7 @@
                     <option ng-repeat="cluster in OwningClustersList" ng-selected="{{cluster == Environment.Value.OwningCluster}}" value="{{cluster}}">{{cluster}}</option>
                 </select>
             </div>
-            <span class="help-block" ng-if="form.OwningClusters.$dirty && form.OwningClusters.$error.required">Owning cluster is mandatory.</span>
+            <span class="help-block" ng-if="form.OwningClusters.$dirty && form.OwningClusters.$error.required">Owning team is mandatory.</span>
         </div>
 
         <div class="form-group" ng-class="{'has-error': form.DeploymentMap.$invalid}">

--- a/client/app/environments/servers/env-manage-servers.html
+++ b/client/app/environments/servers/env-manage-servers.html
@@ -17,7 +17,7 @@
         <select class="form-control" ng-model="vm.selected.status" ng-options="status for status in vm.options.statuses" ng-change="vm.update()"></select>
       </div>
       <div class="form-group">
-        <label class="control-label text-left">Cluster:</label>
+        <label class="control-label text-left">Team:</label>
       </div>
       <div class="form-group">
         <select class="form-control" ng-model="vm.selected.cluster" ng-options="cluster for cluster in vm.options.clusters" ng-change="vm.update()">Any</select>
@@ -59,7 +59,7 @@
         <thead>
           <tr>
             <th class="text-nowrap">Server Role</th>
-            <th class="text-nowrap">Owning Cluster</th>
+            <th class="text-nowrap">Owning Team</th>
             <th class="text-nowrap">Services</th>
             <th class="text-nowrap" current-desired-title="{{vm.view.allServersCount}}">Servers ({{ vm.view.allServersCount }})</th>
             <th class="text-nowrap">AMI</th>

--- a/client/app/environments/settings/env-manage-settings.html
+++ b/client/app/environments/settings/env-manage-settings.html
@@ -14,7 +14,7 @@
     <div class="col-md-12" ng-show="vm.dataFound">
         <form name="form" id="EnvironmentDetails" class="form-horizontal">
             <div class="form-group" ng-class="{'has-error': form.OwningClusters.$invalid}">
-                <label class="col-md-1 control-label text-left nowrap">Owning Cluster: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
+                <label class="col-md-1 control-label text-left nowrap">Owning Team: <span class="glyphicon glyphicon-asterisk mandatory"></span></label>
                 <div class="col-md-2" ng-if="vm.canUser('edit')">
                     <select class="form-control"
                             name="OwningClusters"
@@ -26,7 +26,7 @@
                 <div class="col-md-2" ng-if="!vm.canUser('edit')">
                     <label class="control-label text-left nonbold">{{vm.newEnvironment.OwningCluster}}</label>
                 </div>
-                <span class="help-block" ng-if="form.OwningClusters.$dirty && form.OwningClusters.$error.required">Owning cluster is mandatory.</span>
+                <span class="help-block" ng-if="form.OwningClusters.$dirty && form.OwningClusters.$error.required">Owning team is mandatory.</span>
             </div>
 
             <div class="form-group" ng-class="{'has-error': form.DeploymentMap.$invalid}">

--- a/client/app/environments/summary/EnvironmentsSummaryController.js
+++ b/client/app/environments/summary/EnvironmentsSummaryController.js
@@ -76,7 +76,7 @@ angular.module('EnvironmentManager.environments').controller('EnvironmentsSummar
               Operation: target.Value || {}
             };
 
-            var scheduleAction = target.Value.ScheduleStatus;
+            var scheduleAction = (target.Value || {}).ScheduleStatus;
             result.Operation.getScheduleAction = function () { return scheduleAction; };
 
             return result;

--- a/client/app/environments/summary/env-summary.html
+++ b/client/app/environments/summary/env-summary.html
@@ -15,7 +15,7 @@
     </select>
   </div>
   <div class="form-group">
-    <label class="control-label text-left">Owning Cluster:</label>
+    <label class="control-label text-left">Owning Team:</label>
   </div>
   <div class="form-group">
     <select class="form-control" ng-model="vm.selectedOwningCluster" ng-change="vm.refresh()">
@@ -41,7 +41,7 @@
         <tr>
           <th class="text-nowrap"></th>
           <th class="text-nowrap">Environment</th>
-          <th class="text-nowrap">Owning Cluster</th>
+          <th class="text-nowrap">Owning Team</th>
           <th class="text-nowrap">Description</th>
           <th class="text-nowrap">Deployment Map</th>
           <th class="text-nowrap">Status</th>

--- a/client/app/operations/amis/ops-amis.html
+++ b/client/app/operations/amis/ops-amis.html
@@ -16,7 +16,7 @@
     </select>
   </div>
   <div class="form-group">
-    <label class="control-label text-left">Cluster:</label>
+    <label class="control-label text-left">Team:</label>
   </div>
   <div class="form-group">
     <select class="form-control" ng-model="vm.selectedOwningCluster" ng-change="vm.refresh()">
@@ -62,7 +62,7 @@
     <table class="table">
       <thead>
         <tr>
-          <th class="text-nowrap" ng-if="vm.selectedOwningCluster == 'Any'">Owning Cluster</th>
+          <th class="text-nowrap" ng-if="vm.selectedOwningCluster == 'Any'">Owning Team</th>
           <th class="text-nowrap">Instance</th>
           <th class="text-nowrap">Role</th>
           <th class="text-nowrap">Launch Date</th>

--- a/client/app/operations/deployments/ops-deployments.html
+++ b/client/app/operations/deployments/ops-deployments.html
@@ -29,7 +29,7 @@
     </select>
   </div>
   <div class="form-group">
-    <label class="control-label text-left">Cluster:</label>
+    <label class="control-label text-left">Team:</label>
   </div>
   <div class="form-group">
     <select class="form-control" ng-model="vm.selectedOwningCluster" ng-change="vm.refresh()">

--- a/client/app/operations/maintenance/ops-maintenance-addserver-modal.html
+++ b/client/app/operations/maintenance/ops-maintenance-addserver-modal.html
@@ -36,7 +36,7 @@ Environment: {{server.Environment}}
 Name: {{vm.serverDetails.Name}}
 InstanceId: {{vm.serverDetails.InstanceId}}
 Ip: {{vm.serverDetails.Ip}}
-Owning Cluster: {{vm.serverDetails.OwningCluster}}
+Owning Team: {{vm.serverDetails.OwningCluster}}
 Role: {{vm.serverDetails.Role}}
 Status: {{vm.serverDetails.Status}}
 AutoScalingGroup: {{vm.serverDetails['aws:autoscaling:groupName'] || 'None'}}</pre>

--- a/client/app/operations/maintenance/ops-maintenance.html
+++ b/client/app/operations/maintenance/ops-maintenance.html
@@ -47,7 +47,7 @@
           <th class="text-nowrap">Name</th>
           <th class="text-nowrap">InstanceId</th>
           <th class="text-nowrap">IP Address</th>
-          <th class="text-nowrap">Owning Cluster</th>
+          <th class="text-nowrap">Owning Team</th>
           <th class="text-nowrap">Role</th>
           <th class="text-nowrap">Status</th>
         </tr>

--- a/client/index.html
+++ b/client/index.html
@@ -206,7 +206,7 @@
               <li><a href="#/config/loadbalancers" ng-class="{active: $route.current.menusection == 'LBs'}">Load Balancer</a></li>
               <li><a href="#/config/upstreams" ng-class="{active: $route.current.menusection == 'LBUpstream'}">Upstreams</a></li>
               <li><a href="#/config/notification-settings" ng-class="{active: $route.current.menusection == 'NotificationSettings'}">Notification Settings</a></li>
-              <li><a href="#/config/clusters" ng-class="{active: $route.current.menusection == 'Clusters'}">Clusters</a></li>
+              <li><a href="#/config/clusters" ng-class="{active: $route.current.menusection == 'Clusters'}">Teams</a></li>
               <li><a href="#/config/environmenttypes" ng-class="{active: $route.current.menusection == 'EnvironmentTypes'}">Environment Types</a></li>
               <li><a href="#/config/accounts" ng-class="{active: $route.current.menusection == 'Accounts'}">Accounts</a></li>
             </ul>

--- a/server/modules/provisioning/autoScaling/tagsProvider.js
+++ b/server/modules/provisioning/autoScaling/tagsProvider.js
@@ -10,11 +10,14 @@ module.exports = {
   get(configuration, sliceName) {
     assert(configuration, 'Expected \'configuration\' argument not to be null');
     let roleName = namingConventionProvider.getRoleName(configuration, sliceName);
+    let legacyTags = {
+      OwningCluster: configuration.cluster.Name,
+      OwningClusterShortName: configuration.cluster.ShortName
+    };
     let tags = {
       EnvironmentType: configuration.environmentTypeName,
       Environment: configuration.environmentName,
-      OwningCluster: configuration.cluster.Name,
-      OwningClusterShortName: configuration.cluster.ShortName,
+      OwningTeam: configuration.cluster.Name,
       Role: roleName,
       SecurityZone: configuration.serverRole.SecurityZone,
       Schedule: configuration.serverRole.ScheduleTag || '',
@@ -25,6 +28,6 @@ module.exports = {
       return Promise.reject(new ConfigurationError('Missing \'ContactEmail\' tag in configuration.'));
     }
 
-    return Promise.resolve(tags);
+    return Promise.resolve(Object.assign({}, legacyTags, tags));
   }
 };

--- a/server/test/modules/provisioning/autoScaling/TagsProvider.spec.js
+++ b/server/test/modules/provisioning/autoScaling/TagsProvider.spec.js
@@ -27,6 +27,7 @@ describe('TagsProvider:', () => {
       },
       cluster: {
         Name: 'Tango',
+        ShortName: 'ta'
       },
     };
 
@@ -37,11 +38,13 @@ describe('TagsProvider:', () => {
     var promise = target.get(configuration);
 
     // Assert
-    return promise.then(tags => should(tags).match({
+    return promise.then(tags => should(tags).eql({
       EnvironmentType: 'Prod',
       Environment: 'pr1',
       SecurityZone: 'Secure',
       OwningCluster: 'Tango',
+      OwningClusterShortName: 'ta',
+      OwningTeam: 'Tango',
       Role: 'expected-role-name',
       ContactEmail: 'test@email.com',
       Schedule: '247',


### PR DESCRIPTION
- Apply _OwningTeam_ tag to newly created machines with the same value as the existing _OwningCluster_ tag.
- Replace instances of the word "cluster" visible in the UI with "team".

https://jira.thetrainline.com/browse/PD-326