### PR TITLE
stop using the expected nodes in teh UI and use the total node count …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+[#unreleased]
+
+### Fixed
+
+- The "Nodes Deployed" value on the details of a deployment now show you the `total deployed / total nodes`. Total nodes was previously incorrect, it would show you a value that ended up with odd results like `10/1` for Nodes Deployed. This was confusing because it was nonsense. If 10 instances have completed, you will now see `10/10` for all the nodes.
+
 ## [6.20.1] 2018-02-27
 
 ### Changed

--- a/client/app/operations/deployments/ops-deployment-details-modal.html
+++ b/client/app/operations/deployments/ops-deployment-details-modal.html
@@ -23,7 +23,7 @@
             <li>
                 <strong>Deployment ID:</strong> {{vm.view.DeploymentID}}</li>
             <li data-ng-if="vm.expectedNodesKnown">
-                <strong>Nodes Deployed:</strong> {{vm.view.nodesCompleted}} / {{vm.view.expectedNodes}}</li>
+                <strong>Nodes Deployed:</strong> {{vm.view.nodesCompleted}} / {{vm.view.nodes.length}}</li>
         </ul>
         <br>
         <p>Please ask in the


### PR DESCRIPTION
…to show how many nodes have been deployed to

## Fixed
Stop using the `expectedNodes` number which is not what we want to show in the nodes deployed section of the details of a deployment. Use the total number of nodes to show the total number of nodes. 