### PR TITLE
Fixed response status code for deployment authorization errors

### DIFF
--- a/server/models/DeploymentMap.js
+++ b/server/models/DeploymentMap.js
@@ -3,7 +3,7 @@
 'use strict';
 
 let _ = require('lodash');
-let ConfigurationError = require('modules/errors/ConfigurationError.class');
+let ResourceNotFoundError = require('modules/errors/ResourceNotFoundError.class');
 let deploymentMaps = require('modules/data-access/deploymentMaps');
 
 class DeploymentMap {
@@ -16,7 +16,7 @@ class DeploymentMap {
     return deploymentMaps.get({ DeploymentMapName: deploymentMapName })
       .then(deploymentMap => (deploymentMap !== null
         ? new DeploymentMap(deploymentMap.Value)
-        : Promise.reject(new ConfigurationError(`Deployment map "${deploymentMapName}" not found.`))),
+        : Promise.reject(new ResourceNotFoundError(`Deployment map "${deploymentMapName}" not found.`))),
         error => Promise.reject(
           new Error(`An error has occurred retrieving "${deploymentMapName}" deployment map: ${error.message}`)));
   }
@@ -27,7 +27,7 @@ class DeploymentMap {
     );
 
     if (deploymentTargets.length === 0) {
-      throw new ConfigurationError(
+      throw new ResourceNotFoundError(
         `Target server role cannot be identified through "${serviceName}" service because there ` +
         'is no reference to it in the deployment map.'
       );

--- a/server/modules/authorization.js
+++ b/server/modules/authorization.js
@@ -5,6 +5,11 @@
 let logger = require('modules/logger');
 let authorize = require('modules/authorizer');
 
+let errorResponseCodes = {
+  BadRequestError: 400,
+  ResourceNotFoundError: 404
+};
+
 function authorizeRequest(authorizer, request, response, next) {
   if (!request.user) {
     response.status(401);
@@ -35,8 +40,9 @@ function handleSecureRequest(authorizer, request, response, next) {
       return sendUnauthorizedResponse(authorizationResult.unsatisfiedPermissions, response);
     }
   }).catch((error) => {
-    if (error.name === 'BadRequestError') {
-      response.status(400);
+    let errorCode = errorResponseCodes[error.name];
+    if (errorCode) {
+      response.status(errorCode);
       response.send(error.message);
     } else {
       sendAuthorizationErrorResponse(error, response);


### PR DESCRIPTION
Now returns a 404 when resources required for authorization are not found.