### PR TITLE
Default min and max ASG size to desired size when creating scheduled actions

### DIFF
--- a/server/commands/asg/SetAutoScalingGroupSchedule.js
+++ b/server/commands/asg/SetAutoScalingGroupSchedule.js
@@ -83,6 +83,7 @@ function setAutoScalingGroupScheduleTag(client, autoScalingGroupName, schedule) 
 }
 
 function setAutoScalingGroupScalingSchedule(client, autoScalingGroupName, newScheduledActions) {
+  let defaultIfNil = (def, obj) => (obj !== null && obj !== undefined ? obj : def);
   return co(function* () {
     let existingScheduledActions = yield getScheduledActions(client, autoScalingGroupName);
     yield existingScheduledActions.map(action => deleteScheduledAction(client, action));
@@ -90,11 +91,12 @@ function setAutoScalingGroupScalingSchedule(client, autoScalingGroupName, newSch
     if (!(newScheduledActions instanceof Array)) return Promise.resolve();
 
     return yield newScheduledActions.map((action, index) => {
+      let desiredCapacityIfNil = defaultIfNil.bind(null, action.DesiredCapacity);
       let namedAction = {
         AutoScalingGroupName: autoScalingGroupName,
         ScheduledActionName: `EM-Scheduled-Action-${index + 1}`,
-        MinSize: action.MinSize,
-        MaxSize: action.MaxSize,
+        MinSize: desiredCapacityIfNil(action.MinSize),
+        MaxSize: desiredCapacityIfNil(action.MaxSize),
         DesiredCapacity: action.DesiredCapacity,
         Recurrence: action.Recurrence
       };

--- a/server/test/commands/asg/SetAutoScalingGroupScheduleTest.js
+++ b/server/test/commands/asg/SetAutoScalingGroupScheduleTest.js
@@ -1,0 +1,79 @@
+'use strict';
+
+let proxyquire = require('proxyquire').noCallThru();
+require('should');
+let sinon = require('sinon');
+
+const MUT = '../../../commands/asg/SetAutoScalingGroupSchedule';
+
+function createFixture({
+  autoScalingGroupClientFactory = { create() { return Promise.resolve({ setTag() { }, createScheduledAction() { } }); } }
+}) {
+  let fakes = {
+    '../../modules/clientFactories/autoScalingGroupClientFactory': autoScalingGroupClientFactory,
+    '../../modules/clientFactories/ec2InstanceClientFactory': {},
+    '../../models/AutoScalingGroup': {}
+  };
+  return proxyquire(MUT, fakes);
+}
+
+describe('SetAutoScalingGroupSchedule', function () {
+  describe('When I set a schedule that resizes the auto scaling group', function () {
+    context('and the auto scaling group has no pre-existing scheduled actions', function () {
+      context('and I do not specify min and max sizes', function () {
+        function setup() {
+          let createScheduledAction = sinon.spy(() => Promise.resolve());
+          let sut = createFixture({
+            autoScalingGroupClientFactory: {
+              create() {
+                return Promise.resolve({
+                  setTag() { return Promise.resolve(); },
+                  createScheduledAction,
+                  describeScheduledActions() { return Promise.resolve([]); }
+                });
+              }
+            }
+          });
+          return {
+            createScheduledAction,
+            sut
+          };
+        }
+        it('the min size defaults to the desired size', function () {
+          let { createScheduledAction, sut } = setup();
+          return sut({
+            schedule: [
+              { MaxSize: 9, DesiredCapacity: 2, Recurrence: '0 8 * * 1,2,3,4,5' },
+              { MaxSize: 9, DesiredCapacity: 3, Recurrence: '0 19 * * 1,2,3,4,5' }
+            ]
+          }).then(() => {
+            sinon.assert.calledTwice(createScheduledAction);
+            sinon.assert.calledWithMatch(createScheduledAction, {
+              MinSize: 2
+            });
+            sinon.assert.calledWithMatch(createScheduledAction, {
+              MinSize: 3
+            });
+          });
+        });
+        it('the max size defaults to the desired size', function () {
+          let { createScheduledAction, sut } = setup();
+          return sut({
+            schedule: [
+              { MinSize: 9, DesiredCapacity: 2, Recurrence: '0 8 * * 1,2,3,4,5' },
+              { MinSize: 9, DesiredCapacity: 3, Recurrence: '0 19 * * 1,2,3,4,5' }
+            ]
+          }).then(() => {
+            sinon.assert.calledTwice(createScheduledAction);
+            sinon.assert.calledWithMatch(createScheduledAction, {
+              MaxSize: 2
+            });
+            sinon.assert.calledWithMatch(createScheduledAction, {
+              MaxSize: 3
+            });
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
PUT /api/v1/asgs/{name}/scaling-schedule

used to require
```
"schedule": [
  { "MinSize":"3", "MaxSize":"3", "DesiredCapacity":"3", "Recurrence":"00 22 * * 1,2,3,4,5" }
]
```
now the MinSize and MaxSize properties may be omitted:
```
"schedule": [
  { "DesiredCapacity":"3", "Recurrence":"00 22 * * 1,2,3,4,5" }
]
```

https://jira.thetrainline.com/browse/PD-795