### PR TITLE
Feature/remove deployment status

### DIFF
--- a/client/app/environments/servers/env-manage-servers.html
+++ b/client/app/environments/servers/env-manage-servers.html
@@ -69,7 +69,6 @@
               <th class="text-nowrap">AMI</th>
               <th class="text-nowrap">Out of Date</th>
               <th class="text-nowrap">Schedule</th>
-              <th class="text-nowrap">Deployments</th>
               <th class="text-nowrap">Delete</th>
             </tr>
           </thead>
@@ -109,13 +108,6 @@
                   <schedule-viewer schedule="role.schedule" simple-view="true"></schedule-viewer>
                 </a>
               </td>
-              <td>
-                <span ng-if="!vm.roleInformation" class="glyphicon glyphicon-hourglass"></span>
-                <span ng-if="vm.roleInformation">
-                  <span ng-if="!role.info.deployments" class="glyphicon glyphicon-thumbs-up"> None in Progress</span>
-                <span ng-if="role.info.deployments" class="glyphicon glyphicon-warning-sign"> Deployments in Progress</span>
-                </span>
-              </td>
               <td ng-if="vm.canDeleteAsg(role.asgName)" class="command command-delete ng-scope"><span class="glyphicon glyphicon-remove" ng-click="vm.deleteAsg(role.asgName)" title="Delete"></span></td>
             </tr>
           </tbody>
@@ -135,7 +127,6 @@
               <th class="text-nowrap">AMI</th>
               <th class="text-nowrap">Out of Date</th>
               <th class="text-nowrap">Schedule</th>
-              <th class="text-nowrap">Deployments</th>
               <th class="text-nowrap">Delete</th>
             </tr>
           </thead>
@@ -174,14 +165,6 @@
                 <a ng-if="!role.hasScalingSchedule" ng-click="vm.showInstanceDetails(role.asgName, 'schedule')">
                   <schedule-viewer schedule="role.schedule" simple-view="true"></schedule-viewer>
                 </a>
-              </td>
-              <td>
-                <span ng-if="!vm.roleInformation" class="glyphicon glyphicon-hourglass"></span>
-                <span ng-if="vm.roleInformation">
-                  <span ng-if="!role.info.deployments">None</span>
-                <span ng-if="role.info.deployments"><span class="glyphicon glyphicon-warning-sign warning"></span> Deployments
-                in Progress</span>
-                </span>
               </td>
               <td ng-if="vm.canDeleteAsg(role.asgName)" class="command command-delete ng-scope"><span class="glyphicon glyphicon-remove" ng-click="vm.deleteAsg(role.asgName)" title="Delete"></span></td>
             </tr>


### PR DESCRIPTION
## Change
The Servers screen was experiencing timeouts while it tried to get the deployment status across *all* instances. This doesn't need to be there at the moment and can be replaced with calls to the EC2 Monitor in the future. 