### PR TITLE
Single deployment monitor runs in a cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 - The "Nodes Deployed" value on the details of a deployment now show you the `total deployed / total nodes`. Total nodes was previously incorrect, it would show you a value that ended up with odd results like `10/1` for Nodes Deployed. This was confusing because it was nonsense. If 10 instances have completed, you will now see `10/10` for all the nodes.
 
+- Switched to at-most-once delivery of Deployment Completed notifications by ensuring only one deployment monitor is running at any given time. This also reduces the load on the AWS APIs.
+
 ### Added
 
 - You can not terminate an instance directly and not have to scale up then down. If you want a new instance to remove one with missing services, or any other reason, you can. The ASG screen contains a `terminate` button that is available to all instances that are `In Service` and `Running`. When you terminate an instance, your ASG will delete that instance and replace it with another to meet the desired count of that ASG. Please note that to change the count of machines in your ASG, you will need to change the desired count. You cannot reduce the number of machines in your ASG by terminating instances one by one. 

--- a/server/modules/clusterNode.js
+++ b/server/modules/clusterNode.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const cluster = require('exp-leader-election');
+const logger = require('./logger');
+const config = require('../config').getUserValue('local');
+
+const consulConfig = {
+  key: 'locks/envmgr/leader',
+  consul: config.consul
+};
+
+let leader = false;
+
+cluster(consulConfig)
+  .on('gainedLeadership', (...args) => {
+    leader = true;
+    logger.debug('Gained leadership', ...args);
+  })
+  .on('error', (err) => {
+    if (leader) {
+      logger.debug('Lost leadership');
+    }
+    leader = false;
+    logger.error('Error during leader election / renewal', err);
+  });
+
+module.exports = {
+  isLeader: () => {
+    return leader;
+  }
+};

--- a/server/modules/monitoring/DeploymentMonitorScheduler.js
+++ b/server/modules/monitoring/DeploymentMonitorScheduler.js
@@ -2,8 +2,10 @@
 
 'use strict';
 
-let logger = require('../logger');
-let deploymentMonitor = require('./DeploymentMonitor');
+const logger = require('../logger');
+const deploymentMonitor = require('./DeploymentMonitor');
+const clusterNode = require('../clusterNode');
+
 const MAX_MONITOR_INTERVAL = 60;
 const MIN_MONITOR_INTERVAL = 45;
 
@@ -15,7 +17,7 @@ function scheduleDeploymentMonitor(isPeakTime) {
   logger.debug(`DeploymentMonitor: Next execution will start in ${interval} seconds`);
 
   setTimeout(() => {
-    deploymentMonitor.monitorActiveDeployments().then(
+    monitorActiveDeployments().then(
 
       (activeDeploymentsMonitored) => {
         scheduleDeploymentMonitor(activeDeploymentsMonitored > 0);
@@ -28,6 +30,11 @@ function scheduleDeploymentMonitor(isPeakTime) {
 
     );
   }, interval * 1000);
+}
+
+function monitorActiveDeployments() {
+  if (!clusterNode.isLeader()) return Promise.resolve(0);
+  return deploymentMonitor.monitorActiveDeployments();
 }
 
 function getDeploymentMonitorInterval(isPeakTime) {

--- a/server/modules/monitoring/DeploymentMonitorScheduler.js
+++ b/server/modules/monitoring/DeploymentMonitorScheduler.js
@@ -14,7 +14,9 @@ let monitorInterval = 0;
 function scheduleDeploymentMonitor(isPeakTime) {
   let interval = getDeploymentMonitorInterval(isPeakTime);
 
-  logger.debug(`DeploymentMonitor: Next execution will start in ${interval} seconds`);
+  if (clusterNode.isLeader()) {
+    logger.debug(`DeploymentMonitor: Next execution will start in ${interval} seconds`);
+  }
 
   setTimeout(() => {
     monitorActiveDeployments().then(

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1715,6 +1715,30 @@
       "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
+    "exp-leader-election": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exp-leader-election/-/exp-leader-election-0.2.2.tgz",
+      "integrity": "sha1-jgPs8wQ25RwAGRIchMi3KjuDLoU=",
+      "requires": {
+        "consul": "0.25.0",
+        "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "consul": {
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/consul/-/consul-0.25.0.tgz",
+          "integrity": "sha1-BcBqZnaJIgQnBV3pLGRY3tef8u0=",
+          "requires": {
+            "papi": "0.25.1"
+          }
+        },
+        "papi": {
+          "version": "0.25.1",
+          "resolved": "https://registry.npmjs.org/papi/-/papi-0.25.1.tgz",
+          "integrity": "sha1-pUwCKxeA+SQPrmqh6GGyHJ+PEtk="
+        }
+      }
+    },
     "expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -51,6 +51,7 @@
     "cookie-parser": "~1.4.3",
     "deep-freeze-strict": "^1.1.1",
     "es6-template-strings": "~2.0.1",
+    "exp-leader-election": "^0.2.2",
     "express": "~4.14.0",
     "express-request-id": "~1.3.0",
     "glob-intersection": "~0.1.3",


### PR DESCRIPTION
This change makes sure that only a single instance of the deployment monitor is running at any given time. It reduces load on the AWS API and it makes a best effort to ensure that Deployment Completed notifications are only delivered once.