### PR TITLE
Configure hosting AWS region on startup

### DIFF
--- a/server/deployment/code-deploy/on-after-install.sh
+++ b/server/deployment/code-deploy/on-after-install.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 create_systemd_unit() {
+  echo "Creating systemd unit ${1}" >&2
   local SERVICE_DEFINITION=$1
   local SRC_FILE=/opt/environment-manager/deployment/systemd/${SERVICE_DEFINITION}
   local TARGET_FILE=/lib/systemd/system/${SERVICE_DEFINITION}
@@ -12,3 +13,6 @@ create_systemd_unit() {
 
 create_systemd_unit "environment-manager.service"
 create_systemd_unit "environment-manager-debug.service"
+
+echo "Allowing execution of environment-manager start script" >&2
+chmod a+x /opt/environment-manager/start

--- a/server/deployment/systemd/environment-manager.service
+++ b/server/deployment/systemd/environment-manager.service
@@ -4,7 +4,7 @@ Conflicts=environment-manager-debug.service
 [Service]
 EnvironmentFile=/etc/environment-manager.env
 WorkingDirectory=/opt/environment-manager/
-ExecStart=/usr/bin/npm start
+ExecStart=/opt/environment-manager/start
 
 Restart=always
 StandardOutput=syslog

--- a/server/gulpfile.js
+++ b/server/gulpfile.js
@@ -29,6 +29,7 @@ function copy() {
     'globals.js',
     'index.js',
     'package.json',
+    'start',
     'tempMapResolver.js',
     'yarn.lock'
   ]).pipe(gulp.dest(output()));

--- a/server/start
+++ b/server/start
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+# This script is called by systemd to start environment-manager
+# it sets up the environment and then runs Environment Manager
+# in place of the shell
+
+# Use the EC2 metadata service to look up the AWS region in which this server is running
+# and set the region Environment Manager will use when querying its management resources
+export EM_AWS_REGION=$(curl --silent --show-error http://169.254.169.254/2016-09-02/dynamic/instance-identity/document | jq --raw-output '.region')
+echo "EM_AWS_REGION=${EM_AWS_REGION}" >&2
+
+exec npm start


### PR DESCRIPTION
Environment Manager reads the region containing its management resources from the _EM_AWS_REGION_ environment variable.

This PR changes the way the Environment Manager service is started. A shell script runs and sets the value of the  _EM_AWS_REGION_ environment variable to the region in which the EC2 instance is running, using the EC2 metadata service. The script then replaces the shell with the Environment Manager service in the running process.

This mechanism separates the setting of the configuration variable from its use. An Environment Manager service running on an EC2 instance will get its regional settings from the environment in which it is running without explicit configuration, while a developer can set the value of the _EM_AWS_REGION_ variable explicitly.