### PR TITLE
Fixed filtering in deployments 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed a bug in the deployments screen where $http requests were not being cancelled properly if the request did not complete and the filter was changed. Incorrect results were being displayed.
+
 ## [6.9.0] 2017-09-26
 
 ### Fixed

--- a/client/app/common/models/Deployment.js
+++ b/client/app/common/models/Deployment.js
@@ -44,12 +44,16 @@ angular.module('EnvironmentManager.common').factory('Deployment',
     });
 
     Deployment.getAll = function (params) {
-      return $http({
+      var cancellable = $q.defer();
+      var promise = $http({
         url: baseUrl,
-        params: params
+        params: params,
+        timeout: cancellable.promise
       }).then(function (response) {
         return response.data;
       });
+      promise.abort = function(){ cancellable.resolve(); }
+      return promise;
     };
 
     Deployment.getById = function (accountName, deploymentId) {

--- a/client/app/operations/deployments/opsDeploymentsList.js
+++ b/client/app/operations/deployments/opsDeploymentsList.js
@@ -18,8 +18,10 @@ angular.module('EnvironmentManager.operations').component('opsDeploymentsList', 
 
     function refresh() {
       vm.dataLoading = true;
-
-      Deployment.getAll(vm.query).then(function (data) {
+      if (vm.currentRequest) vm.currentRequest.abort();
+      vm.currentRequest = Deployment.getAll(vm.query);
+      vm.currentRequest.then(function (data) {
+        vm.currentRequest = null;
         vm.deployments = data.map(Deployment.convertToListView);
         vm.uniqueServices = _.uniq(data.map(function (d) { return d.Value.ServiceName; }));
         vm.dataLoading = false;


### PR DESCRIPTION
So that previous calls to $http are cancelled properly if filters are changed before the $http request completes. This can cause race conditions that cause incorrect results to be displayed