### PR TITLE
Feature/notify users of action being performed

### DIFF
--- a/client/app/common/common-modal/CommonModalController.js
+++ b/client/app/common/common-modal/CommonModalController.js
@@ -11,10 +11,11 @@ angular.module('EnvironmentManager.common').controller('CommonModalController',
     vm.action = configuration.action || 'Ok';
     vm.severity = (configuration.severity || 'Default').toLowerCase();
     vm.details = (configuration.details || []).map($sce.trustAsHtml);
-    vm.infoMode = configuration.infomode || false;
+    vm.infoMode = configuration.infomode;
     vm.cancelLabel = configuration.cancelLabel || 'Cancel';
     vm.acknowledge = configuration.acknowledge;
     vm.isAcknowledged = !vm.acknowledge;
+    vm.notificationMode = configuration.notificationMode;
 
     vm.ok = function () {
       $uibModalInstance.close();

--- a/client/app/common/common-modal/common-modal.html
+++ b/client/app/common/common-modal/common-modal.html
@@ -16,7 +16,7 @@
     </div>
 </div>
 
-<div class="modal-footer">
+<div class="modal-footer" ng-if="!vm.notificationMode">
     <button ng-if="!vm.infoMode" class="btn btn-default" type="button" ng-click="vm.cancel()">{{vm.cancelLabel}}</button>
     <button ng-disabled="!vm.isAcknowledged" class="btn btn-{{vm.severity}}" type="button" ng-click="vm.ok()">{{vm.action}}</button>
 </div>

--- a/client/app/common/services/modalService.js
+++ b/client/app/common/services/modalService.js
@@ -15,17 +15,25 @@ angular.module('EnvironmentManager.common').factory('modal',
     //    infomode: false // true to hide cancel button for info only messages
     // }
 
+    function getParameters(configuration) {
+      return {
+        templateUrl: '/app/common/common-modal/common-modal.html',
+        controller: 'CommonModalController as vm',
+        resolve: {
+          configuration: configuration
+        }
+      };
+    }
+
     return {
       confirmation: function (configuration) {
-        var parameters = {
-          templateUrl: '/app/common/common-modal/common-modal.html',
-          controller: 'CommonModalController as vm',
-          resolve: {
-            configuration: configuration
-          }
-        };
+        return $uibModal.open(getParameters(configuration)).result;
+      },
 
-        return $uibModal.open(parameters).result;
+      notification: function (configuration) {
+        configuration.notificationMode = true;
+
+        return $uibModal.open(getParameters(configuration));
       },
 
       error: function (title, errorMessage) {

--- a/client/app/environments/dialogs/ASGDetailsModalController.js
+++ b/client/app/environments/dialogs/ASGDetailsModalController.js
@@ -284,9 +284,12 @@ angular.module('EnvironmentManager.environments').controller('ASGDetailsModalCon
     };
 
     vm.updateAutoScalingGroup = function () {
-      confirmAZChange().then(function () {
-        loading.lockPage(true);
-        var updated = {
+      confirmAZChange()
+        .then(createUpdatedAsgModel)
+        .then(sendAsgUpdate);
+
+      function createUpdatedAsgModel() {
+        return {
           size: {
             min: vm.asgUpdate.MinSize,
             desired: vm.asgUpdate.DesiredCapacity,
@@ -299,19 +302,20 @@ angular.module('EnvironmentManager.environments').controller('ASGDetailsModalCon
             availabilityZoneName: vm.asgUpdate.AvailabilityZone
           }
         };
+      }
 
-        vm.asg.updateAutoScalingGroup(updated)
+      function sendAsgUpdate(updated) {
+        return vm.asg.updateAutoScalingGroup(updated)
           .then(function () {
             modal.information({
-              title: 'ASG Updated',
-              message: 'ASG update successful. You can monitor instance changes by using the Refresh Icon in the top right of the window.<br/><br/><b>Note:</b> During scale-down instances will wait in a Terminating state for 10 minutes to allow for connection draining before termination.'
+              title: 'ASG Update Sent',
+              message: 'ASG update sent. Environment Manager will synchronise with AWS shortly. You can monitor instance changes by using the Refresh Icon in the top right of the window.<br/><br/><b>Note:</b> During scale-down instances will wait in a Terminating state for 10 minutes to allow for connection draining before termination.'
             });
           })
           .finally(function () {
-            loading.lockPage(false);
             vm.refresh();
           });
-      });
+      }
     };
 
     function confirmAZChange() {

--- a/client/app/environments/dialogs/ASGDetailsModalController.js
+++ b/client/app/environments/dialogs/ASGDetailsModalController.js
@@ -59,6 +59,7 @@ angular.module('EnvironmentManager.environments').controller('ASGDetailsModalCon
       vm.asgUpdate = vm.asg;
       vm.asgUpdate.SelectedAction = parameters.defaultAction || 'instances';
       vm.asgUpdate.AvailabilityZone = deriveAvailabilityZoneFriendlyName(vm.asgUpdate.AvailabilityZones);
+      vm.asgUpdate.NewSchedule = vm.asg.Schedule;
       vm.selectedScheduleMode = vm.asgUpdate.ScalingSchedule && vm.asgUpdate.ScalingSchedule.length ? 'scaling' : 'schedule';
     }
 
@@ -309,7 +310,7 @@ angular.module('EnvironmentManager.environments').controller('ASGDetailsModalCon
           .then(function () {
             modal.information({
               title: 'ASG Update Sent',
-              message: 'ASG update sent. Environment Manager will synchronise with AWS shortly. You can monitor instance changes by using the Refresh Icon in the top right of the window.<br/><br/><b>Note:</b> During scale-down instances will wait in a Terminating state for 10 minutes to allow for connection draining before termination.'
+              message: '<div class="alert alert-info">ASG update sent. Environment Manager will synchronise with AWS shortly.</div><br> You can monitor instance changes by using the Refresh Icon in the top right of the window.<br/><br/><b>Note:</b> During scale-down instances will wait in a Terminating state for 10 minutes to allow for connection draining before termination.'
             });
           })
           .finally(function () {
@@ -326,7 +327,7 @@ angular.module('EnvironmentManager.environments').controller('ASGDetailsModalCon
 
       return modal.confirmation({
         title: 'Change Availability Zones',
-        message: 'Are you sure you want to change the AZ settings? AWS will instantly rebalance your instances according to these settings.',
+        message: '<div class="alert alert-info">It will take a moment for Environment Manager to synchronise with AWS. You can monitor instance changes by using the Refresh Icon in the top right of the window.</div><br>Are you sure you want to change the AZ settings?',
         severity: 'Danger'
       });
     }
@@ -384,8 +385,8 @@ angular.module('EnvironmentManager.environments').controller('ASGDetailsModalCon
 
       return AutoScalingGroup.updateSchedule(vm.environmentName, vm.asg.AsgName, newSchedule).then(function () {
         modal.information({
-          title: 'ASG Schedule Updated',
-          message: 'ASG schedule updated successfully.'
+          title: 'ASG Schedule Update Sent',
+          message: '<div class="alert alert-info">It will take a moment for Environment Manager to synchronise with AWS. You can monitor instance changes by using the Refresh Icon in the top right of the window.</div>'
         });
       }).catch(function (err) {
         if (err.status === 404) {


### PR DESCRIPTION
- Always use the known state of AWS from the monitor
- Update notifications to inform users that EM and AWS will be out of sync momentarily 
- Make http requests at the same time where possible

^ The difference between EM and AWS and the sync time is something we have discussed in other issues, and may change to allow a more timely update to information moving forward. 