### PR TITLE
strict ssl should not be on when dealing with self signed certs

### DIFF
--- a/server/modules/ec2-monitor/ec2-monitor-client.js
+++ b/server/modules/ec2-monitor/ec2-monitor-client.js
@@ -1,6 +1,6 @@
 'use strict';
 
-let request = require('request-promise');
+let request = require('request-promise').defaults({ strictSSL: false });
 let config = require('../../config');
 
 let monitorUri = `${config.getUserValue('local').emEc2Url}/api`;


### PR DESCRIPTION
## Fix
When dealing with self signed certificates, there are errors when using an https emec2uri. This has been resolved with a configuration option to `request`. 