### PR TITLE
Allow LoadBalancers of Environment Type to be empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.23.3] 2018-05-17
+
+### Fixed
+
+- Cannot configure an Environment Type with no load balancers
+
 ## [6.23.2] 2018-05-16
 
 ### Fixed
@@ -474,8 +480,10 @@ Example:
 - The body of the notification event raised by PUT /config/upstreams/{name} was not stringified. 
 - A number of bugs related to the removal of a account as a special case of an account. 
 
-[Unreleased]: https://github.com/trainline/environment-manager/compare/6.23.1...master
-[6.23.1]: https://github.com/trainline/environment-manager/compare/6.23.0..6.23.0
+[Unreleased]: https://github.com/trainline/environment-manager/compare/6.23.3...master
+[6.23.3]: https://github.com/trainline/environment-manager/compare/6.23.2..6.23.3
+[6.23.2]: https://github.com/trainline/environment-manager/compare/6.23.1..6.23.2
+[6.23.1]: https://github.com/trainline/environment-manager/compare/6.23.0..6.23.1
 [6.23.0]: https://github.com/trainline/environment-manager/compare/6.22.2..6.23.0
 [6.22.2]: https://github.com/trainline/environment-manager/compare/6.22.1...6.22.2
 [6.22.1]: https://github.com/trainline/environment-manager/compare/6.22.0...6.22.1

--- a/client/schema/EnvironmentType.schema.json
+++ b/client/schema/EnvironmentType.schema.json
@@ -71,7 +71,7 @@
         "minLength": 1,
         "maxLength": 127
       },
-      "minItems": 1,
+      "minItems": 0,
       "uniqueItems": true
     },
     "PuppetBranch": {


### PR DESCRIPTION
This change allows users to configure Environment Types with 0 load balancers for those that don't have or need any. Environment Manager handles this scenario nicely already, but the schema validation didn't allow the change through the UI. This addresses that issue.