### PR TITLE
Feature/user settings

### DIFF
--- a/client/app/app.module.js
+++ b/client/app/app.module.js
@@ -14,6 +14,7 @@ var app = angular.module('EnvironmentManager', [
   'EnvironmentManager.operations',
   'EnvironmentManager.configuration',
   'EnvironmentManager.compare',
+  'EnvironmentManager.settings',
   'angular-loading-bar',
   'smart-table',
   'highcharts-ng'

--- a/client/app/common/MainController.js
+++ b/client/app/common/MainController.js
@@ -5,7 +5,7 @@
 'use strict';
 
 angular.module('EnvironmentManager.common').controller('MainController',
-  function ($rootScope, $scope, $route, $routeParams, $http, $location, $window, modal, Environment, environmentDeploy, releasenotesservice) {
+  function ($rootScope, $scope, $route, $routeParams, $http, $location, $window, $uibModal, modal, Environment, environmentDeploy, releasenotesservice) {
     var vm = this;
 
     vm.appVersion = $window.version;
@@ -39,6 +39,18 @@ angular.module('EnvironmentManager.common').controller('MainController',
         return 'Unknown section';
       }
     };
+
+    vm.showUserSettings = function () {
+      $uibModal.open({
+        bindToController: true,
+        controller: 'UserSettingsController as vm',
+        templateUrl: '/app/settings/user-settings-modal.html'
+      });
+    }
+
+    vm.something = function () {
+      alert('hello')
+    }
 
     vm.logout = function () {
       $http.post('/api/v1/logout', {}).then(function () {

--- a/client/app/common/services/localStorageService.js
+++ b/client/app/common/services/localStorageService.js
@@ -27,7 +27,7 @@
     }
 
     function exists(key) {
-      if (get(key) === null) return false;
+      if (get(key) === null || get(key) === "") return false;
       return true;
     }
   }

--- a/client/app/environments/summary/EnvironmentsSummaryController.js
+++ b/client/app/environments/summary/EnvironmentsSummaryController.js
@@ -19,6 +19,7 @@ angular.module('EnvironmentManager.environments').controller('EnvironmentsSummar
     vm.environmentFilter;
 
     vm.hasUserSettings = localstorageservice.exists('em-settings-environments');
+    console.log(vm.hasUserSettings)
     vm.userSettings = localstorageservice.get('em-settings-environments');
     vm.toggleAllEnvironmentsLabel = vm.hasUserSettings ? "Show All Environments" : "Filter From User Settings";
 

--- a/client/app/environments/summary/EnvironmentsSummaryController.js
+++ b/client/app/environments/summary/EnvironmentsSummaryController.js
@@ -5,7 +5,7 @@
 'use strict';
 
 angular.module('EnvironmentManager.environments').controller('EnvironmentsSummaryController',
-  function ($scope, $routeParams, $location, $uibModal, $http, $q, modal, resources, cachedResources, Environment) {
+  function ($scope, $routeParams, $location, $uibModal, $http, $q, modal, resources, cachedResources, Environment, localstorageservice) {
     var vm = this;
 
     var SHOW_ALL_OPTION = 'Any';
@@ -17,6 +17,9 @@ angular.module('EnvironmentManager.environments').controller('EnvironmentsSummar
     vm.selectedEnvironmentType = SHOW_ALL_OPTION;
     vm.selectedOwningCluster = SHOW_ALL_OPTION;
     vm.environmentFilter;
+
+    vm.hasUserSettings = localstorageservice.exists('em-settings-environments');
+    vm.userSettings = localstorageservice.get('em-settings-environments');
 
     vm.dataLoading = false;
 
@@ -39,6 +42,10 @@ angular.module('EnvironmentManager.environments').controller('EnvironmentsSummar
         vm.refresh();
       });
     }
+
+    vm.showAllEnvironments = function () {
+      vm.filteredData = vm.data;
+    };
 
     vm.refresh = function () {
       vm.dataLoading = true;
@@ -83,6 +90,13 @@ angular.module('EnvironmentManager.environments').controller('EnvironmentsSummar
             return result;
           });
 
+        if (vm.hasUserSettings)
+          vm.filteredData = vm.data.filter(function (e) {
+            return vm.userSettings.split(',').includes(e.EnvironmentName);
+          });
+        else
+          vm.filteredData = vm.data;
+
         vm.dataLoading = false;
       });
     };
@@ -91,9 +105,9 @@ angular.module('EnvironmentManager.environments').controller('EnvironmentsSummar
       modal.confirmation({
         title: 'Delete Environment',
         message:
-        'Are you sure you want to delete the environment <strong>' + environment.EnvironmentName + '</strong>?<br /><br />' +
-        'This will permanently delete the environment as well as any associated load balancer settings and upstreams.' +
-        'It will not delete any associated AWS resources',
+          'Are you sure you want to delete the environment <strong>' + environment.EnvironmentName + '</strong>?<br /><br />' +
+          'This will permanently delete the environment as well as any associated load balancer settings and upstreams.' +
+          'It will not delete any associated AWS resources',
         action: 'Delete',
         severity: 'Danger'
       }).then(function () {

--- a/client/app/environments/summary/EnvironmentsSummaryController.js
+++ b/client/app/environments/summary/EnvironmentsSummaryController.js
@@ -20,6 +20,7 @@ angular.module('EnvironmentManager.environments').controller('EnvironmentsSummar
 
     vm.hasUserSettings = localstorageservice.exists('em-settings-environments');
     vm.userSettings = localstorageservice.get('em-settings-environments');
+    vm.toggleAllEnvironmentsLabel = vm.hasUserSettings ? "Show All Environments" : "Filter From User Settings";
 
     vm.dataLoading = false;
 
@@ -43,9 +44,15 @@ angular.module('EnvironmentManager.environments').controller('EnvironmentsSummar
       });
     }
 
-    vm.showAllEnvironments = function () {
-      vm.filteredData = vm.data;
-    };
+    vm.toggleAllEnvironments = function () {
+      if (vm.toggleAllEnvironmentsLabel === "Show All Environments") {
+        vm.toggleAllEnvironmentsLabel = "Filter From User Settings";
+        vm.displayData = vm.data;
+      } else {
+        vm.toggleAllEnvironmentsLabel = "Show All Environments";
+        vm.displayData = vm.filteredData;
+      }
+    }
 
     vm.refresh = function () {
       vm.dataLoading = true;
@@ -90,12 +97,14 @@ angular.module('EnvironmentManager.environments').controller('EnvironmentsSummar
             return result;
           });
 
-        if (vm.hasUserSettings)
+        if (vm.hasUserSettings) {
           vm.filteredData = vm.data.filter(function (e) {
             return vm.userSettings.split(',').includes(e.EnvironmentName);
           });
+          vm.displayData = vm.filteredData;
+        }
         else
-          vm.filteredData = vm.data;
+          vm.displayData = vm.data;
 
         vm.dataLoading = false;
       });

--- a/client/app/environments/summary/env-summary.html
+++ b/client/app/environments/summary/env-summary.html
@@ -14,7 +14,7 @@
     <input type="text" autofocus class="form-control" ng-model="vm.environmentFilter" placeholder="enter filter values...">
   </div>
   <div class="form-group">
-    <button class="btn btn-default right" ng-click="vm.showAllEnvironments()">Show All Environments</button>
+    <button class="btn btn-default right" ng-click="vm.toggleAllEnvironments()">{{vm.toggleAllEnvironmentsLabel}}</button>
   </div>
   <div class="form-group">
     <label class="control-label text-left">Environment Type:</label>
@@ -61,7 +61,7 @@
         </tr>
       </thead>
       <tbody>
-        <tr ng-repeat="env in vm.filteredData | orderBy : 'EnvironmentName' | filter : vm.environmentFilter">
+        <tr ng-repeat="env in vm.displayData | orderBy : 'EnvironmentName' | filter : vm.environmentFilter">
           <td>
             <span class="glyphicon glyphicon-lock" data-ng-if="env.Operation.DeploymentsLocked"></span>
             <span class="glyphicon glyphicon-wrench" data-ng-if="env.Operation.InMaintenance"></span>

--- a/client/app/environments/summary/env-summary.html
+++ b/client/app/environments/summary/env-summary.html
@@ -1,16 +1,20 @@
 <div class="row">
-  <div class="col-md-12"><h2>Environments</h2></div>
+  <div class="col-md-12">
+    <h2>Environments</h2>
+  </div>
   <div id="RefreshData">
-  <span class="glyphicon glyphicon-refresh" ng-click="vm.refresh()" title="Refresh data"></span>
+    <span class="glyphicon glyphicon-refresh" ng-click="vm.refresh()" title="Refresh data"></span>
   </div>
 </div>
-
 <form id="SearchFilter" class="form-inline">
   <div class="form-group">
     <label class="control-label text-left">Environment Filter:</label>
   </div>
   <div class="form-group">
     <input type="text" autofocus class="form-control" ng-model="vm.environmentFilter" placeholder="enter filter values...">
+  </div>
+  <div class="form-group">
+    <button class="btn btn-default right" ng-click="vm.showAllEnvironments()">Show All Environments</button>
   </div>
   <div class="form-group">
     <label class="control-label text-left">Environment Type:</label>
@@ -57,17 +61,21 @@
         </tr>
       </thead>
       <tbody>
-        <tr ng-repeat="env in vm.data | orderBy : 'EnvironmentName' | filter : vm.environmentFilter">
+        <tr ng-repeat="env in vm.filteredData | orderBy : 'EnvironmentName' | filter : vm.environmentFilter">
           <td>
             <span class="glyphicon glyphicon-lock" data-ng-if="env.Operation.DeploymentsLocked"></span>
             <span class="glyphicon glyphicon-wrench" data-ng-if="env.Operation.InMaintenance"></span>
           </td>
           <td>
-            <a href="#/environment/servers?environment={{env.EnvironmentName}}">{{env.EnvironmentName}} <small ng-if="env.Configuration.EnvironmentType">({{env.Configuration.EnvironmentType}})</small></a>
+            <a href="#/environment/servers?environment={{env.EnvironmentName}}">{{env.EnvironmentName}}
+              <small ng-if="env.Configuration.EnvironmentType">({{env.Configuration.EnvironmentType}})</small>
+            </a>
           </td>
           <td>{{env.Configuration.OwningCluster}}</td>
           <td>{{env.Configuration.Description}}</td>
-          <td><a href="#/config/deploymentmaps/{{env.Configuration.DeploymentMap}}" target="_blank">{{env.Configuration.DeploymentMap}}</a></td>
+          <td>
+            <a href="#/config/deploymentmaps/{{env.Configuration.DeploymentMap}}" target="_blank">{{env.Configuration.DeploymentMap}}</a>
+          </td>
           <td>
             <span ng-class="{'warning': env.Operation.getScheduleAction()==='OFF', 'ok': env.Operation.getScheduleAction()!=='OFF'}">
               {{env.Operation.getScheduleAction()}}

--- a/client/app/settings/UserSettingsController.js
+++ b/client/app/settings/UserSettingsController.js
@@ -1,0 +1,49 @@
+(function () {
+    'use strict';
+
+    angular
+        .module('EnvironmentManager.settings')
+        .controller('UserSettingsController', UserSettingsController);
+
+    UserSettingsController.$inject = ['$uibModal', '$uibModalInstance', 'localstorageservice'];
+
+    function UserSettingsController($uibModal, $uibModalInstance, localstorageservice) {
+        var vm = this;
+
+        vm.title = 'User Settings';
+        vm.loadSettings = loadSettings;
+        vm.save = save;
+        vm.closeAndSave = closeAndSave;
+
+        vm.settings = {};
+
+        loadSettings();
+
+        function save() {
+            _saveEnvironments();
+        }
+
+        function closeAndSave() {
+            save();
+            $uibModalInstance.close();
+        }
+
+        function close() {
+            $uibModalInstance.close();
+        }
+
+        function loadSettings() {
+            vm.settings.environments = localstorageservice.get('em-settings-environments');
+        }
+
+        function _saveEnvironments() {
+            var providedEnvironments = vm.settings.environments;
+            var listOfEnvironments = providedEnvironments.split(',').map(function (e) {
+                return e.trim();
+            });
+            var environmentsReadyToSave = listOfEnvironments.join(',');
+            vm.settings.environments = environmentsReadyToSave;
+            localstorageservice.set('em-settings-environments', environmentsReadyToSave);
+        }
+    }
+}());

--- a/client/app/settings/UserSettingsController.js
+++ b/client/app/settings/UserSettingsController.js
@@ -14,6 +14,7 @@
         vm.loadSettings = loadSettings;
         vm.save = save;
         vm.closeAndSave = closeAndSave;
+        vm.close = close;
 
         vm.settings = {};
 

--- a/client/app/settings/settings.module.js
+++ b/client/app/settings/settings.module.js
@@ -1,0 +1,5 @@
+/* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
+
+'use strict';
+
+angular.module('EnvironmentManager.settings', []);

--- a/client/app/settings/user-settings-modal.html
+++ b/client/app/settings/user-settings-modal.html
@@ -1,0 +1,20 @@
+<div class="modal-header">
+    <h2 class="text-{{vm.severity}}">{{vm.title}}</h2>
+</div>
+
+<div class="modal-body">
+    <form class="form-horizontal">
+        <div class="form-group">
+            <label for="environments" class="col-sm-2 control-label">Environments</label>
+            <div class="col-sm-10">
+                <input type="text" class="form-control" id="environments" ng-model="vm.settings.environments" placeholder="c01,c02,st1">
+            </div>
+        </div>
+    </form>
+</div>
+
+<div class="modal-footer">
+    <button class="btn btn-default" ng-click="vm.save()">Save</button>
+    <button class="btn btn-default" ng-click="vm.closeAndSave()">Save &amp; Close</button>
+    <button class="btn btn-warning" ng-click="vm.close()">Close</button>
+</div>

--- a/client/index.html
+++ b/client/index.html
@@ -68,6 +68,7 @@
   <script src="app/operations/operations.module.js"></script>
   <script src="app/operations/upstream/directives/lbServersStatesCell.js"></script>
   <script src="app/environments/environments.module.js"></script>
+  <script src="app/settings/settings.module.js"></script>
   <script src="app/environments/dialogs/asg/asgSingleService.js"></script>
   <script src="app/environments/dialogs/asg/asgSingleInstance.js"></script>
   <script src="app/environments/dialogs/asg/asgServices.js"></script>
@@ -186,6 +187,7 @@
   <script src="app/compare/CompareController.js"></script>
   <script src="app/common/utilities.js"></script>
   <script src="app/common/loginForm.js"></script>
+  <script src="app/settings/UserSettingsController.js"></script>
   <script src="app/common/MainController.js"></script>
   <script src="app/app.module.js"></script>
   <!-- endinject -->
@@ -211,6 +213,7 @@
           </ul>
         </nav>
         <div id="userinfo">
+          <span class="glyphicon glyphicon-cog" ng-click="main.showUserSettings()"></span>
           <span><span class="glyphicon glyphicon-user"></span> <strong>{{ main.loggedInUser }}</strong></span>
           <span id="logout"><a ng-click="main.logout()">Logout</a></span>
         </div>


### PR DESCRIPTION
Create local storage to hold a list of environments. 
If the user has set this, the environment summary screen will by default filter the results based on that list. 
This will allow users to focus on the environments they care about. 

The screen also has a toggle to switch to all environments in the list if they want to go to an environment they don't normally use - the access to these envrionments has not been removed. 