### PR TITLE
Fix for user object within the cache reset logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## [Unreleased]
 
+### Fixed
+- Logging for cache reset was causing server errors due to not having access to a user object. This has been resolved. [#344]
+
 ### Added
 - Toggle APIs now support the ability to explicitly set the desired state of an upstream or service
 
@@ -167,3 +170,4 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 [#338]: https://github.com/trainline/environment-manager/pull/338
 [#336]: https://github.com/trainline/environment-manager/pull/336
 [#340]: https://github.com/trainline/environment-manager/pull/340
+[#344]: https://github.com/trainline/environment-manager/pull/344

--- a/server/modules/cacheRouter.js
+++ b/server/modules/cacheRouter.js
@@ -6,6 +6,7 @@ let express = require('express');
 let router = express.Router();
 let assert = require('assert');
 let remoteCacheFlush = require('modules/remoteCacheFlush');
+let cookieAuthentication = require('modules/authentications/cookieAuthentication');
 let logger = require('modules/logger');
 
 router.post('/:environment', (req, res) => {
@@ -14,10 +15,12 @@ router.post('/:environment', (req, res) => {
   const hosts = req.body.hosts;
   const environment = req.params.environment;
 
-  logger.info(`Request to reset cache in ${environment} by user ${req.user.getName()}`);
-
-  remoteCacheFlush.flush(environment, hosts)
-    .then(() => res.status(200).send('[cachereset::success]'))
+  cookieAuthentication.middleware(req, res, _ => 0)
+    .then(() => {
+      logger.info(`Request to reset cache in ${environment} by user ${req.user.getName()}`);
+      return remoteCacheFlush.flush(environment, hosts)
+        .then(() => res.status(200).send('[cachereset::success]'));
+    })
     .catch(e => res.status(400).send('[cachereset::error]: ', e.message));
 });
 


### PR DESCRIPTION
Logging for cache reset was causing server errors due to not having access to a user object. This has been resolved.