### PR TITLE
 fix memoize for graphs containing objects that do not inherit from Object.prototype

### DIFF
--- a/server/modules/memoize.js
+++ b/server/modules/memoize.js
@@ -2,7 +2,7 @@
 
 'use strict';
 
-let deepFreeze = require('deep-freeze');
+let deepFreeze = require('deep-freeze-strict');
 
 function isPromise(obj) {
   return obj && obj.then && typeof obj.then === 'function';

--- a/server/package.json
+++ b/server/package.json
@@ -49,7 +49,7 @@
     "compression": "~1.6.2",
     "consul": "~0.27.0",
     "cookie-parser": "~1.4.3",
-    "deep-freeze": "~0.0.1",
+    "deep-freeze-strict": "^1.1.1",
     "es6-template-strings": "~2.0.1",
     "express": "~4.14.0",
     "express-request-id": "~1.3.0",

--- a/server/test/modules/memoizeTest.js
+++ b/server/test/modules/memoizeTest.js
@@ -39,6 +39,13 @@ describe('memoize', function () {
       g(1, 'one').should.be.eql(f(1, 'one'));
     });
   });
+  context('when I memoize a function that returns an object with no prototype', function () {
+    it('the first call to the memoized function returns the same result as the un-memoized function', function () {
+      let f = (x) => { let t = Object.create(null); t.x = x; return t; };
+      let g = memoize(f);
+      should.deepEqual(g(0), f(0));
+    });
+  });
   context('when I call the memoized function twice with the same arguments', function () {
     it('the un-memoized function is called once', function () {
       let f = sinon.spy(() => undefined);
@@ -59,9 +66,8 @@ describe('memoize', function () {
       let first = g(1, 'one');
       try {
         delete first.x;
-      } finally {
-        g(1, 'one').should.be.eql(f(1, 'one'));
-      }
+      } catch (error) {} // eslint-disable-line no-empty
+      g(1, 'one').should.be.eql(f(1, 'one'));
     });
   });
   context('when I call the memoized function twice with different arguments', function () {

--- a/server/test/modules/memoizeTest.js
+++ b/server/test/modules/memoizeTest.js
@@ -1,5 +1,3 @@
-/* TODO: enable linting and fix resulting errors */
-/* eslint-disable */
 'use strict';
 
 let memoize = require('../../modules/memoize');
@@ -7,78 +5,79 @@ let should = require('should');
 let sinon = require('sinon');
 
 describe('memoize', function () {
-    let typeInstances = [1, 's', {}, undefined, null, false,];
-    context('when I try to memoize a value that is not a function', function () {
-        typeInstances.forEach(instance => {
-            let type = instance === null ? 'null' : (typeof instance);
-            it(`and it is a ${type} an error tells me I can only memoize a function.`, function () {
-                (() => memoize(instance)).should.throw(/Can only memoize a function/);
-            });
-        });
+  let typeInstances = [1, 's', {}, undefined, null, false];
+  context('when I try to memoize a value that is not a function', function () {
+    typeInstances.forEach((instance) => {
+      let type = instance === null ? 'null' : (typeof instance);
+      it(`and it is a ${type} an error tells me I can only memoize a function.`, function () {
+        (() => memoize(instance)).should.throw(/Can only memoize a function/);
+      });
     });
-    context('when I memoize a function', function () {
-        it('the result is a function', function () {
-            memoize(() => undefined).should.be.Function();
-        });
-        it('the first call to the memoized function returns the same result as the un-memoized function', function () {
-            let f = (x, y) => ({ x, y });
-            let g = memoize(f);
-            g(1, 'one').should.be.eql(f(1, 'one'));
-        });
-        it('the result is immutable', function () {
-            let f = (x, y) => ({ x, nested: { y } });
-            let g = memoize(f);
-            let result = g(1, 'old');
-            let mutateResult = () => { result.nested.y = 'new'; return result };
-            mutateResult.should.throw();
-            result.nested.y.should.eql('old');
-        });
+  });
+  context('when I memoize a function', function () {
+    it('the result is a function', function () {
+      memoize(() => undefined).should.be.Function();
     });
-    context('when I memoize a function that returns a promise', function () {
-        it('the first call to the memoized function returns the same result as the un-memoized function', function () {
-            let f = x => Promise.resolve(Promise.resolve(x));
-            let g = memoize(f);
-            g(1, 'one').should.be.eql(f(1, 'one'));
-        });
+    it('the first call to the memoized function returns the same result as the un-memoized function', function () {
+      let f = (x, y) => ({ x, y });
+      let g = memoize(f);
+      g(1, 'one').should.be.eql(f(1, 'one'));
     });
-    context('when I call the memoized function twice with the same arguments', function () {
-        it('the un-memoized function is called once', function () {
-            let f = sinon.spy(() => undefined);
-            let g = memoize(f);
-            g(1, 2);
-            g(1, 2);
-            f.calledOnce.should.be.true();
-        });
-        it('the second call returns the same result as the un-memoized function', function () {
-            let f = (x, y) => ({ x, y });
-            let g = memoize(f);
-            g(1, 'one');
-            g(1, 'one').should.be.eql(f(1, 'one'));
-        });
-        it('mutating the result of the first call does not affect the result of the second', function () {
-            let f = (x, y) => ({ x, y });
-            let g = memoize(f);
-            let first = g(1, 'one');
-            try {
-                delete first.x;
-            } catch (error) {}
-            g(1, 'one').should.be.eql(f(1, 'one'));
-        });
+    it('the result is immutable', function () {
+      let f = (x, y) => ({ x, nested: { y } });
+      let g = memoize(f);
+      let result = g(1, 'old');
+      let mutateResult = () => { result.nested.y = 'new'; return result; };
+      mutateResult.should.throw();
+      result.nested.y.should.eql('old');
     });
-    context('when I call the memoized function twice with different arguments', function () {
-        it('the un-memoized function is called twice', function () {
-            let f = sinon.spy(() => undefined);
-            let g = memoize(f);
-            g(1, 2);
-            g(2, 1);
-            f.calledTwice.should.be.true();
-        });
-        it('the second call returns the same result as the un-memoized function', function () {
-            let f = (x, y) => ({ x, y });
-            let g = memoize(f);
-            g(1, 'one');
-            g(1, 'two').should.be.eql(f(1, 'two'));
-        });
+  });
+  context('when I memoize a function that returns a promise', function () {
+    it('the first call to the memoized function returns the same result as the un-memoized function', function () {
+      let f = x => Promise.resolve(Promise.resolve(x));
+      let g = memoize(f);
+      g(1, 'one').should.be.eql(f(1, 'one'));
     });
+  });
+  context('when I call the memoized function twice with the same arguments', function () {
+    it('the un-memoized function is called once', function () {
+      let f = sinon.spy(() => undefined);
+      let g = memoize(f);
+      g(1, 2);
+      g(1, 2);
+      f.calledOnce.should.be.true();
+    });
+    it('the second call returns the same result as the un-memoized function', function () {
+      let f = (x, y) => ({ x, y });
+      let g = memoize(f);
+      g(1, 'one');
+      g(1, 'one').should.be.eql(f(1, 'one'));
+    });
+    it('mutating the result of the first call does not affect the result of the second', function () {
+      let f = (x, y) => ({ x, y });
+      let g = memoize(f);
+      let first = g(1, 'one');
+      try {
+        delete first.x;
+      } finally {
+        g(1, 'one').should.be.eql(f(1, 'one'));
+      }
+    });
+  });
+  context('when I call the memoized function twice with different arguments', function () {
+    it('the un-memoized function is called twice', function () {
+      let f = sinon.spy(() => undefined);
+      let g = memoize(f);
+      g(1, 2);
+      g(2, 1);
+      f.calledTwice.should.be.true();
+    });
+    it('the second call returns the same result as the un-memoized function', function () {
+      let f = (x, y) => ({ x, y });
+      let g = memoize(f);
+      g(1, 'one');
+      g(1, 'two').should.be.eql(f(1, 'two'));
+    });
+  });
 });
 

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -550,9 +550,9 @@ deep-eql@^0.1.3:
   dependencies:
     type-detect "0.1.1"
 
-deep-freeze@~0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/deep-freeze/-/deep-freeze-0.0.1.tgz#3a0b0005de18672819dfd38cd31f91179c893e84"
+deep-freeze-strict@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/deep-freeze-strict/-/deep-freeze-strict-1.1.1.tgz#77d0583ca24a69be4bbd9ac2fae415d55523e5b0"
 
 deep-is@~0.1.3:
   version "0.1.3"


### PR DESCRIPTION
The `memoize` module previously used [deep-freeze], which [fails for graphs containing objects that do not inherit from `Object.prototype`](https://github.com/substack/deep-freeze/issues/13).

This change replaces [deep-freeze] with [deep-freeze-strict], which does not have this limitation.

[deep-freeze]: https://www.npmjs.com/package/deep-freeze
[deep-freeze-strict]: https://www.npmjs.com/package/deep-freeze-strict