### PR TITLE
Alter logging order, statements and screen for deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - Server view now shows an ordered list of ASGs beginning with ASGs in Error state, then Warning, Not Running and finally Healthy. 
 
+- The deployment details modal now shows the log in time order ascending (like a normal log!). A link has been added to this screen to the `deployment-support` Slack channel. When the deployment is now in the hands of the Consul Deployment Agent (CDA), the UI will show information on what that _means_. There are lots of things that could happen that are now outside the control of Environment Manager which could result in a failed or hanging deployment - until we automate those checks, we can at least show a list of what the common causes are. Some of the entries within the log have been changed to be more reflective of the operation being performed. 
+
 ## Added 
 
 - A selection of a team is now persisted through the use of Environment Manager. This is kept between screens and also between new browser windows on the same machine. From now on, if you tell Environment Manager you want to be looking at 'my team', you will be looking at that team constantly until you change that selection. [#416]

--- a/client/app/app.module.js
+++ b/client/app/app.module.js
@@ -27,6 +27,7 @@ app.config(['cfpLoadingBarProvider', function (cfpLoadingBarProvider) {
 // Setup global routes
 app.config(function ($routeProvider, $compileProvider) {
   $compileProvider.preAssignBindingsEnabled(true);
+  $compileProvider.aHrefSanitizationWhitelist(/^(slack|https?|ftp|mailto|file|sms|tel):/);
   $routeProvider
     .when('/', {
       templateUrl: '/app/environments/summary/env-summary.html',

--- a/client/app/operations/deployments/ops-deployment-details-modal.html
+++ b/client/app/operations/deployments/ops-deployment-details-modal.html
@@ -1,5 +1,7 @@
 <div class="modal-header">
-    <h2>Status: <span class="{{vm.view.statusClass}}">{{vm.view.status}}</span></h2>
+    <h2>Status:
+        <span class="{{vm.view.statusClass}}">{{vm.view.status}}</span>
+    </h2>
     <div id="RefreshData" ng-show="vm.view.Status === 'In Progress'">
         <span class="glyphicon glyphicon-refresh {{vm.view.statusClass}}" ng-class="{ spin: vm.spin }" ng-click="vm.refresh()" title="Refresh data"></span>
     </div>
@@ -8,28 +10,58 @@
 <div class="modal-body">
     <div class="summary">
         <ul>
-            <li><strong>{{vm.view.duration.label}}:</strong> {{vm.view.duration.value}}</li>
-            <li><strong>Service:</strong> {{vm.view.ServiceName}} ({{vm.view.ServiceVersion}})</li>
-            <li><strong>AutoScalingGroup:</strong> <a ng-href="{{vm.view.asgLink}}">{{vm.view.asgName}}</a></li>
-            <li><strong>User:</strong> {{vm.view.User}} ({{vm.view.OwningCluster}})</li>
-            <li><strong>Deployment ID:</strong> {{vm.view.DeploymentID}}</li>
-            <li data-ng-if="vm.expectedNodesKnown"><strong>Nodes Deployed:</strong> {{vm.view.nodesCompleted}} / {{vm.view.expectedNodes}}</li>
+            <li>
+                <strong>{{vm.view.duration.label}}:</strong> {{vm.view.duration.value}}</li>
+            <li>
+                <strong>Service:</strong> {{vm.view.ServiceName}} ({{vm.view.ServiceVersion}})</li>
+            <li>
+                <strong>AutoScalingGroup:</strong>
+                <a ng-href="{{vm.view.asgLink}}">{{vm.view.asgName}}</a>
+            </li>
+            <li>
+                <strong>User:</strong> {{vm.view.User}} ({{vm.view.OwningCluster}})</li>
+            <li>
+                <strong>Deployment ID:</strong> {{vm.view.DeploymentID}}</li>
+            <li data-ng-if="vm.expectedNodesKnown">
+                <strong>Nodes Deployed:</strong> {{vm.view.nodesCompleted}} / {{vm.view.expectedNodes}}</li>
         </ul>
-
+        <br>
+        <p>Please ask in the
+            <a href="{{vm.deploymentSupportSlack}}">#deployment-support</a> channel if you need assistance.</p>
         <div ng-if="vm.view.error" class="alert alert-danger">
             <ul>
-                <li><strong>Error:</strong> {{vm.view.error.error}}</li>
-                <li ng-if="vm.view.error.detail"><strong>Detail:</strong> {{vm.view.error.detail}}</li>
+                <li>
+                    <strong>Error:</strong> {{vm.view.error.error}}</li>
+                <li ng-if="vm.view.error.detail">
+                    <strong>Detail:</strong> {{vm.view.error.detail}}</li>
             </ul>
         </div>
 
         <button class="btn btn-default cancel-deployment" type="button" ng-if="vm.allowCancel()" ng-click="vm.cancelDeployment()">Cancel Deployment...</button>
-
+    </div>
+    <div ng-if="vm.deploymentWaiting">
+        <div class="alert alert-info">
+            <p>Environment Manager will now wait 60 minutes for the Consul Deployment Agent
+                    (CDA) that is installed on each node to perform the deployment.</p>
+            <p>If deployment appears to hang and one or more of the nodes seem to be stuck in
+                <strong>Not Started</strong> state then please check the status of the node.</p>
+            <p>Please verify the node is: </p>
+            <hr>
+            <ul>
+                <li>
+                    <span class="glyphicon glyphicon-question-sign"></span> Switched on</li>
+                <li>
+                    <span class="glyphicon glyphicon-question-sign"></span> Has enough resources to run the deployment (disk space, memory, CPU)</li>
+                <li>
+                    <span class="glyphicon glyphicon-question-sign"></span> Has network connectivity (try to connect to your node using RDP or SSH)</li>
+            </ul>
+        </div>
+        <hr>
     </div>
 
     <h4>Deployment Log</h4>
-    <pre class="log">{{vm.view.log}}</pre>
-    
+    <pre class="log">{{vm.view.log.lines}}</pre>
+
     <div ng-if="vm.view.nodes && vm.view.nodes.length > 0">
         <h4>Nodes</h4>
         <div class="nodes">
@@ -45,22 +77,26 @@
                 </thead>
                 <tbody>
                     <tr ng-repeat="node in vm.view.nodes" data-ng-class="{'initializing':node.initializing || node.failedToInitialize} ">
-                        <td>{{node.instanceId}} <span ng-show="node.instanceIP">({{ node.instanceIP }})</span></td>
+                        <td>{{node.instanceId}}
+                            <span ng-show="node.instanceIP">({{ node.instanceIP }})</span>
+                        </td>
                         <td class="{{node.status.class}}">
                             <span ng-if="node.status.status.toLowerCase()=='in progress'" class="glyphicon glyphicon-refresh"></span>
                             <span ng-if="node.status.status.toLowerCase()=='success'" class="glyphicon glyphicon-ok"></span>
                             <span ng-if="node.status.status.toLowerCase()=='failed'" class="glyphicon glyphicon-remove"></span>
                             <span data-ng-if="node.initializing">
-                              <img src="/assets/images/activity.gif" style="margin-left: 14px" />
+                                <img src="/assets/images/activity.gif" style="margin-left: 14px" />
                             </span>
                             <span data-ng-hide="node.initializing">
-                              {{node.status.status}}
+                                {{node.status.status}}
                             </span>
                             <span ng-if="node.status.lastStage"> ({{node.status.lastStage}})</span>
                         </td>
                         <td>{{node.duration}}</td>
                         <td>{{node.numberOfAttempts}}</td>
-                        <td><a target="_blank" ng-show="node.logLink" href="{{node.logLink}}">Show</a></td>
+                        <td>
+                            <a target="_blank" ng-show="node.logLink" href="{{node.logLink}}">Show</a>
+                        </td>
                     </tr>
                 </tbody>
             </table>

--- a/server/commands/deployments/DeployService.js
+++ b/server/commands/deployments/DeployService.js
@@ -126,7 +126,8 @@ function deploy(deployment, destination, sourcePackage, command) {
 
     deploymentLogger.inProgress(
       deployment.id,
-      'Waiting for nodes to perform service deployment...'
+      `Environment Manager will now wait 60 minutes for the Consul Deployment Agent
+ (CDA) that is installed on each node to perform the deployment....`
     );
   }).catch((error) => {
     let deploymentStatus = {

--- a/server/commands/deployments/GetInfrastructureRequirements.js
+++ b/server/commands/deployments/GetInfrastructureRequirements.js
@@ -26,7 +26,7 @@ module.exports = function GetInfrastructureRequirements(command) {
     let slice = deployment.serviceSlice;
     let requiredInfra = { asgsToCreate: [], launchConfigsToCreate: [], expectedInstances: 0 };
 
-    logger.info('Reading infrastructure configuration...');
+    logger.info('Reading the current state of AWS...');
 
     let configuration = yield configProvider.get(environmentName, serviceName, deployment.serverRoleName);
     let asgsToCreate = yield getASGsToCreate(logger, configuration, accountName, slice);

--- a/server/commands/deployments/PushDeployment.js
+++ b/server/commands/deployments/PushDeployment.js
@@ -39,7 +39,7 @@ module.exports = function PushDeploymentCommandHandler(command) {
       updateTargetState(command, serviceDeploymentDefinition)
     ];
 
-    logger.info('Consul metadata has been updated');
+    logger.info('Environment Manager has now updated Consul with the details of your deployment.');
   }).catch((error) => {
     logger.error('An error has occurred updating consul metadata', error);
     return Promise.reject(error);

--- a/server/commands/services/UpdateTargetState.js
+++ b/server/commands/services/UpdateTargetState.js
@@ -11,6 +11,6 @@ module.exports = function UpdateTargetState(command) {
   let { deploymentId, key, options, value } = command;
   return schema('UpdateTargetStateCommand')
     .then(x => x.assert(command))
-    .then(() => deploymentLogsStreamer.log(deploymentId, `Updating key ${command.key}`))
+    .then(() => deploymentLogsStreamer.log(deploymentId, `Updating Consul key ${command.key}`))
     .then(() => serviceTargets.setTargetState(command.environment, { key, value, options }));
 };


### PR DESCRIPTION
The deployment details modal now shows the log in time order ascending (like a normal log!). A link has been added to this screen to the `deployment-support` Slack channel. When the deployment is now in the hands of the Consul Deployment Agent (CDA), the UI will show information on what that _means_. There are lots of things that could happen that are now outside the control of Environment Manager which could result in a failed or hanging deployment - until we automate those checks, we can at least show a list of what the common causes are. Some of the entries within the log have been changed to be more reflective of the operation being performed.