### PR TITLE
use local storage unless route has provided a value which should over…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+[#unreleased]
+
+## Added 
+
+- A selection of a team is now persisted through the use of Environment Manager. This is kept between screens and also between new browser windows on the same machine. From now on, if you tell Environment Manager you want to be looking at 'my team', you will be looking at that team constantly until you change that selection. [#416]
+
 ## [6.19.0] 2018-02-14
 
 ### Changed
@@ -395,6 +401,7 @@ Example:
 [6.1.0]: https://github.com/trainline/environment-manager/compare/6.0.2...v6.1.0
 [6.0.2]: https://github.com/trainline/environment-manager/compare/6.0.1...6.0.2
 
+[#416]: https://github.com/trainline/environment-manager/pull/416
 [#403]: https://github.com/trainline/environment-manager/pull/403
 [#412]: https://github.com/trainline/environment-manager/pull/412
 [#408]: https://github.com/trainline/environment-manager/pull/408

--- a/client/app/common/services/localStorageService.js
+++ b/client/app/common/services/localStorageService.js
@@ -15,9 +15,7 @@
     return {
       get: get,
       set: set,
-      exists: exists,
-      getValueOrDefault: getValueOrDefault,
-      keys: getKeys()
+      exists: exists
     };
 
     function get(key) {
@@ -31,18 +29,6 @@
     function exists(key) {
       if (get(key) === null || get(key) === '') return false;
       return true;
-    }
-
-    function getValueOrDefault(key, defaultValue) {
-      return exists(key) ? get(key) : defaultValue;
-    }
-
-    function getKeys() {
-      return {
-        selections: {
-          team: 'em-selections-team'
-        }
-      };
     }
   }
 }());

--- a/client/app/common/services/localStorageService.js
+++ b/client/app/common/services/localStorageService.js
@@ -16,7 +16,8 @@
       get: get,
       set: set,
       exists: exists,
-      getValueOrDefault: getValueOrDefault
+      getValueOrDefault: getValueOrDefault,
+      keys: getKeys()
     };
 
     function get(key) {
@@ -34,6 +35,14 @@
 
     function getValueOrDefault(key, defaultValue) {
       return exists(key) ? get(key) : defaultValue;
+    }
+
+    function getKeys() {
+      return {
+        selections: {
+          team: 'em-selections-team'
+        }
+      };
     }
   }
 }());

--- a/client/app/common/services/localStorageService.js
+++ b/client/app/common/services/localStorageService.js
@@ -15,7 +15,8 @@
     return {
       get: get,
       set: set,
-      exists: exists
+      exists: exists,
+      getValueOrDefault: getValueOrDefault
     };
 
     function get(key) {
@@ -29,6 +30,10 @@
     function exists(key) {
       if (get(key) === null || get(key) === '') return false;
       return true;
+    }
+
+    function getValueOrDefault(key, defaultValue) {
+      return exists(key) ? get(key) : defaultValue;
     }
   }
 }());

--- a/client/app/common/services/teamStorageService.js
+++ b/client/app/common/services/teamStorageService.js
@@ -1,0 +1,34 @@
+/* Copyright (c) Trainline Limited, 2016-2017. All rights reserved. See LICENSE.txt in the project root for license information. */
+
+'use strict';
+
+(function () {
+  angular
+    .module('EnvironmentManager.common')
+    .factory('teamstorageservice', teamstorageservice);
+
+  teamstorageservice.$inject = ['localstorageservice'];
+
+  function teamstorageservice(localstorageservice) {
+    var key = 'em-selections-team';
+
+    return {
+      get: get,
+      set: set
+    };
+
+    function get(defaultValue) {
+      var value = '';
+
+      if (defaultValue) value = defaultValue;
+
+      if (localstorageservice.exists(key)) value = localstorageservice.get(key);
+
+      return value;
+    }
+
+    function set(value) {
+      localstorageservice.set(key, value);
+    }
+  }
+}());

