### PR TITLE
check whether 'any' has been used prior to displaying this page and i…

### DIFF
--- a/client/app/operations/upstream/OpsUpstreamController.js
+++ b/client/app/operations/upstream/OpsUpstreamController.js
@@ -31,7 +31,7 @@ angular.module('EnvironmentManager.operations').controller('OpsUpstreamControlle
           querySync = new QuerySync(vm, {
             environment: {
               property: 'selectedEnvironment',
-              default: environmentstorageservice.get(vm.environmentsList[0])
+              default: getDefaultUpstreamEnvironment(environmentstorageservice.get(vm.environmentsList[0]))
             },
             cluster: {
               property: 'selectedOwningCluster',
@@ -62,6 +62,12 @@ angular.module('EnvironmentManager.operations').controller('OpsUpstreamControlle
       });
     }
 
+    function getDefaultUpstreamEnvironment(value) {
+      return value.toLowerCase() === 'any' ?
+        'c01' :
+        value;
+    }
+
     vm.refresh = function () {
       vm.dataLoading = true;
       UpstreamConfig.getForEnvironment(vm.selectedEnvironment).then(function (data) {
@@ -81,6 +87,7 @@ angular.module('EnvironmentManager.operations').controller('OpsUpstreamControlle
 
     vm.updateFilter = function () {
       querySync.updateQuery();
+
 
       environmentstorageservice.set(vm.selectedEnvironment);
       teamstorageservice.set(vm.selectedOwningCluster);


### PR DESCRIPTION
…f it has, default to 'c01'.

## Fixed
The upstreams page did not have an `any` value in the environment selection like the rest of the application. This meant that a user navigating to this page having selected `any` elsewhere, was breaking when it asked for an upstream status of `NOTHING`. The options here were to introduce `any` to the upstream page and bring back everything by default, or default to the `c01` item if the user wasn't already pointing to an environment. I have opted to keep the results set as small as possible. 