### PR TITLE
Prevent modifications to auto scaling groups in locked environments

### DIFF
--- a/client/app/environments/dialogs/ASGDetailsModalController.js
+++ b/client/app/environments/dialogs/ASGDetailsModalController.js
@@ -181,7 +181,7 @@ angular.module('EnvironmentManager.environments').controller('ASGDetailsModalCon
           }
 
           vm.currentDistribution = asgDistributionService.calcDistribution(vm.deploymentAzsList, vm.asg);
-          vm.getLBStatus().finally(function(){
+          vm.getLBStatus().finally(function () {
             vm.loadingUpstreamStatus = false;
           });
 
@@ -198,12 +198,12 @@ angular.module('EnvironmentManager.environments').controller('ASGDetailsModalCon
       });
     };
 
-    vm.getLBStatus = function() {
+    vm.getLBStatus = function () {
       var env = parameters.environment.EnvironmentName;
       var params = { account: 'all' };
 
-      return resources.config.lbUpstream.all(params).then(function(upstreams) {
-        return vm.getLBData(env).then(function(lbs) {
+      return resources.config.lbUpstream.all(params).then(function (upstreams) {
+        return vm.getLBData(env).then(function (lbs) {
           var instances = vm.asgState.Instances;
 
           vm.upstreamStatusData.lbs = lbs;
@@ -213,9 +213,9 @@ angular.module('EnvironmentManager.environments').controller('ASGDetailsModalCon
       });
     }
 
-    vm.getLBData = function(env) {
-      return accountMappingService.getEnvironmentLoadBalancers(env).then(function(lbNames){
-        return $q.all(lbNames.map(function(lbName){
+    vm.getLBData = function (env) {
+      return accountMappingService.getEnvironmentLoadBalancers(env).then(function (lbNames) {
+        return $q.all(lbNames.map(function (lbName) {
           var url = ['api', 'v1', 'load-balancer', lbName].join('/');
           return $http.get(url).then(function (response) {
             var upstreams = response.data;
@@ -280,15 +280,17 @@ angular.module('EnvironmentManager.environments').controller('ASGDetailsModalCon
             availabilityZoneName: vm.asgUpdate.AvailabilityZone
           }
         };
-        vm.asg.updateAutoScalingGroup(updated).then(function () {
-          loading.lockPage(false);
-          modal.information({
-            title: 'ASG Updated',
-            message: 'ASG update successful. You can monitor instance changes by using the Refresh Icon in the top right of the window.<br/><br/><b>Note:</b> During scale-down instances will wait in a Terminating state for 10 minutes to allow for connection draining before termination.'
-          }).then(function () {
+        vm.asg.updateAutoScalingGroup(updated)
+          .then(function () {
+            modal.information({
+              title: 'ASG Updated',
+              message: 'ASG update successful. You can monitor instance changes by using the Refresh Icon in the top right of the window.<br/><br/><b>Note:</b> During scale-down instances will wait in a Terminating state for 10 minutes to allow for connection draining before termination.'
+            });
+          })
+          .finally(function () {
+            loading.lockPage(false);
             vm.refresh();
           });
-        });
       });
     };
 
@@ -361,13 +363,13 @@ angular.module('EnvironmentManager.environments').controller('ASGDetailsModalCon
           title: 'ASG Schedule Updated',
           message: 'ASG schedule updated successfully.'
         });
-      }).catch(function(err){
+      }).catch(function (err) {
         if (err.status === 404) {
           modal.error('Error', 'An error has occurred: ' + err.data.error);
         } else {
           throw err;
         }
-      }).finally(function() {
+      }).finally(function () {
         resetForm();
         vm.refresh();
       });

--- a/client/app/environments/settings/env-manage-settings.html
+++ b/client/app/environments/settings/env-manage-settings.html
@@ -91,10 +91,11 @@
                 <div class="col-md-3">
                     <label>
                         <input type="checkbox" data-ng-model="vm.newEnvironment.IsLocked" />
-                        <span class="glyphicon glyphicon-lock" aria-hidden="true"></span> Lock Deployments</label>
+                        <span class="glyphicon glyphicon-lock" aria-hidden="true"></span> Lock Environment</label>
                     <p>
                         <em>
-                            This will prevent any further deployments to this environment until it is unlocked.
+                            Prevent deployment of services and modifications to auto scaling groups in this environment.
+                            Any operations in progress will continue to completion.
                         </em>
                     </p>
                 </div>
@@ -107,7 +108,7 @@
                         <span class="glyphicon glyphicon-wrench" aria-hidden="true"></span> Maintenance Mode</label>
                     <p>
                         <em>
-                            This will cause users of publicly available services in this environment to see a maintenance page.
+                            Users of publicly available services in this environment will see a maintenance page.
                         </em>
                     </p>
                 </div>

--- a/server/api/controllers/asgs/asgController.js
+++ b/server/api/controllers/asgs/asgController.js
@@ -2,6 +2,7 @@
 
 'use strict';
 
+let Promise = require('bluebird');
 let _ = require('lodash');
 let co = require('co');
 let getAllASGs = require('queryHandlers/ScanCrossAccountAutoScalingGroups');
@@ -18,6 +19,46 @@ let GetAutoScalingGroupScheduledActions = require('queryHandlers/GetAutoScalingG
 let getASGReady = require('modules/environment-state/getASGReady');
 let Environment = require('models/Environment');
 let sns = require('modules/sns/EnvironmentManagerEvents');
+let opsEnvironment = require('modules/data-access/opsEnvironment');
+
+class ValidationError extends Error {
+  constructor(obj) {
+    super();
+    Object.assign(this, obj);
+  }
+}
+
+function checkEnvironmentExists(environmentName) {
+  return environment => (environment
+    ? Promise.resolve(environment)
+    : Promise.reject(new ValidationError({
+      errors: [
+        { title: 'Environment Not Found', detail: `environment name: ${environmentName}` }
+      ],
+      status: 400
+    })));
+}
+
+function checkEnvironmentUnlocked(environment) {
+  return Promise.resolve()
+    .then(() => {
+      let { EnvironmentName, Value: { DeploymentsLocked = false } = {} } = environment || {};
+      return DeploymentsLocked
+        ? Promise.reject(new ValidationError({
+          errors: [
+            { title: 'Environment Locked', detail: `environment name: ${EnvironmentName}` }
+          ],
+          status: 400
+        }))
+        : Promise.resolve(environment);
+    });
+}
+
+function handleValidationErrors(res) {
+  return error => (error instanceof ValidationError
+    ? res.status(error.status || 400).json({ errors: error.errors })
+    : Promise.reject(error));
+}
 
 /**
  * GET /asgs
@@ -119,14 +160,16 @@ function getScalingSchedule(req, res, next) {
 function putAsg(req, res, next) {
   const environmentName = req.swagger.params.environment.value;
   const autoScalingGroupName = req.swagger.params.name.value;
-
   const parameters = req.swagger.params.body.value;
 
-  UpdateAutoScalingGroup({
-    environmentName,
-    autoScalingGroupName,
-    parameters
-  })
+  return opsEnvironment.get({ EnvironmentName: environmentName })
+    .then(checkEnvironmentExists(environmentName))
+    .then(checkEnvironmentUnlocked)
+    .then(() => UpdateAutoScalingGroup({
+      environmentName,
+      autoScalingGroupName,
+      parameters
+    }))
     .then(data => res.json(data))
     .then(() => sns.publish({
       message: JSON.stringify({
@@ -142,6 +185,7 @@ function putAsg(req, res, next) {
         ID: autoScalingGroupName
       }
     }))
+    .catch(handleValidationErrors(res))
     .catch(next);
 }
 
@@ -152,56 +196,50 @@ function deleteAsg(req, res, next) {
   const environmentName = req.swagger.params.environment.value;
   const autoScalingGroupName = req.swagger.params.name.value;
 
-  return co(function* () {
-    let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
-    AutoScalingGroup.getByName(accountName, autoScalingGroupName)
-      .then(asg => asg.deleteASG())
-      .then((status) => {
-        res.json({
-          Ok: status
-        });
-      })
-      .then(() => sns.publish({
-        message: JSON.stringify({
-          Endpoint: {
-            Url: `/asgs/${autoScalingGroupName}`,
-            Method: 'DELETE'
-          }
-        }),
-        topic: sns.TOPICS.OPERATIONS_CHANGE,
-        attributes: {
-          Environment: environmentName,
-          Action: sns.ACTIONS.DELETE,
-          ID: autoScalingGroupName
+  return opsEnvironment.get({ EnvironmentName: environmentName })
+    .then(checkEnvironmentExists(environmentName))
+    .then(checkEnvironmentUnlocked)
+    .then(() => Environment.getAccountNameForEnvironment(environmentName))
+    .then(accountName => AutoScalingGroup.getByName(accountName, autoScalingGroupName))
+    .then(asg => asg.deleteASG())
+    .then((status) => { res.json({ Ok: status }); })
+    .then(() => sns.publish({
+      message: JSON.stringify({
+        Endpoint: {
+          Url: `/asgs/${autoScalingGroupName}`,
+          Method: 'DELETE'
         }
-      }));
-  }).catch(next);
+      }),
+      topic: sns.TOPICS.OPERATIONS_CHANGE,
+      attributes: {
+        Environment: environmentName,
+        Action: sns.ACTIONS.DELETE,
+        ID: autoScalingGroupName
+      }
+    }))
+    .catch(handleValidationErrors(res))
+    .catch(next);
 }
 
 /**
  * PUT /asgs/{name}/scaling-schedule
  */
 function putScalingSchedule(req, res, next) {
-  const body = req.swagger.params.body.value;
+  const { propagateToInstances, schedule } = req.swagger.params.body.value;
   const environmentName = req.swagger.params.environment.value;
   const autoScalingGroupName = req.swagger.params.name.value;
 
-  return co(function* () {
-    let data = {};
-
-    let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
-    let schedule = body.schedule;
-    let propagateToInstances = body.propagateToInstances;
-
-    data = yield SetAutoScalingGroupSchedule({
+  return opsEnvironment.get({ EnvironmentName: environmentName })
+    .then(checkEnvironmentExists(environmentName))
+    .then(checkEnvironmentUnlocked)
+    .then(() => Environment.getAccountNameForEnvironment(environmentName))
+    .then(accountName => SetAutoScalingGroupSchedule({
       accountName,
       autoScalingGroupName,
       schedule,
       propagateToInstances
-    });
-
-    res.json(data);
-  })
+    }))
+    .then(data => res.json(data))
     .then(() => sns.publish({
       message: JSON.stringify({
         Endpoint: {
@@ -216,6 +254,7 @@ function putScalingSchedule(req, res, next) {
         ID: autoScalingGroupName
       }
     }))
+    .catch(handleValidationErrors(res))
     .catch(next);
 }
 
@@ -230,31 +269,34 @@ function putAsgSize(req, res, next) {
   const autoScalingGroupDesiredSize = body.desired;
   const autoScalingGroupMaxSize = body.max;
 
-  return co(function* () {
-    let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
-    SetAutoScalingGroupSize({
+  return opsEnvironment.get({ EnvironmentName: environmentName })
+    .then(checkEnvironmentExists(environmentName))
+    .then(checkEnvironmentUnlocked)
+    .then(() => Environment.getAccountNameForEnvironment(environmentName))
+    .then(accountName => SetAutoScalingGroupSize({
       accountName,
       autoScalingGroupName,
       autoScalingGroupMinSize,
       autoScalingGroupDesiredSize,
       autoScalingGroupMaxSize
-    })
-      .then(data => res.json(data))
-      .then(() => sns.publish({
-        message: JSON.stringify({
-          Endpoint: {
-            Url: `/asgs/${autoScalingGroupName}/size`,
-            Method: 'PUT'
-          }
-        }),
-        topic: sns.TOPICS.OPERATIONS_CHANGE,
-        attributes: {
-          Environment: environmentName,
-          Action: sns.ACTIONS.PUT,
-          ID: autoScalingGroupName
+    }))
+    .then(data => res.json(data))
+    .then(() => sns.publish({
+      message: JSON.stringify({
+        Endpoint: {
+          Url: `/asgs/${autoScalingGroupName}/size`,
+          Method: 'PUT'
         }
-      }));
-  }).catch(next);
+      }),
+      topic: sns.TOPICS.OPERATIONS_CHANGE,
+      attributes: {
+        Environment: environmentName,
+        Action: sns.ACTIONS.PUT,
+        ID: autoScalingGroupName
+      }
+    }))
+    .catch(handleValidationErrors(res))
+    .catch(next);
 }
 
 /**
@@ -265,29 +307,32 @@ function putAsgLaunchConfig(req, res, next) {
   const data = req.swagger.params.body.value;
   const autoScalingGroupName = req.swagger.params.name.value;
 
-  return co(function* () {
-    let accountName = yield Environment.getAccountNameForEnvironment(environmentName);
-    SetLaunchConfiguration({
+  return opsEnvironment.get({ EnvironmentName: environmentName })
+    .then(checkEnvironmentExists(environmentName))
+    .then(checkEnvironmentUnlocked)
+    .then(() => Environment.getAccountNameForEnvironment(environmentName))
+    .then(accountName => SetLaunchConfiguration({
       accountName,
       autoScalingGroupName,
       data
-    })
-      .then(res.json.bind(res))
-      .then(() => sns.publish({
-        message: JSON.stringify({
-          Endpoint: {
-            Url: `/asgs/${autoScalingGroupName}/launch-config`,
-            Method: 'PUT'
-          }
-        }),
-        topic: sns.TOPICS.OPERATIONS_CHANGE,
-        attributes: {
-          Environment: environmentName,
-          Action: sns.ACTIONS.PUT,
-          ID: autoScalingGroupName
+    }))
+    .then(x => res.json(x))
+    .then(() => sns.publish({
+      message: JSON.stringify({
+        Endpoint: {
+          Url: `/asgs/${autoScalingGroupName}/launch-config`,
+          Method: 'PUT'
         }
-      }));
-  }).catch(next);
+      }),
+      topic: sns.TOPICS.OPERATIONS_CHANGE,
+      attributes: {
+        Environment: environmentName,
+        Action: sns.ACTIONS.PUT,
+        ID: autoScalingGroupName
+      }
+    }))
+    .catch(handleValidationErrors(res))
+    .catch(next);
 }
 
 module.exports = {


### PR DESCRIPTION
This feature extends environment locking from deployments to the following operations:

- DELETE /asgs/{name}
- PUT /asgs/{name}
- PUT /asgs/{name}/launch-config
- PUT /asgs/{name}/scaling-schedule
- PUT /asgs/{name}/size

https://jira.thetrainline.com/browse/PD-351