--- a/client/app/configuration/deployment-maps/DeploymentMapController.js
+++ b/client/app/configuration/deployment-maps/DeploymentMapController.js
@@ -29,7 +29,7 @@ angular.module('EnvironmentManager.configuration').controller('DeploymentMapCont
     var querySync = new QuerySync(vm, {
       cluster: {
         property: 'selectedOwningCluster',
-        default: localstorageservice.getValueOrDefault('em-selections-team', SHOW_ALL_OPTION)
+        default: localstorageservice.getValueOrDefault(localstorageservice.keys.selections.team, SHOW_ALL_OPTION)
       },
       service: {
         property: 'serviceName',
@@ -70,7 +70,7 @@ angular.module('EnvironmentManager.configuration').controller('DeploymentMapCont
 
     vm.search = function () {
       querySync.updateQuery();
-      localstorageservice.set('em-selections-team', vm.selectedOwningCluster);
+      localstorageservice.set(localstorageservice.keys.selections.team, vm.selectedOwningCluster);
       vm.deploymentTargets = vm.deploymentMap.Value.DeploymentTarget.filter(function (target) {
         var match = vm.selectedOwningCluster == SHOW_ALL_OPTION || target.OwningCluster == vm.selectedOwningCluster;
 

--- a/client/app/configuration/deployment-maps/DeploymentMapController.js
+++ b/client/app/configuration/deployment-maps/DeploymentMapController.js
@@ -5,7 +5,7 @@
 'use strict';
 
 angular.module('EnvironmentManager.configuration').controller('DeploymentMapController',
-  function ($scope, $routeParams, $location, $q, $uibModal, QuerySync, resources, cachedResources, modal, deploymentMapConverter, DeploymentMap, localstorageservice) {
+  function ($scope, $routeParams, $location, $q, $uibModal, QuerySync, resources, cachedResources, modal, deploymentMapConverter, DeploymentMap, teamstorageservice) {
     var vm = this;
 
     var SHOW_ALL_OPTION = 'Any';
@@ -29,7 +29,7 @@ angular.module('EnvironmentManager.configuration').controller('DeploymentMapCont
     var querySync = new QuerySync(vm, {
       cluster: {
         property: 'selectedOwningCluster',
-        default: localstorageservice.getValueOrDefault(localstorageservice.keys.selections.team, SHOW_ALL_OPTION)
+        default: teamstorageservice.get(SHOW_ALL_OPTION)
       },
       service: {
         property: 'serviceName',
@@ -70,7 +70,7 @@ angular.module('EnvironmentManager.configuration').controller('DeploymentMapCont
 
     vm.search = function () {
       querySync.updateQuery();
-      localstorageservice.set(localstorageservice.keys.selections.team, vm.selectedOwningCluster);
+      teamstorageservice.set(vm.selectedOwningCluster);
       vm.deploymentTargets = vm.deploymentMap.Value.DeploymentTarget.filter(function (target) {
         var match = vm.selectedOwningCluster == SHOW_ALL_OPTION || target.OwningCluster == vm.selectedOwningCluster;
 

--- a/client/app/configuration/deployment-maps/DeploymentMapTargetController.js
+++ b/client/app/configuration/deployment-maps/DeploymentMapTargetController.js
@@ -66,7 +66,7 @@ angular.module('EnvironmentManager.configuration').controller('DeploymentMapTarg
           var newTarget = {
             ServerRoleName: '',
             FleetPerSlice: false,
-            OwningCluster: localstorageservice.getValueOrDefault('em-selections-team', vm.owningClustersList[0].ClusterName),
+            OwningCluster: localstorageservice.getValueOrDefault(localstorageservice.keys.selections.team, vm.owningClustersList[0].ClusterName),
             SecurityZone: vm.securityZonesList[0],
             ASG: {
               MinCapacity: 0,

--- a/client/app/configuration/deployment-maps/DeploymentMapTargetController.js
+++ b/client/app/configuration/deployment-maps/DeploymentMapTargetController.js
@@ -5,7 +5,7 @@
 'use strict';
 
 angular.module('EnvironmentManager.configuration').controller('DeploymentMapTargetController',
-  function ($scope, $location, $uibModalInstance, $uibModal, $q, Image, resources, cachedResources, modal, deploymentMap, deploymentTarget, deploymentMapConverter, displayMode, awsService, localstorageservice) {
+  function ($scope, $location, $uibModalInstance, $uibModal, $q, Image, resources, cachedResources, modal, deploymentMap, deploymentTarget, deploymentMapConverter, displayMode, awsService, teamstorageservice) {
     var vm = this;
 
     var userHasPermission;
@@ -66,7 +66,7 @@ angular.module('EnvironmentManager.configuration').controller('DeploymentMapTarg
           var newTarget = {
             ServerRoleName: '',
             FleetPerSlice: false,
-            OwningCluster: localstorageservice.getValueOrDefault(localstorageservice.keys.selections.team, vm.owningClustersList[0].ClusterName),
+            OwningCluster: teamstorageservice.get(vm.owningClustersList[0].ClusterName),
             SecurityZone: vm.securityZonesList[0],
             ASG: {
               MinCapacity: 0,

--- a/client/app/configuration/deployment-maps/DeploymentMapTargetController.js
+++ b/client/app/configuration/deployment-maps/DeploymentMapTargetController.js
@@ -5,7 +5,7 @@
 'use strict';
 
 angular.module('EnvironmentManager.configuration').controller('DeploymentMapTargetController',
-  function ($scope, $location, $uibModalInstance, $uibModal, $q, Image, resources, cachedResources, modal, deploymentMap, deploymentTarget, deploymentMapConverter, displayMode, awsService) {
+  function ($scope, $location, $uibModalInstance, $uibModal, $q, Image, resources, cachedResources, modal, deploymentMap, deploymentTarget, deploymentMapConverter, displayMode, awsService, localstorageservice) {
     var vm = this;
 
     var userHasPermission;
@@ -66,7 +66,7 @@ angular.module('EnvironmentManager.configuration').controller('DeploymentMapTarg
           var newTarget = {
             ServerRoleName: '',
             FleetPerSlice: false,
-            OwningCluster: vm.owningClustersList[0].ClusterName,
+            OwningCluster: localstorageservice.getValueOrDefault('em-selections-team', vm.owningClustersList[0].ClusterName),
             SecurityZone: vm.securityZonesList[0],
             ASG: {
               MinCapacity: 0,

--- a/client/app/configuration/em-services/ServicesController.js
+++ b/client/app/configuration/em-services/ServicesController.js
@@ -6,7 +6,7 @@
 
 // Manage all services
 angular.module('EnvironmentManager.configuration').controller('ServicesController',
-  function ($scope, $routeParams, $location, $http, resources, cachedResources, modal) {
+  function ($scope, $routeParams, $location, $http, resources, cachedResources, modal, localstorageservice) {
     var vm = this;
     var SHOW_ALL_OPTION = 'Any';
 
@@ -25,7 +25,7 @@ angular.module('EnvironmentManager.configuration').controller('ServicesControlle
       var cluster = $routeParams.cluster;
       var service = $routeParams.service;
 
-      vm.selectedOwningCluster = cluster || SHOW_ALL_OPTION;
+      vm.selectedOwningCluster = cluster || localstorageservice.getValueOrDefault('em-selections-team', SHOW_ALL_OPTION);
       vm.selectedService = service || '';
 
       cachedResources.config.clusters.all().then(function (clusters) {
@@ -41,6 +41,9 @@ angular.module('EnvironmentManager.configuration').controller('ServicesControlle
 
     vm.refresh = function () {
       var query = {};
+
+      localstorageservice.set('em-selections-team', vm.selectedOwningCluster);
+      
       if (vm.selectedOwningCluster != SHOW_ALL_OPTION) {
         query.cluster = vm.selectedOwningCluster;
       }

--- a/client/app/configuration/em-services/ServicesController.js
+++ b/client/app/configuration/em-services/ServicesController.js
@@ -6,7 +6,7 @@
 
 // Manage all services
 angular.module('EnvironmentManager.configuration').controller('ServicesController',
-  function ($scope, $routeParams, $location, $http, resources, cachedResources, modal, localstorageservice) {
+  function ($scope, $routeParams, $location, $http, resources, cachedResources, modal, teamstorageservice) {
     var vm = this;
     var SHOW_ALL_OPTION = 'Any';
 
@@ -25,7 +25,7 @@ angular.module('EnvironmentManager.configuration').controller('ServicesControlle
       var cluster = $routeParams.cluster;
       var service = $routeParams.service;
 
-      vm.selectedOwningCluster = cluster || localstorageservice.getValueOrDefault(localstorageservice.keys.selections.team, SHOW_ALL_OPTION);
+      vm.selectedOwningCluster = cluster || teamstorageservice.get(SHOW_ALL_OPTION);
       vm.selectedService = service || '';
 
       cachedResources.config.clusters.all().then(function (clusters) {
@@ -42,7 +42,7 @@ angular.module('EnvironmentManager.configuration').controller('ServicesControlle
     vm.refresh = function () {
       var query = {};
 
-      localstorageservice.set(localstorageservice.keys.selections.team, vm.selectedOwningCluster);
+      teamstorageservice.set(vm.selectedOwningCluster);
       
       if (vm.selectedOwningCluster != SHOW_ALL_OPTION) {
         query.cluster = vm.selectedOwningCluster;

--- a/client/app/configuration/em-services/ServicesController.js
+++ b/client/app/configuration/em-services/ServicesController.js
@@ -25,7 +25,7 @@ angular.module('EnvironmentManager.configuration').controller('ServicesControlle
       var cluster = $routeParams.cluster;
       var service = $routeParams.service;
 
-      vm.selectedOwningCluster = cluster || localstorageservice.getValueOrDefault('em-selections-team', SHOW_ALL_OPTION);
+      vm.selectedOwningCluster = cluster || localstorageservice.getValueOrDefault(localstorageservice.keys.selections.team, SHOW_ALL_OPTION);
       vm.selectedService = service || '';
 
       cachedResources.config.clusters.all().then(function (clusters) {
@@ -42,7 +42,7 @@ angular.module('EnvironmentManager.configuration').controller('ServicesControlle
     vm.refresh = function () {
       var query = {};
 
-      localstorageservice.set('em-selections-team', vm.selectedOwningCluster);
+      localstorageservice.set(localstorageservice.keys.selections.team, vm.selectedOwningCluster);
       
       if (vm.selectedOwningCluster != SHOW_ALL_OPTION) {
         query.cluster = vm.selectedOwningCluster;

--- a/client/app/environments/servers/ManageEnvironmentServersController.js
+++ b/client/app/environments/servers/ManageEnvironmentServersController.js
@@ -6,7 +6,7 @@
 
 angular.module('EnvironmentManager.environments')
   .controller('ManageEnvironmentServersController',
-  function ($rootScope, $routeParams, $http, $q, cachedResources, resources, $uibModal, accountMappingService, serversView, QuerySync, environmentDeploy, $scope, serviceDiscovery, enums, modal, asgservice, localstorageservice) {
+  function ($rootScope, $routeParams, $http, $q, cachedResources, resources, $uibModal, accountMappingService, serversView, QuerySync, environmentDeploy, $scope, serviceDiscovery, enums, modal, asgservice, teamstorageservice) {
     var vm = this;
 
     var SHOW_ALL_OPTION = 'Any';
@@ -23,7 +23,7 @@ angular.module('EnvironmentManager.environments')
       },
       cluster: {
         property: 'selected.cluster',
-        default: localstorageservice.getValueOrDefault(localstorageservice.keys.selections.team, SHOW_ALL_OPTION)
+        default: teamstorageservice.get(SHOW_ALL_OPTION)
       },
       server: {
         property: 'selected.serverRole',
@@ -140,7 +140,7 @@ angular.module('EnvironmentManager.environments')
     vm.update = function () {
       querySync.updateQuery();
       vm.view = serversView(vm.data, vm.selected)
-      localstorageservice.set(localstorageservice.keys.selections.team, vm.selected.cluster);
+      teamstorageservice.set(vm.selected.cluster);
       return $q.resolve();
     };
 

--- a/client/app/environments/servers/ManageEnvironmentServersController.js
+++ b/client/app/environments/servers/ManageEnvironmentServersController.js
@@ -23,7 +23,7 @@ angular.module('EnvironmentManager.environments')
       },
       cluster: {
         property: 'selected.cluster',
-        default: localstorageservice.getValueOrDefault('em-selections-team', SHOW_ALL_OPTION)
+        default: localstorageservice.getValueOrDefault(localstorageservice.keys.selections.team, SHOW_ALL_OPTION)
       },
       server: {
         property: 'selected.serverRole',
@@ -140,7 +140,7 @@ angular.module('EnvironmentManager.environments')
     vm.update = function () {
       querySync.updateQuery();
       vm.view = serversView(vm.data, vm.selected)
-      localstorageservice.set('em-selections-team', vm.selected.cluster);
+      localstorageservice.set(localstorageservice.keys.selections.team, vm.selected.cluster);
       return $q.resolve();
     };
 

--- a/client/app/environments/servers/ManageEnvironmentServersController.js
+++ b/client/app/environments/servers/ManageEnvironmentServersController.js
@@ -6,7 +6,7 @@
 
 angular.module('EnvironmentManager.environments')
   .controller('ManageEnvironmentServersController',
-  function ($rootScope, $routeParams, $http, $q, cachedResources, resources, $uibModal, accountMappingService, serversView, QuerySync, environmentDeploy, $scope, serviceDiscovery, enums, modal, asgservice) {
+  function ($rootScope, $routeParams, $http, $q, cachedResources, resources, $uibModal, accountMappingService, serversView, QuerySync, environmentDeploy, $scope, serviceDiscovery, enums, modal, asgservice, localstorageservice) {
     var vm = this;
 
     var SHOW_ALL_OPTION = 'Any';
@@ -23,7 +23,7 @@ angular.module('EnvironmentManager.environments')
       },
       cluster: {
         property: 'selected.cluster',
-        default: SHOW_ALL_OPTION
+        default: localstorageservice.getValueOrDefault('em-selections-team', SHOW_ALL_OPTION)
       },
       server: {
         property: 'selected.serverRole',
@@ -60,7 +60,6 @@ angular.module('EnvironmentManager.environments')
       $q.all([
         cachedResources.config.clusters.all().then(function (clusters) {
           vm.options.clusters = vm.options.clusters.concat(_.map(clusters, 'ClusterName')).sort();
-          vm.selected.cluster = vm.options.clusters[0];
         }),
 
         cachedResources.config.environments.all().then(function (envData) {
@@ -141,6 +140,7 @@ angular.module('EnvironmentManager.environments')
     vm.update = function () {
       querySync.updateQuery();
       vm.view = serversView(vm.data, vm.selected)
+      localstorageservice.set('em-selections-team', vm.selected.cluster);
       return $q.resolve();
     };
 

--- a/client/app/environments/summary/EnvironmentsSummaryController.js
+++ b/client/app/environments/summary/EnvironmentsSummaryController.js
@@ -21,6 +21,7 @@ angular.module('EnvironmentManager.environments').controller('EnvironmentsSummar
     vm.hasUserSettings = localstorageservice.exists('em-settings-environments');
     vm.userSettings = localstorageservice.get('em-settings-environments');
     vm.toggleAllEnvironmentsLabel = vm.hasUserSettings ? "Show All Environments" : "Filter From User Settings";
+    vm.browsedOwningCluster = localstorageservice.getValueOrDefault('em-selections-team', SHOW_ALL_OPTION);
 
     vm.dataLoading = false;
 
@@ -38,8 +39,7 @@ angular.module('EnvironmentManager.environments').controller('EnvironmentsSummar
         })
       ]).then(function () {
         vm.selectedEnvironmentType = $routeParams.environmentType || SHOW_ALL_OPTION;
-        vm.selectedOwningCluster = $routeParams.cluster || SHOW_ALL_OPTION;
-
+        vm.selectedOwningCluster = $routeParams.cluster || vm.browsedOwningCluster;
         vm.refresh();
       });
     }
@@ -60,6 +60,8 @@ angular.module('EnvironmentManager.environments').controller('EnvironmentsSummar
         environmentType: vm.selectedEnvironmentType,
         cluster: vm.selectedOwningCluster
       });
+
+      localstorageservice.set('em-selections-team', vm.selectedOwningCluster);
 
       var query = {};
       if (vm.selectedEnvironmentType != SHOW_ALL_OPTION) {

--- a/client/app/environments/summary/EnvironmentsSummaryController.js
+++ b/client/app/environments/summary/EnvironmentsSummaryController.js
@@ -5,7 +5,7 @@
 'use strict';
 
 angular.module('EnvironmentManager.environments').controller('EnvironmentsSummaryController',
-  function ($scope, $routeParams, $location, $uibModal, $http, $q, modal, resources, cachedResources, Environment, localstorageservice) {
+  function ($scope, $routeParams, $location, $uibModal, $http, $q, modal, resources, cachedResources, Environment, localstorageservice, teamstorageservice) {
     var vm = this;
 
     var SHOW_ALL_OPTION = 'Any';
@@ -21,7 +21,7 @@ angular.module('EnvironmentManager.environments').controller('EnvironmentsSummar
     vm.hasUserSettings = localstorageservice.exists('em-settings-environments');
     vm.userSettings = localstorageservice.get('em-settings-environments');
     vm.toggleAllEnvironmentsLabel = vm.hasUserSettings ? "Show All Environments" : "Filter From User Settings";
-    vm.browsedOwningCluster = localstorageservice.getValueOrDefault(localstorageservice.keys.selections.team, SHOW_ALL_OPTION);
+    vm.browsedOwningCluster = teamstorageservice.get(SHOW_ALL_OPTION);
 
     vm.dataLoading = false;
 
@@ -61,7 +61,7 @@ angular.module('EnvironmentManager.environments').controller('EnvironmentsSummar
         cluster: vm.selectedOwningCluster
       });
 
-      localstorageservice.set(localstorageservice.keys.selections.team, vm.selectedOwningCluster);
+      teamstorageservice.set(vm.selectedOwningCluster);
 
       var query = {};
       if (vm.selectedEnvironmentType != SHOW_ALL_OPTION) {

--- a/client/app/environments/summary/EnvironmentsSummaryController.js
+++ b/client/app/environments/summary/EnvironmentsSummaryController.js
@@ -21,7 +21,7 @@ angular.module('EnvironmentManager.environments').controller('EnvironmentsSummar
     vm.hasUserSettings = localstorageservice.exists('em-settings-environments');
     vm.userSettings = localstorageservice.get('em-settings-environments');
     vm.toggleAllEnvironmentsLabel = vm.hasUserSettings ? "Show All Environments" : "Filter From User Settings";
-    vm.browsedOwningCluster = localstorageservice.getValueOrDefault('em-selections-team', SHOW_ALL_OPTION);
+    vm.browsedOwningCluster = localstorageservice.getValueOrDefault(localstorageservice.keys.selections.team, SHOW_ALL_OPTION);
 
     vm.dataLoading = false;
 
@@ -61,7 +61,7 @@ angular.module('EnvironmentManager.environments').controller('EnvironmentsSummar
         cluster: vm.selectedOwningCluster
       });
 
-      localstorageservice.set('em-selections-team', vm.selectedOwningCluster);
+      localstorageservice.set(localstorageservice.keys.selections.team, vm.selectedOwningCluster);
 
       var query = {};
       if (vm.selectedEnvironmentType != SHOW_ALL_OPTION) {

--- a/client/app/operations/amis/OpsAMIsController.js
+++ b/client/app/operations/amis/OpsAMIsController.js
@@ -38,7 +38,7 @@ angular.module('EnvironmentManager.operations').controller('OpsAMIsController',
             },
             cluster: {
               property: 'selectedOwningCluster',
-              default: localstorageservice.getValueOrDefault('em-selections-team', SHOW_ALL_OPTION)
+              default: localstorageservice.getValueOrDefault(localstorageservice.keys.selections.team, SHOW_ALL_OPTION)
             },
             server: {
               property: 'selectedServerRole',
@@ -79,7 +79,7 @@ angular.module('EnvironmentManager.operations').controller('OpsAMIsController',
 
       querySync.updateQuery();
 
-      localstorageservice.set('em-selections-team', vm.selectedOwningCluster);
+      localstorageservice.set(localstorageservice.keys.selections.team, vm.selectedOwningCluster);
 
       accountMappingService.getAccountForEnvironment(vm.selectedEnvironment).then(function (accountName) {
         vm.selectedAccount = accountName;

--- a/client/app/operations/amis/OpsAMIsController.js
+++ b/client/app/operations/amis/OpsAMIsController.js
@@ -5,7 +5,7 @@
 'use strict';
 
 angular.module('EnvironmentManager.operations').controller('OpsAMIsController',
-  function ($scope, $routeParams, $location, $uibModal, $q, resources, cachedResources, accountMappingService, awsService, modal, QuerySync, localstorageservice) {
+  function ($scope, $routeParams, $location, $uibModal, $q, resources, cachedResources, accountMappingService, awsService, modal, QuerySync, teamstorageservice) {
     var vm = this;
     var SHOW_ALL_OPTION = 'Any';
 
@@ -38,7 +38,7 @@ angular.module('EnvironmentManager.operations').controller('OpsAMIsController',
             },
             cluster: {
               property: 'selectedOwningCluster',
-              default: localstorageservice.getValueOrDefault(localstorageservice.keys.selections.team, SHOW_ALL_OPTION)
+              default: teamstorageservice.get(SHOW_ALL_OPTION)
             },
             server: {
               property: 'selectedServerRole',
@@ -79,7 +79,7 @@ angular.module('EnvironmentManager.operations').controller('OpsAMIsController',
 
       querySync.updateQuery();
 
-      localstorageservice.set(localstorageservice.keys.selections.team, vm.selectedOwningCluster);
+      teamstorageservice.set(vm.selectedOwningCluster);
 
       accountMappingService.getAccountForEnvironment(vm.selectedEnvironment).then(function (accountName) {
         vm.selectedAccount = accountName;

--- a/client/app/operations/amis/OpsAMIsController.js
+++ b/client/app/operations/amis/OpsAMIsController.js
@@ -5,7 +5,7 @@
 'use strict';
 
 angular.module('EnvironmentManager.operations').controller('OpsAMIsController',
-  function ($scope, $routeParams, $location, $uibModal, $q, resources, cachedResources, accountMappingService, awsService, modal, QuerySync) {
+  function ($scope, $routeParams, $location, $uibModal, $q, resources, cachedResources, accountMappingService, awsService, modal, QuerySync, localstorageservice) {
     var vm = this;
     var SHOW_ALL_OPTION = 'Any';
 
@@ -38,7 +38,7 @@ angular.module('EnvironmentManager.operations').controller('OpsAMIsController',
             },
             cluster: {
               property: 'selectedOwningCluster',
-              default: SHOW_ALL_OPTION
+              default: localstorageservice.getValueOrDefault('em-selections-team', SHOW_ALL_OPTION)
             },
             server: {
               property: 'selectedServerRole',
@@ -78,6 +78,8 @@ angular.module('EnvironmentManager.operations').controller('OpsAMIsController',
       vm.dataLoading = true;
 
       querySync.updateQuery();
+
+      localstorageservice.set('em-selections-team', vm.selectedOwningCluster);
 
       accountMappingService.getAccountForEnvironment(vm.selectedEnvironment).then(function (accountName) {
         vm.selectedAccount = accountName;

--- a/client/app/operations/deployments/OpsDeploymentsController.js
+++ b/client/app/operations/deployments/OpsDeploymentsController.js
@@ -43,7 +43,7 @@ angular.module('EnvironmentManager.operations').controller('OpsDeploymentsContro
       },
       cluster: {
         property: 'selectedOwningCluster',
-        default: localstorageservice.getValueOrDefault('em-selections-team', SHOW_ALL_OPTION)
+        default: localstorageservice.getValueOrDefault(localstorageservice.keys.selections.team, SHOW_ALL_OPTION)
       },
       service: {
         property: 'serviceName',
@@ -142,7 +142,7 @@ angular.module('EnvironmentManager.operations').controller('OpsDeploymentsContro
         query.since = new Date(dateNow).toISOString();
       }
 
-      localstorageservice.set('em-selections-team', vm.selectedOwningCluster);
+      localstorageservice.set(localstorageservice.keys.selections.team, vm.selectedOwningCluster);
 
       vm.query = query;
     };

--- a/client/app/operations/deployments/OpsDeploymentsController.js
+++ b/client/app/operations/deployments/OpsDeploymentsController.js
@@ -5,7 +5,7 @@
 'use strict';
 
 angular.module('EnvironmentManager.operations').controller('OpsDeploymentsController',
-  function ($routeParams, $uibModal, $scope, $q, $timeout, resources, cachedResources, enums, QuerySync, Deployment, localstorageservice) {
+  function ($routeParams, $uibModal, $scope, $q, $timeout, resources, cachedResources, enums, QuerySync, Deployment, teamstorageservice) {
     var vm = this;
 
     var SHOW_ALL_OPTION = 'Any';
@@ -43,7 +43,7 @@ angular.module('EnvironmentManager.operations').controller('OpsDeploymentsContro
       },
       cluster: {
         property: 'selectedOwningCluster',
-        default: localstorageservice.getValueOrDefault(localstorageservice.keys.selections.team, SHOW_ALL_OPTION)
+        default: teamstorageservice.get(SHOW_ALL_OPTION)
       },
       service: {
         property: 'serviceName',
@@ -142,7 +142,7 @@ angular.module('EnvironmentManager.operations').controller('OpsDeploymentsContro
         query.since = new Date(dateNow).toISOString();
       }
 
-      localstorageservice.set(localstorageservice.keys.selections.team, vm.selectedOwningCluster);
+      teamstorageservice.set(vm.selectedOwningCluster);
 
       vm.query = query;
     };

--- a/client/app/operations/deployments/OpsDeploymentsController.js
+++ b/client/app/operations/deployments/OpsDeploymentsController.js
@@ -5,7 +5,7 @@
 'use strict';
 
 angular.module('EnvironmentManager.operations').controller('OpsDeploymentsController',
-  function ($routeParams, $uibModal, $scope, $q, $timeout, resources, cachedResources, enums, QuerySync, Deployment) {
+  function ($routeParams, $uibModal, $scope, $q, $timeout, resources, cachedResources, enums, QuerySync, Deployment, localstorageservice) {
     var vm = this;
 
     var SHOW_ALL_OPTION = 'Any';
@@ -43,7 +43,7 @@ angular.module('EnvironmentManager.operations').controller('OpsDeploymentsContro
       },
       cluster: {
         property: 'selectedOwningCluster',
-        default: SHOW_ALL_OPTION
+        default: localstorageservice.getValueOrDefault('em-selections-team', SHOW_ALL_OPTION)
       },
       service: {
         property: 'serviceName',
@@ -86,7 +86,6 @@ angular.module('EnvironmentManager.operations').controller('OpsDeploymentsContro
           vm.statusList = [SHOW_ALL_OPTION].concat(deploymentStatuses);
         })
       ]).then(function () {
-        // Show default results
         vm.refresh();
       });
     }
@@ -142,6 +141,8 @@ angular.module('EnvironmentManager.operations').controller('OpsDeploymentsContro
         dateNow -= (vm.selectedDateRangeValue);
         query.since = new Date(dateNow).toISOString();
       }
+
+      localstorageservice.set('em-selections-team', vm.selectedOwningCluster);
 
       vm.query = query;
     };

--- a/client/app/operations/upstream/OpsUpstreamController.js
+++ b/client/app/operations/upstream/OpsUpstreamController.js
@@ -5,7 +5,7 @@
 'use strict';
 
 angular.module('EnvironmentManager.operations').controller('OpsUpstreamController',
-  function ($routeParams, $location, $uibModal, $q, $http, resources, QuerySync, cachedResources, accountMappingService, modal, UpstreamConfig, localstorageservice) {
+  function ($routeParams, $location, $uibModal, $q, $http, resources, QuerySync, cachedResources, accountMappingService, modal, UpstreamConfig, teamstorageservice) {
     var vm = this;
     var querySync;
     var SHOW_ALL_OPTION = 'Any';
@@ -35,7 +35,7 @@ angular.module('EnvironmentManager.operations').controller('OpsUpstreamControlle
             },
             cluster: {
               property: 'selectedOwningCluster',
-              default: localstorageservice.getValueOrDefault(localstorageservice.keys.selections.team, SHOW_ALL_OPTION)
+              default: teamstorageservice.get(SHOW_ALL_OPTION)
             },
             state: {
               property: 'selectedState',
@@ -82,7 +82,7 @@ angular.module('EnvironmentManager.operations').controller('OpsUpstreamControlle
     vm.updateFilter = function () {
       querySync.updateQuery();
 
-      localstorageservice.set(localstorageservice.keys.selections.team, vm.selectedOwningCluster);
+      teamstorageservice.set(vm.selectedOwningCluster);
 
       vm.data = vm.fullUpstreamData.filter(function (upstream) {
         if (upstream.Value.EnvironmentName !== vm.selectedEnvironment) {

--- a/client/app/operations/upstream/OpsUpstreamController.js
+++ b/client/app/operations/upstream/OpsUpstreamController.js
@@ -35,7 +35,7 @@ angular.module('EnvironmentManager.operations').controller('OpsUpstreamControlle
             },
             cluster: {
               property: 'selectedOwningCluster',
-              default: localstorageservice.getValueOrDefault('em-selections-team', SHOW_ALL_OPTION)
+              default: localstorageservice.getValueOrDefault(localstorageservice.keys.selections.team, SHOW_ALL_OPTION)
             },
             state: {
               property: 'selectedState',
@@ -82,7 +82,7 @@ angular.module('EnvironmentManager.operations').controller('OpsUpstreamControlle
     vm.updateFilter = function () {
       querySync.updateQuery();
 
-      localstorageservice.set('em-selections-team', vm.selectedOwningCluster);
+      localstorageservice.set(localstorageservice.keys.selections.team, vm.selectedOwningCluster);
 
       vm.data = vm.fullUpstreamData.filter(function (upstream) {
         if (upstream.Value.EnvironmentName !== vm.selectedEnvironment) {

--- a/client/app/operations/upstream/OpsUpstreamController.js
+++ b/client/app/operations/upstream/OpsUpstreamController.js
@@ -5,7 +5,7 @@
 'use strict';
 
 angular.module('EnvironmentManager.operations').controller('OpsUpstreamController',
-  function ($routeParams, $location, $uibModal, $q, $http, resources, QuerySync, cachedResources, accountMappingService, modal, UpstreamConfig) {
+  function ($routeParams, $location, $uibModal, $q, $http, resources, QuerySync, cachedResources, accountMappingService, modal, UpstreamConfig, localstorageservice) {
     var vm = this;
     var querySync;
     var SHOW_ALL_OPTION = 'Any';
@@ -35,7 +35,7 @@ angular.module('EnvironmentManager.operations').controller('OpsUpstreamControlle
             },
             cluster: {
               property: 'selectedOwningCluster',
-              default: SHOW_ALL_OPTION
+              default: localstorageservice.getValueOrDefault('em-selections-team', SHOW_ALL_OPTION)
             },
             state: {
               property: 'selectedState',
@@ -82,6 +82,8 @@ angular.module('EnvironmentManager.operations').controller('OpsUpstreamControlle
     vm.updateFilter = function () {
       querySync.updateQuery();
 
+      localstorageservice.set('em-selections-team', vm.selectedOwningCluster);
+
       vm.data = vm.fullUpstreamData.filter(function (upstream) {
         if (upstream.Value.EnvironmentName !== vm.selectedEnvironment) {
           return false;
@@ -119,9 +121,9 @@ angular.module('EnvironmentManager.operations').controller('OpsUpstreamControlle
     };
 
     vm.showInstanceDetails = function (upstreamData) {
-      return getASGsForHost(upstreamData).then(function(asgs){
+      return getASGsForHost(upstreamData).then(function (asgs) {
         if (asgs && asgs.length) {
-          return selectASG(asgs).then(function(asg){
+          return selectASG(asgs).then(function (asg) {
             return showAsgDetails(asg);
           });
         } else {
@@ -143,7 +145,7 @@ angular.module('EnvironmentManager.operations').controller('OpsUpstreamControlle
     function selectASG(asgs) {
       if (asgs.length === 1)
         return Promise.resolve(_.first(asgs));
-      
+
       var instance = $uibModal.open({
         templateUrl: '/app/operations/upstream/select-asg-modal.html',
         controller: 'ASGSelectionModalController as vm',
@@ -161,8 +163,8 @@ angular.module('EnvironmentManager.operations').controller('OpsUpstreamControlle
     function showAsgDetails(asgName) {
       cachedResources.config.environments.all().then(function (envData) {
         return cachedResources.config.environments.getByName(vm.selectedEnvironment, 'EnvironmentName', envData);
-      }).then(function(env){
-        var account = accountMappingService.getAccountForEnvironment(vm.selectedEnvironment).then(function(account){
+      }).then(function (env) {
+        var account = accountMappingService.getAccountForEnvironment(vm.selectedEnvironment).then(function (account) {
           $uibModal.open({
             templateUrl: '/app/environments/dialogs/env-asg-details-modal.html',
             controller: 'ASGDetailsModalController as vm',
@@ -266,7 +268,7 @@ angular.module('EnvironmentManager.operations').controller('OpsUpstreamControlle
 
       var url = ['api', 'v1', 'services', service, "asgs"].join('/') + '?environment=' + environment + '&slice=' + slice;
       return $http.get(url).then(function (response) {
-        return response.data.map(function(asg){return asg.AutoScalingGroupName;});
+        return response.data.map(function (asg) { return asg.AutoScalingGroupName; });
       });
     }
 

--- a/client/index.html
+++ b/client/index.html
@@ -149,6 +149,7 @@
   <script src="app/common/services/releaseNotesService.js"></script>
   <script src="app/common/services/modalService.js"></script>
   <script src="app/common/services/localStorageService.js"></script>
+  <script src="app/common/services/teamStorageService.js"></script>
   <script src="app/common/services/localResourceFactoryService.js"></script>
   <script src="app/common/services/loading.js"></script>
   <script src="app/common/services/loadBalancerService.js"></script>


### PR DESCRIPTION
…ride that

## Change

Using the `localstorageservice` values are set to either the route parameters in the URL, the localstorage value if it exists, or the default option if provided to the service. 

At the moment there is a difference between the controllers where some use the `QuerySync` factory which meant it was a little challenging to get a solution that worked across them both in an encapsulated way. A directive was attempted but one that catered to all use cases could not be found. 