### PR TITLE
Limit service version identifiers to 100 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Fixed
 
 - Environment Manager Sensu Alerts for Node
+- [Truncation of service version identifiers at 50 characters in the UI](https://gitlab.tools.trainline.eu/capitainetrain/mweb/issues/487). Service version identifiers now limited to 100 characters in UI and API. User notified if a longer version identifier is pasted into UI. [#347]
 
 ## [Released]
 
@@ -191,3 +192,4 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 [#343]: https://github.com/trainline/environment-manager/pull/343
 [#344]: https://github.com/trainline/environment-manager/pull/344
 [#346]: https://github.com/trainline/environment-manager/pull/346
+[#347]: https://github.com/trainline/environment-manager/pull/347

--- a/client/app/environments/dialogs/env-deploy-modal.html
+++ b/client/app/environments/dialogs/env-deploy-modal.html
@@ -48,10 +48,11 @@
                name="Version"
                class="form-control"
                required=""
-               maxlength="50"
+               ng-maxlength="100"
                ng-model="vm.deploymentSettings.Version" />
       </div>
       <span class="help-block" ng-if="form.Version.$dirty && form.Version.$error.required">Service version is mandatory.</span>
+      <span class="help-block" ng-if="form.Version.$dirty && form.Version.$error.maxlength">Service version is too long.</span>
     </div>
     <div class="form-group">
       <label class="col-md-3 control-label text-left">Mode:</label>

--- a/server/api/swagger.yaml
+++ b/server/api/swagger.yaml
@@ -3323,6 +3323,7 @@ definitions:
         type: string
       version:
         type: string
+        maxLength: 100
       mode:
         type: string
         enum:
@@ -3495,6 +3496,7 @@ parameters:
     required: true
     type: string
     pattern: (0|[1-9]\d*)(\.(0|[1-9]\d*)){2}(-[\da-zA-Z\-]+(\.[\da-zA-Z\-]+)*)?(\+[\da-zA-Z\-]+(\.[\da-zA-Z\-]+)*)?
+    maxLength: 100
   package-environment:
     name: environment
     description: The name of the environment targeted by this package.


### PR DESCRIPTION
## Description

Limit service version identifiers to 100 characters in the UI and the API. Notify the user if a longer version identifier is pasted into the version text box.

![image](https://user-images.githubusercontent.com/3935360/31011639-eacc1652-a506-11e7-97d5-6d5b9da7927b.png)

## References

* [GitLab](https://gitlab.tools.trainline.eu/capitainetrain/mweb/issues/487),
* [Jira](https://jira.thetrainline.com/browse/PD-435)