### PR TITLE
Feature/pd233 disable services

### DIFF
--- a/client/app/common/services/targetStateService.js
+++ b/client/app/common/services/targetStateService.js
@@ -4,14 +4,17 @@
 
 angular.module('EnvironmentManager.common').factory('targetStateService', function ($rootScope, $q, $http) {
   return {
-    changeDeploymentAction: function (deploymentId, enable) {
-      var action = enable ? 'Install' : 'Ignore';
-      var url = '/api/v1/deployments/' + deploymentId;
+    toggleServiceStatus: function (environment, service, slice, enable, serverRole, environmentType) {
+      var url = '/api/v1/target-state/' + environment + '/' + service + '/toggle-status';
+
       var data = {
-        Action: action
+        Enable: enable,
+        Slice: slice,
+        ServerRole: serverRole,
+        EnvironmentType: environmentType
       };
 
-      return $http.patch(url, data)
+      return $http.put(url, data)
         .then(function (result) {
           return result.data;
         }, $rootScope.$broadcast.bind($rootScope, 'error'));

--- a/client/app/environments/dialogs/asg/asgServices.js
+++ b/client/app/environments/dialogs/asg/asgServices.js
@@ -62,7 +62,7 @@ angular.module('EnvironmentManager.environments').component('asgServices', {
         modal.confirmation({
           title: 'Delete Auto Scaling Group?',
           message: 'There are no longer any active services for this ASG. Would you like ' +
-            'to delete the ASG and it\'s associated Launch Configuration?',
+          'to delete the ASG and it\'s associated Launch Configuration?',
           severity: 'Warning'
         }).then(function () {
           vm.asg.delete().then(function () {
@@ -79,19 +79,27 @@ angular.module('EnvironmentManager.environments').component('asgServices', {
         promise = modal.confirmation({
           title: 'Disable service deployment?',
           message: 'This will prevent service <strong>' + service.Name + (service.Slice === 'none' ? '' : service.Slice) +
-            ' version ' + service.Version + '</strong> from ' +
-            'being deployed to new instances from now on. It will NOT affect any existing machines.' +
-            'You can use this option to effectively uninstall this service by scaling the ASG to create a new set of servers.<br/>' +
-            'Are you sure you want to continue?',
+          ' version ' + service.Version + '</strong> from ' +
+          'being deployed to new instances from now on. It will NOT affect any existing machines.' +
+          'You can use this option to effectively uninstall this service by scaling the ASG to create a new set of servers.<br/>' +
+          'Are you sure you want to continue?',
           severity: 'Warning'
         });
       }
       promise.then(function () {
-        targetStateService.changeDeploymentAction(service.DeploymentId, enableService).then(function (result) {
-          service.Action = result.Action;
-          checkIfAllServicesDisabled();
-          vm.refresh();
-        });
+        var environment = vm.asg.Environment;
+        var serviceName = service.Name;
+        var enable = enableService;
+        var slice = service.Slice;
+        var serverRole = vm.asg.Role;
+        var EnvironmentType = vm.asg.EnvironmentType;
+
+        targetStateService.toggleServiceStatus(environment, serviceName, slice, enable, serverRole, EnvironmentType)
+          .then(function (result) {
+            service.Action = result.Action;
+            checkIfAllServicesDisabled();
+            vm.refresh();
+          });
       }, function () {
         service.installationEnabled = true;
       });

--- a/server/api/controllers/deployments/deploymentsController.js
+++ b/server/api/controllers/deployments/deploymentsController.js
@@ -184,6 +184,12 @@ function patchDeployment(req, res, next) {
 
 function switchDeployment(key, enable, user) {
   return deploymentsHelper.get({ key }).then((deployment) => {
+    // Old deployments don't have 'ServerRoleName' and 'RuntimeServerRoleName' fields.
+    // Unfortunately we are unable to determine these from existing data.
+    if (deployment.Value.ServerRoleName === undefined || deployment.Value.RuntimeServerRoleName === undefined) {
+      throw new Error('This operation is unsupported for Deployments started before 01.2017. If you would like to use this feature,'
+        + 'please redeploy your service before trying again, or contact Platform Dev team.');
+    }
     let serverRole = deployment.Value.RuntimeServerRoleName;
     let environment = deployment.Value.EnvironmentName;
     let slice = deployment.Value.ServiceSlice;

--- a/server/api/controllers/target-state/targetStateController.js
+++ b/server/api/controllers/target-state/targetStateController.js
@@ -4,6 +4,7 @@
 
 let GetServerRoles = require('queryHandlers/services/GetServerRoles');
 let deleteTargetState = require('modules/environment-state/deleteTargetState');
+const { toggleServiceStatus } = require('modules/toggleServiceStatus');
 const sns = require('modules/sns/EnvironmentManagerEvents');
 
 /**
@@ -93,9 +94,27 @@ function deleteTargetStateByServiceVersion(req, res, next) {
     .catch(next);
 }
 
+/**
+ * PUT /target-state/{environment}/{service}/toggle-status
+ */
+function toggleServiceStatusHandler(req, res, next) {
+  const environment = req.swagger.params.environment.value;
+  const service = req.swagger.params.service.value;
+  const body = req.swagger.params.body.value;
+  const enable = body.Enable;
+  const slice = body.Slice;
+  const serverRole = body.ServerRole;
+  const user = req.user;
+
+  toggleServiceStatus({ environment, service, slice, enable, serverRole, user })
+    .then((data) => { res.json(data); })
+    .catch(next);
+}
+
 module.exports = {
   getTargetState,
   deleteTargetStateByEnvironment,
   deleteTargetStateByService,
-  deleteTargetStateByServiceVersion
+  deleteTargetStateByServiceVersion,
+  toggleServiceStatusHandler
 };

--- a/server/api/swagger.yaml
+++ b/server/api/swagger.yaml
@@ -1105,6 +1105,45 @@ paths:
       responses:
         200:
           description: OK
+  /target-state/{environment}/{service}/toggle-status:
+    x-swagger-router-controller: targetStateController
+    put:
+      operationId: toggleServiceStatusHandler
+      summary: Disable/Enable a service in the target state key value store.
+      tags:
+        - Target State
+      x-authorizer: environments
+      parameters:
+        - name: environment
+          in: path
+          type: string
+          required: true
+        - name: service
+          in: path
+          type: string
+          required: true
+        - name: body
+          in: body
+          required: true
+          schema:
+            type: object
+            required:
+              - Enable
+              - Slice
+              - ServerRole
+              - EnvironmentType
+            properties:
+              Enable:
+                type: boolean
+              Slice:
+                type: string
+              ServerRole:
+                type: string
+              EnvironmentType:
+                type: string
+      responses:
+        200:
+          description: OK
   /target-state/{environment}/{service}/{version}:
     x-swagger-router-controller: targetStateController
     delete:

--- a/server/modules/toggleServiceStatus.js
+++ b/server/modules/toggleServiceStatus.js
@@ -1,0 +1,15 @@
+/* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
+
+'use strict';
+
+let sender = require('modules/sender');
+
+function toggleServiceStatus({ environment, service, slice, enable, serverRole, user }) {
+  const name = 'ToggleTargetStatus';
+  const command = { name, environment, service, slice, enable, serverRole };
+  return sender.sendCommand({ user, command });
+}
+
+module.exports = {
+  toggleServiceStatus
+};

--- a/server/test/modules/toggleServiceStatus.spec.js
+++ b/server/test/modules/toggleServiceStatus.spec.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const rewire = require('rewire');
+const sinon = require('sinon');
+const assert = require('assert');
+
+describe.only('toggleServiceStatus', () => {
+  let sut;
+  let senderSpy;
+
+  beforeEach(() => {
+    sut = rewire('modules/toggleServiceStatus');
+    senderSpy = sinon.spy();
+    // eslint-disable-next-line no-underscore-dangle
+    sut.__set__('sender', {
+      sendCommand: (input) => {
+        return Promise.resolve(senderSpy(input));
+      }
+    });
+  });
+
+  it('should send the correct message to sender', (done) => {
+    sut.toggleServiceStatus({
+      environment: 'environment',
+      service: 'service',
+      slice: 'slice',
+      enable: true,
+      serverRole: 'serverRole',
+      user: {}
+    })
+      .then(() => {
+        assert(senderSpy.calledWith({
+          user: {},
+          command: {
+            name: 'ToggleTargetStatus',
+            environment: 'environment',
+            service: 'service',
+            slice: 'slice',
+            enable: true,
+            serverRole: 'serverRole'
+          }
+        }));
+        done();
+      });
+  });
+});

--- a/server/test/modules/toggleServiceStatus.spec.js
+++ b/server/test/modules/toggleServiceStatus.spec.js
@@ -4,7 +4,7 @@ const rewire = require('rewire');
 const sinon = require('sinon');
 const assert = require('assert');
 
-describe.only('toggleServiceStatus', () => {
+describe('toggleServiceStatus', () => {
   let sut;
   let senderSpy;
 


### PR DESCRIPTION
## Server Side
- New public API endpoint for `PUT /target-state/{environment}/{service}/toggle-status`
- This will toggle the status of a service in a given environment
- It uses the same underlying `command` that the deployments API uses to perform basically the same operation. 
- Pulled the body of the  `switchDeployment` out to be used by the target state controller in addition to the deployment controller. Simple test file in place to make sure the commands that were passed to `sender` continue to be passed. 

## Client Side
- `targetStateService` now points to the new end point. 
- The name of the exported function from `targetStateService` has been changed to better reflect what it is doing. 