### PR TITLE
Redefine the duration by which an AMI is outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 [Unreleased]
 
+### Fixed
+
+- Days out of date for an AMI is now the number of days between the release of the following stable AMI and today.
+
 ## [6.12.1] - 2017-11-16
 
 ### Fixed

--- a/server/modules/machineImage/imageSummary.js
+++ b/server/modules/machineImage/imageSummary.js
@@ -4,8 +4,11 @@
 
 let _ = require('lodash/fp');
 let ChronoUnit = require('js-joda').ChronoUnit;
+let { Clock } = require('js-joda');
 let Instant = require('js-joda').Instant;
 let semver = require('semver');
+
+let clock = Clock.systemUTC();
 
 module.exports = {
   isCompatibleImage,
@@ -23,10 +26,10 @@ function isCompatibleImage(amiName) {
   return /^[a-zA-Z0-9.-]+-[0-9]+\.[0-9]+\.[0-9]+$/.test(amiName);
 }
 
-function daysBetween(selected, stable) {
+function daysBetween(selected, now) {
   let created = image => Instant.parse(image.CreationDate);
   try {
-    return created(selected).until(created(stable), ChronoUnit.DAYS);
+    return created(selected).until(now, ChronoUnit.DAYS);
   } catch (error) {
     return 0;
   }
@@ -110,7 +113,7 @@ function rank(summaries) {
     summary.Rank = i;
     summary.IsLatest = isLatest;
     summary.IsLatestStable = isLatestStable;
-    summary.DaysBehindLatest = (summary.AmiType === latestStable.AmiType) ? daysBetween(summary, latestStable) : 0;
+    summary.DaysBehindLatest = (summary.AmiType === latestStable.AmiType) ? daysBetween(prevStable, clock.instant()) : 0;
     prev = summary;
     if (summary.IsStable) {
       prevStable = summary;

--- a/server/test/modules/machineImage/imageSummaryTest.js
+++ b/server/test/modules/machineImage/imageSummaryTest.js
@@ -1,13 +1,11 @@
-/* TODO: enable linting and fix resulting errors */
-/* eslint-disable */
 /* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
+
 'use strict';
 
-let should = require('should');
+require('should');
 let sut = require('../../../modules/machineImage/imageSummary');
 
 describe('imageSummary', function () {
-
   describe('isStable', function () {
     context('when the image has a stable tag', function () {
       it('return true', function () {
@@ -24,11 +22,11 @@ describe('imageSummary', function () {
     context('when the image is not stable', function () {
       let testCases = [
         { Tags: [{ Key: 'sTaBlE', Value: '' }] },
-        { Description: 'not quite StAbLe' },
+        { Description: 'not quite StAbLe' }
       ];
 
       for (let testCase of testCases) {
-        it('returns false when description is ' + testCase.Description, function () {
+        it(`returns false when description is ${testCase.Description}`, function () {
           sut.isStable(testCase).should.be.false();
         });
       }
@@ -78,7 +76,6 @@ describe('imageSummary', function () {
   });
 
   describe('compare', function () {
-
     let testCases = [
       { x: null, y: null, result: 0 },
       { x: { AmiType: null, AmiVersion: null }, y: { AmiType: null, AmiVersion: null }, result: 0 },
@@ -92,7 +89,7 @@ describe('imageSummary', function () {
       { x: { AmiType: 'A', AmiVersion: null }, y: { AmiType: 'B', AmiVersion: null }, result: -1 },
 
       { x: { AmiType: 'A', AmiVersion: '0.0.0' }, y: { AmiType: 'B', AmiVersion: '0.0.1' }, result: -1 },
-      { x: { AmiType: 'A', AmiVersion: '0.0.1' }, y: { AmiType: 'B', AmiVersion: '0.0.0' }, result: -1 },
+      { x: { AmiType: 'A', AmiVersion: '0.0.1' }, y: { AmiType: 'B', AmiVersion: '0.0.0' }, result: -1 }
     ];
 
     for (let testCase of testCases) {
@@ -105,35 +102,34 @@ describe('imageSummary', function () {
   });
 
   describe('rank', function () {
-
     let testCases = [
       [
-        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: false, IsLatest: true, IsLatestStable: false, Rank: 1 },
+        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: false, IsLatest: true, IsLatestStable: false, Rank: 1 }
       ],
       [
-        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, IsLatest: true, IsLatestStable: true, Rank: 1 },
+        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, IsLatest: true, IsLatestStable: true, Rank: 1 }
       ],
       [
         { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, IsLatest: false, IsLatestStable: true, Rank: 2 },
-        { AmiType: 'A', AmiVersion: '0.0.2', IsStable: false, IsLatest: true, IsLatestStable: false, Rank: 1 },
+        { AmiType: 'A', AmiVersion: '0.0.2', IsStable: false, IsLatest: true, IsLatestStable: false, Rank: 1 }
       ],
       [
         { AmiType: 'A', AmiVersion: '0.0.1', IsStable: false, IsLatest: false, IsLatestStable: false, Rank: 3 },
         { AmiType: 'A', AmiVersion: '0.0.2', IsStable: true, IsLatest: false, IsLatestStable: true, Rank: 2 },
-        { AmiType: 'A', AmiVersion: '0.0.3', IsStable: false, IsLatest: true, IsLatestStable: false, Rank: 1 },
+        { AmiType: 'A', AmiVersion: '0.0.3', IsStable: false, IsLatest: true, IsLatestStable: false, Rank: 1 }
       ],
       [
         { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, IsLatest: false, IsLatestStable: true, Rank: 2 },
         { AmiType: 'A', AmiVersion: '0.0.2', IsStable: false, IsLatest: true, IsLatestStable: false, Rank: 1 },
         { AmiType: 'B', AmiVersion: '0.0.1', IsStable: false, IsLatest: false, IsLatestStable: false, Rank: 3 },
         { AmiType: 'B', AmiVersion: '0.0.2', IsStable: true, IsLatest: false, IsLatestStable: true, Rank: 2 },
-        { AmiType: 'B', AmiVersion: '0.0.3', IsStable: false, IsLatest: true, IsLatestStable: false, Rank: 1 },
-      ],
+        { AmiType: 'B', AmiVersion: '0.0.3', IsStable: false, IsLatest: true, IsLatestStable: false, Rank: 1 }
+      ]
     ];
 
     for (let testCase of testCases) {
       testCase.sort(sut.compare);
-      let input = testCase.map(x => {
+      let input = testCase.map((x) => {
         let y = Object.assign({}, x);
         delete y.IsLatest;
         delete y.IsLatestStable;
@@ -150,28 +146,28 @@ describe('imageSummary', function () {
 
     let daysBehindLatestTestCases = [
       [
-        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: false, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 0 },
+        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: false, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 0 }
+      ],
+      [
+        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 0 }
       ],
       [
         { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 0 },
+        { AmiType: 'A', AmiVersion: '0.0.2', IsStable: false, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 0 }
       ],
       [
-        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 0 },
-        { AmiType: 'A', AmiVersion: '0.0.2', IsStable: false, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 0 },
+        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 1 },
+        { AmiType: 'A', AmiVersion: '0.0.2', IsStable: true, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 0 }
       ],
       [
         { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 1 },
         { AmiType: 'A', AmiVersion: '0.0.2', IsStable: true, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 0 },
-      ],
-      [
-        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 1 },
-        { AmiType: 'A', AmiVersion: '0.0.2', IsStable: true, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 0 },
-        { AmiType: 'A', AmiVersion: '0.0.3', IsStable: false, CreationDate: '2000-01-03T00:00:00.000Z', DaysBehindLatest: 0 },
+        { AmiType: 'A', AmiVersion: '0.0.3', IsStable: false, CreationDate: '2000-01-03T00:00:00.000Z', DaysBehindLatest: 0 }
       ],
       [
         { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 2 },
         { AmiType: 'A', AmiVersion: '0.0.2', IsStable: false, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 1 },
-        { AmiType: 'A', AmiVersion: '0.0.3', IsStable: true, CreationDate: '2000-01-03T00:00:00.000Z', DaysBehindLatest: 0 },
+        { AmiType: 'A', AmiVersion: '0.0.3', IsStable: true, CreationDate: '2000-01-03T00:00:00.000Z', DaysBehindLatest: 0 }
       ],
       [
         { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 1 },
@@ -179,13 +175,13 @@ describe('imageSummary', function () {
         { AmiType: 'A', AmiVersion: '0.0.3', IsStable: false, CreationDate: '2000-01-03T00:00:00.000Z', DaysBehindLatest: 0 },
         { AmiType: 'B', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 2 },
         { AmiType: 'B', AmiVersion: '0.0.2', IsStable: true, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 1 },
-        { AmiType: 'B', AmiVersion: '0.0.3', IsStable: true, CreationDate: '2000-01-03T00:00:00.000Z', DaysBehindLatest: 0 },
-      ],
+        { AmiType: 'B', AmiVersion: '0.0.3', IsStable: true, CreationDate: '2000-01-03T00:00:00.000Z', DaysBehindLatest: 0 }
+      ]
     ];
 
     for (let testCase of daysBehindLatestTestCases) {
       testCase.sort(sut.compare);
-      let input = testCase.map(x => {
+      let input = testCase.map((x) => {
         let y = Object.assign({}, x);
         delete y.DaysBehindLatest;
         return y;

--- a/server/test/modules/machineImage/imageSummaryTest.js
+++ b/server/test/modules/machineImage/imageSummaryTest.js
@@ -2,8 +2,20 @@
 
 'use strict';
 
+let proxyquire = require('proxyquire');
 require('should');
-let sut = require('../../../modules/machineImage/imageSummary');
+let { Clock, Instant } = require('js-joda');
+
+
+let sut = proxyquire('../../../modules/machineImage/imageSummary', {
+  'js-joda': {
+    Clock: {
+      systemUTC() {
+        return Clock.fixed(Instant.parse('2000-01-10T00:00:00.000Z'));
+      }
+    }
+  }
+});
 
 describe('imageSummary', function () {
   describe('isStable', function () {
@@ -156,25 +168,25 @@ describe('imageSummary', function () {
         { AmiType: 'A', AmiVersion: '0.0.2', IsStable: false, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 0 }
       ],
       [
-        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 1 },
+        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 8 },
         { AmiType: 'A', AmiVersion: '0.0.2', IsStable: true, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 0 }
       ],
       [
-        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 1 },
+        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 8 },
         { AmiType: 'A', AmiVersion: '0.0.2', IsStable: true, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 0 },
         { AmiType: 'A', AmiVersion: '0.0.3', IsStable: false, CreationDate: '2000-01-03T00:00:00.000Z', DaysBehindLatest: 0 }
       ],
       [
-        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 2 },
-        { AmiType: 'A', AmiVersion: '0.0.2', IsStable: false, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 1 },
+        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 7 },
+        { AmiType: 'A', AmiVersion: '0.0.2', IsStable: false, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 7 },
         { AmiType: 'A', AmiVersion: '0.0.3', IsStable: true, CreationDate: '2000-01-03T00:00:00.000Z', DaysBehindLatest: 0 }
       ],
       [
-        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 1 },
+        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 8 },
         { AmiType: 'A', AmiVersion: '0.0.2', IsStable: true, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 0 },
         { AmiType: 'A', AmiVersion: '0.0.3', IsStable: false, CreationDate: '2000-01-03T00:00:00.000Z', DaysBehindLatest: 0 },
-        { AmiType: 'B', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 2 },
-        { AmiType: 'B', AmiVersion: '0.0.2', IsStable: true, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 1 },
+        { AmiType: 'B', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 8 },
+        { AmiType: 'B', AmiVersion: '0.0.2', IsStable: true, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 7 },
         { AmiType: 'B', AmiVersion: '0.0.3', IsStable: true, CreationDate: '2000-01-03T00:00:00.000Z', DaysBehindLatest: 0 }
       ]
     ];
@@ -187,7 +199,7 @@ describe('imageSummary', function () {
         return y;
       });
 
-      context(`${JSON.stringify(input)}`, function () {
+      context.only(`${JSON.stringify(input)}`, function () {
         it(`should return ${JSON.stringify(testCase)}`, function () {
           sut.rank(input).should.match(testCase);
         });

--- a/server/test/modules/machineImage/imageSummaryTest.js
+++ b/server/test/modules/machineImage/imageSummaryTest.js
@@ -172,6 +172,10 @@ describe('imageSummary', function () {
         { AmiType: 'A', AmiVersion: '0.0.2', IsStable: true, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 0 }
       ],
       [
+        { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, Tags: [{ Key: 'stable', Value: '2000-01-01T00:00:00.000Z' }], CreationDate: '1999-12-20T00:00:00.000Z', DaysBehindLatest: 8 },
+        { AmiType: 'A', AmiVersion: '0.0.2', IsStable: true, Tags: [{ Key: 'stable', Value: '2000-01-02T00:00:00.000Z' }], CreationDate: '1999-12-25T00:00:00.000Z', DaysBehindLatest: 0 }
+      ],
+      [
         { AmiType: 'A', AmiVersion: '0.0.1', IsStable: true, CreationDate: '2000-01-01T00:00:00.000Z', DaysBehindLatest: 8 },
         { AmiType: 'A', AmiVersion: '0.0.2', IsStable: true, CreationDate: '2000-01-02T00:00:00.000Z', DaysBehindLatest: 0 },
         { AmiType: 'A', AmiVersion: '0.0.3', IsStable: false, CreationDate: '2000-01-03T00:00:00.000Z', DaysBehindLatest: 0 }
@@ -199,7 +203,7 @@ describe('imageSummary', function () {
         return y;
       });
 
-      context.only(`${JSON.stringify(input)}`, function () {
+      context(`${JSON.stringify(input)}`, function () {
         it(`should return ${JSON.stringify(testCase)}`, function () {
           sut.rank(input).should.match(testCase);
         });
@@ -214,6 +218,36 @@ describe('imageSummary', function () {
           Name: 'windows-2012r2-ttl-app-7.0.17',
           Tags: [{ Key: 'Name', Value: '' }]
         }).should.have.property('Name').eql('windows-2012r2-ttl-app-7.0.17');
+      });
+    });
+  });
+
+  describe('date when image becomes stable', function () {
+    context('When there is no stable tag', function () {
+      it('Returns the image creation date', function () {
+        let testcase = {
+          CreationDate: '2000-01-01T00:00:00.000Z'
+        };
+        sut.getStableDate(testcase).should.match(Instant.parse(testcase.CreationDate));
+      });
+    });
+    context('When stable tag is not a valid date', function () {
+      it('Returns the image creation date', function () {
+        let testcase = {
+          CreationDate: '2000-01-01T00:00:00.000Z',
+          Tags: [{ Key: 'sTaBlE', Value: 1 }]
+        };
+        sut.getStableDate(testcase).should.match(Instant.parse(testcase.CreationDate));
+      });
+    });
+    context('When the stable tag is a valid date', function () {
+      it('Returns the stable tag value', function () {
+        const stableDate = '2000-01-11T00:00:00.1234567Z';
+        let testcase = {
+          CreationDate: '2000-01-01T00:00:00.000Z',
+          Tags: [{ Key: 'sTaBlE', Value: stableDate }]
+        };
+        sut.getStableDate(testcase).should.match(Instant.parse(stableDate));
       });
     });
   });


### PR DESCRIPTION
The duration by which an AMI is outdated was previously defined as the time elapsed between the creation of that AMI and the creation of the most recent stable AMI of the same type.

It is now defined as the time elapsed between the AMI ceasing to be the latest stable AMI of its type and now.

![image](https://user-images.githubusercontent.com/3935360/33083564-984bb87e-ced7-11e7-8622-aafcd526101f.png)

https://jira.thetrainline.com/browse/PD-57