### PR TITLE
Feature/terminate specific instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+[#unreleased]
+
+### Added
+
+- You can not terminate an instance directly and not have to scale up then down. If you want a new instance to remove one with missing services, or any other reason, you can. The ASG screen contains a `terminate` button that is available to all instances that are `In Service` and `Running`. When you terminate an instance, your ASG will delete that instance and replace it with another to meet the desired count of that ASG. Please note that to change the count of machines in your ASG, you will need to change the desired count. You cannot reduce the number of machines in your ASG by terminating instances one by one. 
+
 ## [6.20.1] 2018-02-27
 
 ### Changed

--- a/client/app/environments/dialogs/ASGDetailsModalController.js
+++ b/client/app/environments/dialogs/ASGDetailsModalController.js
@@ -131,6 +131,10 @@ angular.module('EnvironmentManager.environments').controller('ASGDetailsModalCon
       }
     };
 
+    $scope.$on('InstanceTerminating', function () {
+      vm.refresh();
+    })
+
     vm.refresh = function (onInitialization) {
       vm.dataLoading = true;
       vm.loadingUpstreamStatus = true;

--- a/client/app/environments/dialogs/asg/asgInstances.html
+++ b/client/app/environments/dialogs/asg/asgInstances.html
@@ -16,6 +16,7 @@
           <th class="text-nowrap">AMI</th>
           <th class="text-nowrap">Out of Date</th>
           <th class="text-nowrap">Connect</th>
+          <th class="text-nowrap">Terminate</th>
         </tr>
       </thead>
       <tbody>
@@ -69,6 +70,9 @@
                 </button>
               </span>
             </div>
+          </td>
+          <td>
+            <button class="btn btn-danger" ng-click="vm.terminateInstance(instance.InstanceId, vm.asg.Account)">Terminate</button>
           </td>
         </tr>
       </tbody>

--- a/client/app/environments/dialogs/asg/asgInstances.html
+++ b/client/app/environments/dialogs/asg/asgInstances.html
@@ -72,7 +72,7 @@
             </div>
           </td>
           <td>
-            <button class="btn btn-danger" ng-click="vm.terminateInstance(instance.InstanceId, vm.asg.Account)" title="">Terminate</button>
+            <button class="btn btn-danger" ng-disabled="vm.notReadyForTerminate(instance)" ng-click="vm.terminateInstance(instance.InstanceId, vm.asg.Account)" title="">Terminate</button>
           </td>
         </tr>
       </tbody>

--- a/client/app/environments/dialogs/asg/asgInstances.html
+++ b/client/app/environments/dialogs/asg/asgInstances.html
@@ -72,7 +72,7 @@
             </div>
           </td>
           <td>
-            <button class="btn btn-danger" ng-click="vm.terminateInstance(instance.InstanceId, vm.asg.Account)">Terminate</button>
+            <button class="btn btn-danger" ng-click="vm.terminateInstance(instance.InstanceId, vm.asg.Account)" title="">Terminate</button>
           </td>
         </tr>
       </tbody>

--- a/client/app/environments/dialogs/asg/asgInstances.js
+++ b/client/app/environments/dialogs/asg/asgInstances.js
@@ -9,7 +9,7 @@ angular.module('EnvironmentManager.environments').component('asgInstances', {
     asgState: '<'
   },
   controllerAs: 'vm',
-  controller: function ($uibModal, $http) {
+  controller: function ($uibModal, $http, $scope, modal) {
     var vm = this;
     vm.dataLoading = false;
 
@@ -26,11 +26,29 @@ angular.module('EnvironmentManager.environments').component('asgInstances', {
     };
 
     vm.terminateInstance = function (instanceId, accountName) {
-      //TODO: What to we want to do in the UI with this operation?
-      $http.delete('/api/v1/instances/' + instanceId + '?account=' + accountName)
-        .then(function (response) {
-          alert(JSON.stringify(response));
-        });
+      var modalParameters = {
+        title: 'Terminate instance?',
+        message: 'Are you sure you want to terminate <strong>' + instanceId + '</strong>?',
+        action: 'Terminate',
+        severity: 'Danger',
+        acknowledge: 'I am sure I want to terminate this instance: ' + instanceId + '.'
+      };
+
+      return modal.confirmation(modalParameters).then(function () {
+        return $http.delete('/api/v1/instances/' + instanceId + '?account=' + accountName)
+          .then(() => {
+            $scope.$emit('InstanceTerminating');
+          });
+      });
+    };
+
+    vm.notReadyForTerminate = function (instance) {
+      if (instance.LifecycleState.toLowerCase() !== 'inservice'
+        || instance.State.toLowerCase() !== 'running') {
+        return true;
+      }
+
+      return false;
     };
   }
 });

--- a/client/app/environments/dialogs/asg/asgInstances.js
+++ b/client/app/environments/dialogs/asg/asgInstances.js
@@ -36,7 +36,7 @@ angular.module('EnvironmentManager.environments').component('asgInstances', {
 
       return modal.confirmation(modalParameters).then(function () {
         return $http.delete('/api/v1/instances/' + instanceId + '?account=' + accountName)
-          .then(() => {
+          .then(function () {
             $scope.$emit('InstanceTerminating');
           });
       });

--- a/client/app/environments/dialogs/asg/asgInstances.js
+++ b/client/app/environments/dialogs/asg/asgInstances.js
@@ -9,7 +9,7 @@ angular.module('EnvironmentManager.environments').component('asgInstances', {
     asgState: '<'
   },
   controllerAs: 'vm',
-  controller: function ($uibModal) {
+  controller: function ($uibModal, $http) {
     var vm = this;
     vm.dataLoading = false;
 
@@ -23,6 +23,14 @@ angular.module('EnvironmentManager.environments').component('asgInstances', {
           }
         }
       });
+    };
+
+    vm.terminateInstance = function (instanceId, accountName) {
+      //TODO: What to we want to do in the UI with this operation?
+      $http.delete('/api/v1/instances/' + instanceId + '?account=' + accountName)
+        .then(function (response) {
+          alert(JSON.stringify(response));
+        });
     };
   }
 });

--- a/server/api/swagger.yaml
+++ b/server/api/swagger.yaml
@@ -895,6 +895,23 @@ paths:
           description: The instance
           schema:
             $ref: '#/definitions/Instance'
+    delete:
+      operationId: deleteInstance
+      summary: Delete a specific instance
+      tags:
+        - Instance
+      parameters:
+        - name: id
+          in: path
+          type: string
+          required: true
+        - name: account
+          in: query
+          type: string
+          required: true
+      responses:
+        200:
+          description: success
   /instances/{id}/connect:
     x-swagger-router-controller: instancesController
     get:

--- a/server/modules/resourceFactories/InstanceResourceBase.js
+++ b/server/modules/resourceFactories/InstanceResourceBase.js
@@ -42,6 +42,11 @@ function InstanceResource(client) {
     return query(client);
   };
 
+  this.terminate = function (instanceIds) {
+    return client.terminateInstances({ InstanceIds: instanceIds })
+      .promise();
+  };
+
   this.setTag = function (parameters) {
     let request = {
       Resources: parameters.instanceIds,

--- a/server/modules/resourceFactories/ec2InstanceResourceFactory.js
+++ b/server/modules/resourceFactories/ec2InstanceResourceFactory.js
@@ -19,5 +19,8 @@ module.exports = {
   canCreate: resourceDescriptor =>
     resourceDescriptor.type.toLowerCase() === 'ec2/instance',
 
-  create: (_, { accountName } = {}) => amazonClientFactory.createEC2Client(accountName).then(instanceResource)
+  create(_, { accountName } = {}) {
+    return amazonClientFactory.createEC2Client(accountName)
+      .then(instanceResource);
+  }
 };


### PR DESCRIPTION
`asg-instance` now has a terminate button on each instance. You can use that and send a request to a new endpoint which terminates instances through AWS. You are prompted to confirm you want to do this, then on confirmation, the request it sent and your page refreshed (with some event emitting on the client side) to the parent scope. 

At the moment, `terminate` is allowed only when the machine is in service and running. Otherwise the button is disabled. If the status hasn't changed in the refresh time, sending the same delete request doesn't matter, the operation to terminate an instance is idempotent as per the AWS docs. 