### PR TITLE
Set Consul ACL cache TTL to 10 minutes, not 10 seconds

### DIFF
--- a/server/modules/consulSecretCache.js
+++ b/server/modules/consulSecretCache.js
@@ -6,7 +6,9 @@ let awsMasterClient = require('modules/amazon-client/masterAccountClient');
 let cacheManager = require('modules/cacheManager');
 let logger = require('modules/logger');
 
-cacheManager.create('ConsulToken', createToken, { stdTTL: 10 });
+const TTL = 10 * 60 // seconds
+
+cacheManager.create('ConsulToken', createToken, { stdTTL: TTL });
 
 /**
  * retrieve a ConsulToken

--- a/server/modules/consulSecretCache.js
+++ b/server/modules/consulSecretCache.js
@@ -6,7 +6,7 @@ let awsMasterClient = require('modules/amazon-client/masterAccountClient');
 let cacheManager = require('modules/cacheManager');
 let logger = require('modules/logger');
 
-const TTL = 10 * 60 // seconds
+const TTL = 10 * 60; // seconds
 
 cacheManager.create('ConsulToken', createToken, { stdTTL: TTL });
 


### PR DESCRIPTION
The Consul ACL token was being invalidated every 10 seconds. This fix sets the TTL to 10 minutes.